### PR TITLE
perf(libghostty): cache cell properties and add ARGB color accessors

### DIFF
--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -197,6 +197,8 @@ abstract interface class GhosttyBindings {
   CResult<List<int>> rowCellsGetGraphemes(int cells, int len);
   CResult<RgbColor> rowCellsGetBgColor(int cells);
   CResult<RgbColor> rowCellsGetFgColor(int cells);
+  CResult<int> rowCellsGetBgColorArgb(int cells);
+  CResult<int> rowCellsGetFgColorArgb(int cells);
 
   CResult<int> cellGetCodepoint(int cell);
   CResult<CellContentTag> cellGetContentTag(int cell);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -1220,6 +1220,28 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<int> rowCellsGetBgColorArgb(int cells) {
+    final result = native.ghostty_render_state_row_cells_get(
+      ffi.Pointer.fromAddress(cells),
+      .bgColor,
+      _outColorRgb.cast(),
+    );
+    final color = _outColorRgb.ref;
+    return (result, 0xFF000000 | (color.r << 16) | (color.g << 8) | color.b);
+  }
+
+  @override
+  CResult<int> rowCellsGetFgColorArgb(int cells) {
+    final result = native.ghostty_render_state_row_cells_get(
+      ffi.Pointer.fromAddress(cells),
+      .fgColor,
+      _outColorRgb.cast(),
+    );
+    final color = _outColorRgb.ref;
+    return (result, 0xFF000000 | (color.r << 16) | (color.g << 8) | color.b);
+  }
+
+  @override
   CResult<int> cellGetCodepoint(int cell) => _cellGetU32(cell, .codepoint);
 
   @override

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -1585,6 +1585,44 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<int> rowCellsGetBgColorArgb(int cells) {
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(3);
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_cells_get(
+        cells,
+        RenderStateRowCellsData.bgColor.value,
+        outPtr,
+      ),
+    );
+    final argb =
+        0xFF000000 |
+        (_mem.readU8(outPtr) << 16) |
+        (_mem.readU8(outPtr + _layout.colorRgbG) << 8) |
+        _mem.readU8(outPtr + _layout.colorRgbB);
+    _exports.ghostty_wasm_free_u8_array(outPtr, 3);
+    return (result, argb);
+  }
+
+  @override
+  CResult<int> rowCellsGetFgColorArgb(int cells) {
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(3);
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_cells_get(
+        cells,
+        RenderStateRowCellsData.fgColor.value,
+        outPtr,
+      ),
+    );
+    final argb =
+        0xFF000000 |
+        (_mem.readU8(outPtr) << 16) |
+        (_mem.readU8(outPtr + _layout.colorRgbG) << 8) |
+        _mem.readU8(outPtr + _layout.colorRgbB);
+    _exports.ghostty_wasm_free_u8_array(outPtr, 3);
+    return (result, argb);
+  }
+
+  @override
   CResult<int> cellGetCodepoint(int cell) => _cellGetU32(cell, .codepoint);
 
   @override

