### PR TITLE
refactor(libghostty): make ARGB color accessors nullable getters

### DIFF
--- a/packages/libghostty/lib/src/bindings/types/color.dart
+++ b/packages/libghostty/lib/src/bindings/types/color.dart
@@ -53,6 +53,9 @@ final class RgbColor extends CellColor {
   @override
   int get hashCode => Object.hash(RgbColor, r, g, b);
 
+  /// Converts to a 32-bit ARGB int with full opacity.
+  int get toArgb32 => 0xFF000000 | (r << 16) | (g << 8) | b;
+
   @override
   bool operator ==(Object other) =>
       other is RgbColor && other.r == r && other.g == g && other.b == b;

--- a/packages/libghostty/lib/src/impl/terminal/cell.dart
+++ b/packages/libghostty/lib/src/impl/terminal/cell.dart
@@ -25,6 +25,12 @@ class Cell {
     return code == .success ? rgb : null;
   }
 
+  /// Resolved background as packed ARGB int, or null if unset.
+  int? get backgroundArgb {
+    final (code, argb) = bindings.rowCellsGetBgColorArgb(_handle);
+    return code == .success ? argb : null;
+  }
+
   /// The cell's primary codepoint, or 0 if the cell has no text.
   /// Cached during [_refresh] to avoid redundant FFI calls. Accessed
   /// by both the renderer hot loop and [content].
@@ -47,6 +53,12 @@ class Cell {
   RgbColor? get foreground {
     final (code, rgb) = bindings.rowCellsGetFgColor(_handle);
     return code == .success ? rgb : null;
+  }
+
+  /// Resolved foreground as packed ARGB int, or null if unset.
+  int? get foregroundArgb {
+    final (code, argb) = bindings.rowCellsGetFgColorArgb(_handle);
+    return code == .success ? argb : null;
   }
 
   /// Number of codepoints in this cell's grapheme cluster (0 = empty).
@@ -88,20 +100,6 @@ class Cell {
   /// Cached during [_refresh] to avoid per-access FFI calls.
   CellWide get wide => _wide;
 
-  /// Resolved background as packed ARGB int, or [defaultArgb] if unset.
-  /// Avoids [RgbColor] allocation on the hot path.
-  int backgroundArgb(int defaultArgb) {
-    final (code, argb) = bindings.rowCellsGetBgColorArgb(_handle);
-    return code == .success ? argb : defaultArgb;
-  }
-
-  /// Resolved foreground as packed ARGB int, or [defaultArgb] if unset.
-  /// Avoids [RgbColor] allocation on the hot path.
-  int foregroundArgb(int defaultArgb) {
-    final (code, argb) = bindings.rowCellsGetFgColorArgb(_handle);
-    return code == .success ? argb : defaultArgb;
-  }
-
   bool _advance() {
     if (!bindings.rowCellsNext(_handle)) return false;
     _refresh();
@@ -115,10 +113,10 @@ class Cell {
     _codepoint = _graphemeLen > 0
         ? check(bindings.cellGetCodepoint(_rawCell))
         : 0;
-    // Non-empty cells with narrow codepoints (ASCII, Latin, Cyrillic) are
-    // always narrow. Empty cells and wide-range codepoints need the FFI
-    // query: empty cells can be spacer tails of wide characters.
-    _wide = _graphemeLen > 0 && !_couldBeWide(_codepoint)
+    // Fast path: single-codepoint cells in narrow Unicode ranges are always
+    // narrow. All others need FFI: empty cells can be spacer tails, and
+    // multi-codepoint graphemes can be widened by VS16 (mode 2027).
+    _wide = _graphemeLen == 1 && !_couldBeWide(_codepoint)
         ? .narrow
         : bindings.cellGetWide(_rawCell).$2;
   }

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -651,13 +651,12 @@ void main() {
         expect(terminal.renderState.cell.graphemeLength, 0);
       });
 
-      test('backgroundArgb returns default when no background is set', () {
-        const defaultBg = 0xFF000000;
+      test('backgroundArgb returns null when no background is set', () {
         terminal.write(Uint8List.fromList('A'.codeUnits));
         terminal.renderState.update();
         terminal.renderState.nextRow();
         terminal.renderState.nextCell();
-        expect(terminal.renderState.cell.backgroundArgb(defaultBg), defaultBg);
+        expect(terminal.renderState.cell.backgroundArgb, isNull);
       });
 
       test('backgroundArgb returns packed ARGB for RGB background', () {
@@ -665,19 +664,15 @@ void main() {
         terminal.renderState.update();
         terminal.renderState.nextRow();
         terminal.renderState.nextCell();
-        expect(
-          terminal.renderState.cell.backgroundArgb(0xFF000000),
-          0xFFFF8000,
-        );
+        expect(terminal.renderState.cell.backgroundArgb, 0xFFFF8000);
       });
 
-      test('foregroundArgb returns default when no foreground is set', () {
-        const defaultFg = 0xFFFFFFFF;
+      test('foregroundArgb returns null when no foreground is set', () {
         terminal.write(Uint8List.fromList('A'.codeUnits));
         terminal.renderState.update();
         terminal.renderState.nextRow();
         terminal.renderState.nextCell();
-        expect(terminal.renderState.cell.foregroundArgb(defaultFg), defaultFg);
+        expect(terminal.renderState.cell.foregroundArgb, isNull);
       });
 
       test('foregroundArgb returns packed ARGB for RGB foreground', () {
@@ -685,10 +680,7 @@ void main() {
         terminal.renderState.update();
         terminal.renderState.nextRow();
         terminal.renderState.nextCell();
-        expect(
-          terminal.renderState.cell.foregroundArgb(0xFFFFFFFF),
-          0xFF00FF40,
-        );
+        expect(terminal.renderState.cell.foregroundArgb, 0xFF00FF40);
       });
     });
 


### PR DESCRIPTION
Follow-up to #18.

Convert backgroundArgb and foregroundArgb from methods with a defaultArgb fallback parameter to nullable getters. Callers handle the default value themselves. Also, fix the wide-cell heuristic to check graphemeLen == 1 instead of > 0, since multi-codepoint graphemes (e.g. VS16 emoji) can be wide and need the FFI call.