### PR TITLE
revert: remove cursor blink state exposure

### DIFF
--- a/packages/libghostty/lib/src/bindings/bindings_native.dart
+++ b/packages/libghostty/lib/src/bindings/bindings_native.dart
@@ -316,12 +316,6 @@ class NativeBindings implements GhosttyBindings {
       native.ghostty_render_state_get_cols(ffi.Pointer.fromAddress(handle));
 
   @override
-  bool renderStateGetCursorBlinking(int handle) =>
-      native.ghostty_render_state_get_cursor_blinking(
-        ffi.Pointer.fromAddress(handle),
-      );
-
-  @override
   int renderStateGetCursorStyle(int handle) => native
       .ghostty_render_state_get_cursor_style(ffi.Pointer.fromAddress(handle));
 

--- a/packages/libghostty/lib/src/bindings/bindings_wasm.dart
+++ b/packages/libghostty/lib/src/bindings/bindings_wasm.dart
@@ -343,10 +343,6 @@ class WasmBindings implements GhosttyBindings {
       _fn.call1('ghostty_render_state_get_cols', handle);
 
   @override
-  bool renderStateGetCursorBlinking(int handle) =>
-      _fn.call1('ghostty_render_state_get_cursor_blinking', handle) != 0;
-
-  @override
   int renderStateGetCursorStyle(int handle) =>
       _fn.call1('ghostty_render_state_get_cursor_style', handle);
 

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -145,9 +145,6 @@ abstract interface class GhosttyBindings {
   // ghostty_render_state_get_cursor_style
   int renderStateGetCursorStyle(int handle);
 
-  // ghostty_render_state_get_cursor_blinking
-  bool renderStateGetCursorBlinking(int handle);
-
   // ghostty_render_state_get_fg_color → packed 0xRRGGBB
   int renderStateGetFgColor(int handle);
 

--- a/packages/libghostty/lib/src/ffi/bindings.g.dart
+++ b/packages/libghostty/lib/src/ffi/bindings.g.dart
@@ -1090,19 +1090,6 @@ external int ghostty_render_state_get_cursor_style(
   ffi.Pointer<GhosttyTerminal> terminal,
 );
 
-/// Get whether the cursor should blink.
-///
-/// Reflects the terminal's cursor blink mode as set by DECSCUSR.
-///
-/// @param terminal The terminal handle, must not be NULL
-/// @return true if the cursor should blink, false otherwise
-///
-/// @ingroup terminal
-@ffi.Native<ffi.Bool Function(ffi.Pointer<GhosttyTerminal>)>()
-external bool ghostty_render_state_get_cursor_blinking(
-  ffi.Pointer<GhosttyTerminal> terminal,
-);
-
 /// Get the default foreground color as a packed RGB value.
 ///
 /// The color is packed as (R << 16 | G << 8 | B).
@@ -1479,6 +1466,7 @@ enum GhosttyResult {
   GHOSTTY_INVALID_VALUE(-2);
 
   final int value;
+
   const GhosttyResult(this.value);
 
   static GhosttyResult fromValue(int value) => switch (value) {
@@ -1695,6 +1683,7 @@ enum GhosttyOscCommandType {
   GHOSTTY_OSC_COMMAND_KITTY_TEXT_SIZING(22);
 
   final int value;
+
   const GhosttyOscCommandType(this.value);
 
   static GhosttyOscCommandType fromValue(int value) => switch (value) {
@@ -1746,6 +1735,7 @@ enum GhosttyOscCommandData {
   GHOSTTY_OSC_DATA_CHANGE_WINDOW_TITLE_STR(1);
 
   final int value;
+
   const GhosttyOscCommandData(this.value);
 
   static GhosttyOscCommandData fromValue(int value) => switch (value) {
@@ -1820,6 +1810,7 @@ enum GhosttySgrAttributeTag {
   GHOSTTY_SGR_ATTR_FG_256(30);
 
   final int value;
+
   const GhosttySgrAttributeTag(this.value);
 
   static GhosttySgrAttributeTag fromValue(int value) => switch (value) {
@@ -1872,6 +1863,7 @@ enum GhosttySgrUnderline {
   GHOSTTY_SGR_UNDERLINE_DASHED(5);
 
   final int value;
+
   const GhosttySgrUnderline(this.value);
 
   static GhosttySgrUnderline fromValue(int value) => switch (value) {
@@ -1985,6 +1977,7 @@ enum GhosttyKeyAction {
   GHOSTTY_KEY_ACTION_REPEAT(2);
 
   final int value;
+
   const GhosttyKeyAction(this.value);
 
   static GhosttyKeyAction fromValue(int value) => switch (value) {
@@ -2203,6 +2196,7 @@ enum GhosttyKey {
   GHOSTTY_KEY_PASTE(175);
 
   final int value;
+
   const GhosttyKey(this.value);
 
   static GhosttyKey fromValue(int value) => switch (value) {
@@ -2418,6 +2412,7 @@ enum GhosttyOptionAsAlt {
   GHOSTTY_OPTION_AS_ALT_RIGHT(3);
 
   final int value;
+
   const GhosttyOptionAsAlt(this.value);
 
   static GhosttyOptionAsAlt fromValue(int value) => switch (value) {
@@ -2458,6 +2453,7 @@ enum GhosttyKeyEncoderOption {
   GHOSTTY_KEY_ENCODER_OPT_MACOS_OPTION_AS_ALT(6);
 
   final int value;
+
   const GhosttyKeyEncoderOption(this.value);
 
   static GhosttyKeyEncoderOption fromValue(int value) => switch (value) {

--- a/packages/libghostty/lib/src/terminal/cursor.dart
+++ b/packages/libghostty/lib/src/terminal/cursor.dart
@@ -6,19 +6,17 @@ class Cursor {
   final int row;
   final int col;
   final bool visible;
-  final bool blinking;
   final CursorShape shape;
 
   const Cursor({
     this.row = 0,
     this.col = 0,
     this.visible = true,
-    this.blinking = true,
     this.shape = CursorShape.block,
   });
 
   @override
-  int get hashCode => Object.hash(row, col, visible, blinking, shape);
+  int get hashCode => Object.hash(row, col, visible, shape);
 
   @override
   bool operator ==(Object other) =>
@@ -26,29 +24,20 @@ class Cursor {
       other.row == row &&
       other.col == col &&
       other.visible == visible &&
-      other.blinking == blinking &&
       other.shape == shape;
 
-  Cursor copyWith({
-    int? row,
-    int? col,
-    bool? visible,
-    bool? blinking,
-    CursorShape? shape,
-  }) {
+  Cursor copyWith({int? row, int? col, bool? visible, CursorShape? shape}) {
     return Cursor(
       row: row ?? this.row,
       col: col ?? this.col,
       visible: visible ?? this.visible,
-      blinking: blinking ?? this.blinking,
       shape: shape ?? this.shape,
     );
   }
 
   @override
   String toString() =>
-      'Cursor(row: $row, col: $col, visible: $visible, blinking: $blinking, '
-      'shape: $shape)';
+      'Cursor(row: $row, col: $col, visible: $visible, shape: $shape)';
 }
 
 /// Terminal cursor rendering shape.

--- a/packages/libghostty/lib/src/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/terminal/terminal.dart
@@ -218,7 +218,6 @@ class Terminal extends Disposable {
       col: bindings.renderStateGetCursorX(_handle),
       row: bindings.renderStateGetCursorY(_handle),
       visible: bindings.renderStateGetCursorVisible(_handle),
-      blinking: bindings.renderStateGetCursorBlinking(_handle),
       shape: CursorShapeNative.fromNative(
         bindings.renderStateGetCursorStyle(_handle),
       ),

--- a/packages/libghostty/patches/terminal-c-api.patch
+++ b/packages/libghostty/patches/terminal-c-api.patch
@@ -12,10 +12,10 @@ index 4f8fef88e..1a4656385 100644
  #ifdef __cplusplus
 diff --git a/include/ghostty/vt/terminal.h b/include/ghostty/vt/terminal.h
 new file mode 100644
-index 000000000..e72d4ca9f
+index 000000000..bb1c088d7
 --- /dev/null
 +++ b/include/ghostty/vt/terminal.h
-@@ -0,0 +1,791 @@
+@@ -0,0 +1,779 @@
 +/**
 + * @file terminal.h
 + *
@@ -484,18 +484,6 @@ index 000000000..e72d4ca9f
 +uint8_t ghostty_render_state_get_cursor_style(GhosttyTerminal terminal);
 +
 +/**
-+ * Get whether the cursor should blink.
-+ *
-+ * Reflects the terminal's cursor blink mode as set by DECSCUSR.
-+ *
-+ * @param terminal The terminal handle, must not be NULL
-+ * @return true if the cursor should blink, false otherwise
-+ *
-+ * @ingroup terminal
-+ */
-+bool ghostty_render_state_get_cursor_blinking(GhosttyTerminal terminal);
-+
-+/**
 + * Get the default foreground color as a packed RGB value.
 + *
 + * The color is packed as (R << 16 | G << 8 | B).
@@ -808,10 +796,10 @@ index 000000000..e72d4ca9f
 +
 +#endif /* GHOSTTY_VT_TERMINAL_H */
 diff --git a/src/lib_vt.zig b/src/lib_vt.zig
-index 426660621..972be2f2c 100644
+index 426660621..227e0287d 100644
 --- a/src/lib_vt.zig
 +++ b/src/lib_vt.zig
-@@ -144,6 +144,44 @@ comptime {
+@@ -144,6 +144,43 @@ comptime {
          @export(&c.sgr_attribute_tag, .{ .name = "ghostty_sgr_attribute_tag" });
          @export(&c.sgr_attribute_value, .{ .name = "ghostty_sgr_attribute_value" });
  
@@ -828,7 +816,6 @@ index 426660621..972be2f2c 100644
 +        @export(&c.render_state_get_cursor_y, .{ .name = "ghostty_render_state_get_cursor_y" });
 +        @export(&c.render_state_get_cursor_visible, .{ .name = "ghostty_render_state_get_cursor_visible" });
 +        @export(&c.render_state_get_cursor_style, .{ .name = "ghostty_render_state_get_cursor_style" });
-+        @export(&c.render_state_get_cursor_blinking, .{ .name = "ghostty_render_state_get_cursor_blinking" });
 +        @export(&c.render_state_get_fg_color, .{ .name = "ghostty_render_state_get_fg_color" });
 +        @export(&c.render_state_get_bg_color, .{ .name = "ghostty_render_state_get_bg_color" });
 +        @export(&c.render_state_is_row_dirty, .{ .name = "ghostty_render_state_is_row_dirty" });
@@ -857,7 +844,7 @@ index 426660621..972be2f2c 100644
          if (builtin.target.cpu.arch.isWasm()) {
              const alloc = @import("lib/allocator/convenience.zig");
 diff --git a/src/terminal/c/main.zig b/src/terminal/c/main.zig
-index bc92597f5..19a1590c8 100644
+index bc92597f5..c7a27f52e 100644
 --- a/src/terminal/c/main.zig
 +++ b/src/terminal/c/main.zig
 @@ -4,6 +4,7 @@ pub const key_event = @import("key_event.zig");
@@ -868,7 +855,7 @@ index bc92597f5..19a1590c8 100644
  
  // The full C API, unexported.
  pub const osc_new = osc.new;
-@@ -52,6 +53,44 @@ pub const key_encoder_encode = key_encode.encode;
+@@ -52,6 +53,43 @@ pub const key_encoder_encode = key_encode.encode;
  
  pub const paste_is_safe = paste.is_safe;
  
@@ -885,7 +872,6 @@ index bc92597f5..19a1590c8 100644
 +pub const render_state_get_cursor_y = terminal.get_cursor_y;
 +pub const render_state_get_cursor_visible = terminal.get_cursor_visible;
 +pub const render_state_get_cursor_style = terminal.get_cursor_style;
-+pub const render_state_get_cursor_blinking = terminal.get_cursor_blinking;
 +pub const render_state_get_fg_color = terminal.get_fg_color;
 +pub const render_state_get_bg_color = terminal.get_bg_color;
 +pub const render_state_is_row_dirty = terminal.is_row_dirty;
@@ -913,7 +899,7 @@ index bc92597f5..19a1590c8 100644
  test {
      _ = color;
      _ = osc;
-@@ -59,6 +98,7 @@ test {
+@@ -59,6 +97,7 @@ test {
      _ = key_encode;
      _ = paste;
      _ = sgr;
@@ -923,10 +909,10 @@ index bc92597f5..19a1590c8 100644
      _ = @import("../../lib/allocator.zig");
 diff --git a/src/terminal/c/terminal.zig b/src/terminal/c/terminal.zig
 new file mode 100644
-index 000000000..b764f45f6
+index 000000000..3ba03a7aa
 --- /dev/null
 +++ b/src/terminal/c/terminal.zig
-@@ -0,0 +1,1345 @@
+@@ -0,0 +1,1340 @@
 +const std = @import("std");
 +const Allocator = std.mem.Allocator;
 +const lib_alloc = @import("../../lib/allocator.zig");
@@ -1393,11 +1379,6 @@ index 000000000..b764f45f6
 +        .underline => 2,
 +        .block_hollow => 3,
 +    };
-+}
-+
-+pub fn get_cursor_blinking(handle: Handle) callconv(.c) bool {
-+    const wrapper = handle orelse return true;
-+    return wrapper.render_state.cursor.blinking;
 +}
 +
 +pub fn get_fg_color(handle: Handle) callconv(.c) u32 {

--- a/packages/libghostty/test/terminal/cursor_test.dart
+++ b/packages/libghostty/test/terminal/cursor_test.dart
@@ -25,7 +25,6 @@ void main() {
       expect(cursor.row, 0);
       expect(cursor.col, 0);
       expect(cursor.visible, isTrue);
-      expect(cursor.blinking, isTrue);
       expect(cursor.shape, CursorShape.block);
     });
 
@@ -45,10 +44,6 @@ void main() {
       );
       expect(
         base,
-        isNot(equals(const Cursor(row: 5, col: 10, blinking: false))),
-      );
-      expect(
-        base,
         isNot(
           equals(const Cursor(row: 5, col: 10, shape: CursorShape.underline)),
         ),
@@ -62,11 +57,6 @@ void main() {
       expect(moved.col, 11);
       expect(moved.shape, CursorShape.bar);
       expect(moved.visible, isTrue);
-      expect(moved.blinking, isTrue);
-
-      final nonBlinking = cursor.copyWith(blinking: false);
-      expect(nonBlinking.blinking, isFalse);
-      expect(nonBlinking.row, 5);
     });
   });
 }


### PR DESCRIPTION
Reverts #8. The upstream ghostty PR (https://github.com/ghostty-org/ghostty/pull/11484) was closed unmerged. Exposing `cursor.blinking` (mode 12) as default on conflicts with modern CSI q cursor control.