### PR TITLE
ci: fix Windows build and enable Flutter SDK caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
     name: build-${{ matrix.target }}
     needs: [checks]
     runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -62,7 +65,7 @@ jobs:
             runner: ubuntu-latest
             ext: so
           - target: x86_64-windows
-            runner: ubuntu-latest
+            runner: windows-latest
             ext: dll
           - target: aarch64-linux-android
             runner: ubuntu-latest
@@ -87,23 +90,23 @@ jobs:
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         id: ghostty-cache
         with:
-          path: ${{ runner.temp }}/ghostty-src
+          path: ghostty-src
           key: ghostty-src-${{ steps.ghostty.outputs.full }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.full }}.tar.gz" -o ghostty.tar.gz
-          mkdir -p "$RUNNER_TEMP/ghostty-src"
-          tar xzf ghostty.tar.gz -C "$RUNNER_TEMP/ghostty-src" --strip-components=1
+          mkdir -p ghostty-src
+          tar xzf ghostty.tar.gz -C ghostty-src --strip-components=1
           rm ghostty.tar.gz
       - name: compile
-        working-directory: ${{ runner.temp }}/ghostty-src
+        working-directory: ghostty-src
         run: zig build -Demit-lib-vt=true --release=fast -Dtarget=${{ matrix.target }} ${{ matrix.extra_args }}
       - name: prepare artifact
         id: artifact
         run: |
           FILENAME="libghostty-${{ matrix.target }}.${{ matrix.ext }}"
-          cp "$RUNNER_TEMP"/ghostty-src/zig-out/*/*ghostty-vt.${{ matrix.ext }} "$FILENAME"
+          cp ghostty-src/zig-out/*/*ghostty-vt.${{ matrix.ext }} "$FILENAME"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -129,23 +132,23 @@ jobs:
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         id: ghostty-cache
         with:
-          path: ${{ runner.temp }}/ghostty-src
+          path: ghostty-src
           key: ghostty-src-${{ steps.ghostty.outputs.full }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.full }}.tar.gz" -o ghostty.tar.gz
-          mkdir -p "$RUNNER_TEMP/ghostty-src"
-          tar xzf ghostty.tar.gz -C "$RUNNER_TEMP/ghostty-src" --strip-components=1
+          mkdir -p ghostty-src
+          tar xzf ghostty.tar.gz -C ghostty-src --strip-components=1
           rm ghostty.tar.gz
       - name: compile wasm
-        working-directory: ${{ runner.temp }}/ghostty-src
+        working-directory: ghostty-src
         run: zig build -Demit-lib-vt=true -Dtarget=wasm32-freestanding -Doptimize=ReleaseSmall
       - name: prepare artifact
         id: artifact
         run: |
           FILENAME="libghostty-wasm32-freestanding.wasm"
-          cp "$RUNNER_TEMP/ghostty-src/zig-out/bin/ghostty-vt.wasm" "$FILENAME"
+          cp ghostty-src/zig-out/bin/ghostty-vt.wasm "$FILENAME"
           echo "filename=$FILENAME" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
           channel: stable
+          cache: true
       - name: generate asset hashes
         working-directory: packages/libghostty
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
           channel: stable
+          cache: true
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.pub-cache
@@ -53,6 +54,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
           channel: stable
+          cache: true
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: ${{ env.ZIG_VERSION }}
@@ -97,6 +99,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2.21.0
         with:
           channel: stable
+          cache: true
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: ${{ env.ZIG_VERSION }}


### PR DESCRIPTION
- Switch x86_64-windows from cross-compilation on ubuntu-latest to
  native windows-latest runner where MSVC C++ headers are available
- Use relative paths for ghostty source to avoid Windows tar path issues
- Enable Flutter SDK caching across all CI jobs