### PR TITLE
chore(libghostty): prepare v0.0.6 release

### DIFF
--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.0.6
+
+### Added
+
+- **ARGB color accessors**: `Cell.backgroundArgb` and `Cell.foregroundArgb`
+  return resolved colors as packed 32-bit ARGB ints, or `null` if unset.
+  Callers handle the default themselves.
+- **`RgbColor.toArgb32`**: convert an `RgbColor` to a packed 32-bit ARGB int
+  with full opacity.
+- **`Cell.graphemeLength`**: number of codepoints in the cell's grapheme
+  cluster (0 for empty cells).
+
+### Changed
+
+- **Cell hot path**: `codepoint` and `wide` are cached during row iteration
+  to eliminate per-access FFI calls in the renderer hot loop.
+- **Row hot path**: the raw row pointer is cached and invalidated when the
+  iterator advances to a new row.
+
+### Fixed
+
+- **VS16 emoji width**: multi-codepoint graphemes are no longer misclassified
+  as narrow based on their first codepoint. The wide-cell fast path now only
+  applies to single-codepoint cells, so an emoji base followed by VS16 is
+  correctly marked wide.
+- **Wide-codepoint heuristic**: replaced the hand-rolled Unicode range table
+  in the wide-cell fast path with a single `>= U+1100` check. The old table
+  could mark some wide CJK codepoints as narrow without consulting the FFI
+  width query.
+
 ## 0.0.5
 
 ### Breaking

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.5
+  libghostty: ^0.0.6
 ```
 
 On web, initialize the WASM module once before using any bindings:

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.5
+version: 0.0.6
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
- Bump package version to 0.0.6
- Add ARGB color accessors (`Cell.backgroundArgb`, `Cell.foregroundArgb`, `RgbColor.toArgb32`) and `Cell.graphemeLength`
- Cache `codepoint`, `wide`, and the raw row pointer in the renderer hot path to reduce per-cell FFI calls
- Fix VS16 emoji width classification: multi-codepoint graphemes no longer fall through the single-codepoint fast path
- Replace the hand-rolled wide-codepoint range table with a `>= U+1100` check, deferring to the FFI width query for borderline cases
- Update README version reference