### PR TITLE
chore(libghostty): prepare v0.0.7 release

### DIFF
--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.0.7
+
+### Fixed
+
+- **Linux prebuilts**: the prebuilt Linux binaries failed to load on glibc
+  systems with `invalid ELF header`. They now ship as
+  `libghostty-x86_64-linux-gnu.so` and `libghostty-aarch64-linux-gnu.so`,
+  properly linked against glibc.
+
 ## 0.0.6
 
 ### Added

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.6
+  libghostty: ^0.0.7
 ```
 
 On web, initialize the WASM module once before using any bindings:

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.6
+version: 0.0.7
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
- Bump package version to `0.0.7`
- Add changelog for the Linux prebuilt linking fix (#23)
- Update README version reference