### PR TITLE
fix(libghostty): produce glibc-linked Linux prebuilts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,10 @@ jobs:
           - target: x86_64-ios-simulator
             runner: macos-latest
             ext: dylib
-          - target: x86_64-linux
+          - target: x86_64-linux-gnu
             runner: ubuntu-latest
             ext: so
-          - target: aarch64-linux
+          - target: aarch64-linux-gnu
             runner: ubuntu-latest
             ext: so
           - target: x86_64-linux-musl

--- a/packages/libghostty/lib/src/hook/zig_target.dart
+++ b/packages/libghostty/lib/src/hook/zig_target.dart
@@ -12,7 +12,7 @@ String? zigTarget(OS targetOS, Architecture targetArch, {IOSSdk? iOSSdk}) {
 
   final osStr = switch (targetOS) {
     OS.macOS => 'macos',
-    OS.linux => 'linux',
+    OS.linux => 'linux-gnu',
     OS.windows => 'windows',
     OS.iOS => iOSSdk == IOSSdk.iPhoneSimulator ? 'ios-simulator' : 'ios',
     OS.android => switch (targetArch) {

--- a/packages/libghostty/test/zig_target_test.dart
+++ b/packages/libghostty/test/zig_target_test.dart
@@ -71,9 +71,9 @@ void main() {
         expect(target, 'arm-macos');
       });
 
-      test('linux arm produces arm-linux', () {
+      test('linux arm produces arm-linux-gnu', () {
         final target = zigTarget(OS.linux, Architecture.arm);
-        expect(target, 'arm-linux');
+        expect(target, 'arm-linux-gnu');
       });
 
       test('windows arm produces arm-windows', () {


### PR DESCRIPTION
Switch the linux build matrix targets to the explicit `-gnu` ABI suffix so zig links against glibc. Without it, zig defaults to musl and the resulting `.so` has `DT_NEEDED libc.so` instead of `libc.so.6`, which fails `dlopen` on every glibc Linux system.