--- a/packages/libghostty/lib/src/impl/terminal/cell.dart
+++ b/packages/libghostty/lib/src/impl/terminal/cell.dart
@@ -9,9 +9,11 @@ class Cell {
   final int _handle;
   var _rawCell = 0;
   var _graphemeLen = 0;
+  var _codepoint = 0;
   var _styleId = -1;
   var _prevStyleId = -1;
   var _cachedStyle = const Style();
+  var _wide = CellWide.narrow;
 
   Cell._(this._handle);
 
@@ -24,17 +26,15 @@ class Cell {
   }
 
   /// The cell's primary codepoint, or 0 if the cell has no text.
-  int get codepoint {
-    if (_graphemeLen == 0) return 0;
-    return check(bindings.cellGetCodepoint(_rawCell));
-  }
+  /// Cached during [_refresh] to avoid redundant FFI calls. Accessed
+  /// by both the renderer hot loop and [content].
+  int get codepoint => _codepoint;
 
   /// The cell's full grapheme cluster as a string, or empty if the cell
   /// has no text.
   String get content {
     if (_graphemeLen == 0) return '';
-    final cp = check(bindings.cellGetCodepoint(_rawCell));
-    if (_graphemeLen == 1 && cp < 128) return String.fromCharCode(cp);
+    if (_graphemeLen == 1) return String.fromCharCode(_codepoint);
     return String.fromCharCodes(
       check(bindings.rowCellsGetGraphemes(_handle, _graphemeLen)),
     );
@@ -49,11 +49,14 @@ class Cell {
     return code == .success ? rgb : null;
   }
 
+  /// Number of codepoints in this cell's grapheme cluster (0 = empty).
+  int get graphemeLength => _graphemeLen;
+
   /// Whether the cell has a hyperlink (OSC 8).
-  bool get hasHyperlink => check(bindings.cellGetHasHyperlink(_rawCell));
+  bool get hasHyperlink => bindings.cellGetHasHyperlink(_rawCell).$2;
 
   /// Whether the cell has non-default styling attributes.
-  bool get hasStyling => check(bindings.cellGetHasStyling(_rawCell));
+  bool get hasStyling => bindings.cellGetHasStyling(_rawCell).$2;
 
   /// Whether the cell contains any text.
   bool get hasText => _graphemeLen > 0;
@@ -80,9 +83,24 @@ class Cell {
   /// share identical styling attributes.
   int get styleId => _styleId;
 
-  /// The cell's width: [CellWidth.normal], [CellWidth.wide], or
-  /// [CellWidth.spacerTail] (second cell of a wide character).
-  CellWidth get wide => check(bindings.cellGetWide(_rawCell));
+  /// The cell's width: [CellWide.narrow], [CellWide.wide], or
+  /// [CellWide.spacerTail] (second cell of a wide character).
+  /// Cached during [_refresh] to avoid per-access FFI calls.
+  CellWide get wide => _wide;
+
+  /// Resolved background as packed ARGB int, or [defaultArgb] if unset.
+  /// Avoids [RgbColor] allocation on the hot path.
+  int backgroundArgb(int defaultArgb) {
+    final (code, argb) = bindings.rowCellsGetBgColorArgb(_handle);
+    return code == .success ? argb : defaultArgb;
+  }
+
+  /// Resolved foreground as packed ARGB int, or [defaultArgb] if unset.
+  /// Avoids [RgbColor] allocation on the hot path.
+  int foregroundArgb(int defaultArgb) {
+    final (code, argb) = bindings.rowCellsGetFgColorArgb(_handle);
+    return code == .success ? argb : defaultArgb;
+  }
 
   bool _advance() {
     if (!bindings.rowCellsNext(_handle)) return false;
@@ -94,5 +112,39 @@ class Cell {
     _rawCell = check(bindings.rowCellsGetRawCell(_handle));
     _graphemeLen = check(bindings.rowCellsGetGraphemeLen(_handle));
     _styleId = check(bindings.cellGetStyleId(_rawCell));
+    _codepoint = _graphemeLen > 0
+        ? check(bindings.cellGetCodepoint(_rawCell))
+        : 0;
+    // Non-empty cells with narrow codepoints (ASCII, Latin, Cyrillic) are
+    // always narrow. Empty cells and wide-range codepoints need the FFI
+    // query: empty cells can be spacer tails of wide characters.
+    _wide = _graphemeLen > 0 && !_couldBeWide(_codepoint)
+        ? .narrow
+        : bindings.cellGetWide(_rawCell).$2;
+  }
+
+  /// Fast heuristic: returns false for codepoints that are definitively
+  /// narrow (< U+1100), avoiding the FFI call to [cellGetWide].
+  static bool _couldBeWide(int codepoint) {
+    if (codepoint < 0x1100) return false;
+    if (codepoint < 0x1160) return true;
+    if (codepoint < 0x2329) return false;
+    if (codepoint <= 0x232A) return true;
+    if (codepoint < 0x2E80) return false;
+    if (codepoint <= 0x9FFF) return true;
+    if (codepoint < 0xA960) return false;
+    if (codepoint <= 0xA97F) return true;
+    if (codepoint < 0xAC00) return false;
+    if (codepoint <= 0xD7FF) return true;
+    if (codepoint < 0xF900) return false;
+    if (codepoint <= 0xFAFF) return true;
+    if (codepoint < 0xFE10) return false;
+    if (codepoint <= 0xFE6F) return true;
+    if (codepoint < 0xFF01) return false;
+    if (codepoint <= 0xFF60) return true;
+    if (codepoint < 0xFFE0) return false;
+    if (codepoint <= 0xFFE6) return true;
+    if (codepoint < 0x1F000) return false;
+    return true;
   }
 }

--- a/packages/libghostty/lib/src/impl/terminal/render_state.dart
+++ b/packages/libghostty/lib/src/impl/terminal/render_state.dart
@@ -190,7 +190,10 @@ class RenderState {
       checkCode(bindings.rowIteratorInit(_rowIterator, _handle));
     }
     final hasNext = bindings.rowIteratorNext(_rowIterator);
-    if (hasNext) _cellStarted = false;
+    if (hasNext) {
+      _cellStarted = false;
+      row._invalidate();
+    }
     return hasNext;
   }
 

--- a/packages/libghostty/lib/src/impl/terminal/row.dart
+++ b/packages/libghostty/lib/src/impl/terminal/row.dart
@@ -7,6 +7,8 @@ part of 'terminal.dart';
 /// become invalid after the next [RenderState.update] call.
 class Row {
   final int _handle;
+  var _cachedRawRow = 0;
+  var _rawRowValid = false;
 
   Row._(this._handle);
 
@@ -44,5 +46,15 @@ class Row {
   /// previous row.
   bool get wrapContinuation => check(bindings.rowGetWrapContinuation(_rawRow));
 
-  int get _rawRow => check(bindings.rowIteratorGetRawRow(_handle));
+  int get _rawRow {
+    if (!_rawRowValid) {
+      _cachedRawRow = check(bindings.rowIteratorGetRawRow(_handle));
+      _rawRowValid = true;
+    }
+    return _cachedRawRow;
+  }
+
+  /// Invalidate the cached raw row pointer. Called when the iterator
+  /// advances to a new row.
+  void _invalidate() => _rawRowValid = false;
 }

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -625,6 +625,71 @@ void main() {
         terminal.renderState.nextCell();
         expect(terminal.renderState.cell.hasStyling, isTrue);
       });
+
+      test('codepoint returns value for text and 0 for empty cell', () {
+        terminal.write(Uint8List.fromList('Z'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.codepoint, 0x5A);
+
+        // Skip to an empty cell beyond the written content.
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.codepoint, 0);
+      });
+
+      test('graphemeLength is 1 for single codepoint and 0 for empty', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.graphemeLength, 1);
+
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.graphemeLength, 0);
+      });
+
+      test('backgroundArgb returns default when no background is set', () {
+        const defaultBg = 0xFF000000;
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.backgroundArgb(defaultBg), defaultBg);
+      });
+
+      test('backgroundArgb returns packed ARGB for RGB background', () {
+        terminal.write(Uint8List.fromList('\x1b[48;2;255;128;0mX'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+        terminal.renderState.nextCell();
+        expect(
+          terminal.renderState.cell.backgroundArgb(0xFF000000),
+          0xFFFF8000,
+        );
+      });
+
+      test('foregroundArgb returns default when no foreground is set', () {
+        const defaultFg = 0xFFFFFFFF;
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+        terminal.renderState.nextCell();
+        expect(terminal.renderState.cell.foregroundArgb(defaultFg), defaultFg);
+      });
+
+      test('foregroundArgb returns packed ARGB for RGB foreground', () {
+        terminal.write(Uint8List.fromList('\x1b[38;2;0;255;64mY'.codeUnits));
+        terminal.renderState.update();
+        terminal.renderState.nextRow();
+        terminal.renderState.nextCell();
+        expect(
+          terminal.renderState.cell.foregroundArgb(0xFFFFFFFF),
+          0xFF00FF40,
+        );
+      });
     });
 
     group('Cursor properties', () {


### PR DESCRIPTION
Cache frequently accessed cell properties (codepoint, wide status) during
iterator refresh to eliminate redundant FFI calls in the rendering hot path.