### PR TITLE
feat(libghostty): expose new terminal, grid ref, and kitty image APIs

### DIFF
--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -137,6 +137,18 @@ abstract interface class GhosttyBindings {
   CResult<RgbColor> terminalGetColorCursorDefault(int handle);
   CResult<List<RgbColor>> terminalGetColorPaletteDefault(int handle);
 
+  CResult<Style> terminalGetCursorStyle(int handle);
+  CResult<bool> terminalGetMouseTracking(int handle);
+
+  CResult<int> terminalGetKittyImageStorageLimit(int handle);
+  CResult<bool> terminalGetKittyImageMediumFile(int handle);
+  CResult<bool> terminalGetKittyImageMediumTempFile(int handle);
+  CResult<bool> terminalGetKittyImageMediumSharedMem(int handle);
+  Result terminalSetKittyImageStorageLimit(int handle, int? limit);
+  Result terminalSetKittyImageMediumFile(int handle, {bool? enabled});
+  Result terminalSetKittyImageMediumTempFile(int handle, {bool? enabled});
+  Result terminalSetKittyImageMediumSharedMem(int handle, {bool? enabled});
+
   CResult<Uint8List> pasteEncode(String data, {required bool bracketed});
 
   void terminalSetOnWritePty(int handle, ValueSetter<Uint8List>? callback);
@@ -241,11 +253,17 @@ abstract interface class GhosttyBindings {
   bool styleIsDefault(Style style);
 
   CResult<int> terminalGridRef(int terminal, PointTag pointTag, int x, int y);
+  CResult<({int col, int row})> terminalPointFromGridRef(
+    int terminal,
+    int ref,
+    PointTag pointTag,
+  );
   void gridRefFree(int ref);
   CResult<int> gridRefCell(int ref);
   CResult<int> gridRefRow(int ref);
   CResult<Style> gridRefStyle(int ref);
   CResult<List<int>> gridRefGraphemes(int ref);
+  CResult<String> gridRefHyperlinkUri(int ref);
 
   CResult<int> formatterTerminalNew(
     int terminal,

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -806,6 +806,56 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<Style> terminalGetCursorStyle(int handle) {
+    return _terminalGetStyle(handle, .cursorStyle);
+  }
+
+  @override
+  CResult<bool> terminalGetMouseTracking(int handle) {
+    return _terminalGetBool(handle, .mouseTracking);
+  }
+
+  @override
+  CResult<int> terminalGetKittyImageStorageLimit(int handle) {
+    return _terminalGetU64(handle, .kittyImageStorageLimit);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumFile(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumFile);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumTempFile(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumTempFile);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumSharedMem(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumSharedMem);
+  }
+
+  @override
+  Result terminalSetKittyImageStorageLimit(int handle, int? limit) {
+    return _terminalSetU64(handle, .kittyImageStorageLimit, limit);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumFile(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumFile, enabled);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumTempFile(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumTempFile, enabled);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumSharedMem(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumSharedMem, enabled);
+  }
+
+  @override
   CResult<Uint8List> pasteEncode(String data, {required bool bracketed}) {
     return using((arena) {
       final encoded = utf8.encode(data);
@@ -1340,6 +1390,48 @@ class NativeBindings implements GhosttyBindings {
     return (result, _outBool.value);
   }
 
+  CResult<int> _terminalGetU64(int handle, TerminalData data) {
+    final result = ghostty_terminal_get(
+      Pointer.fromAddress(handle),
+      data,
+      _outU64.cast(),
+    );
+    return (result, _outU64.value);
+  }
+
+  CResult<Style> _terminalGetStyle(int handle, TerminalData data) {
+    final result = ghostty_terminal_get(
+      Pointer.fromAddress(handle),
+      data,
+      _outStyle.cast(),
+    );
+    return (result, _readNativeStyle(_outStyle.ref));
+  }
+
+  Result _terminalSetBool(int handle, TerminalOption option, bool? value) {
+    if (value == null) {
+      return ghostty_terminal_set(Pointer.fromAddress(handle), option, nullptr);
+    }
+    _outBool.value = value;
+    return ghostty_terminal_set(
+      Pointer.fromAddress(handle),
+      option,
+      _outBool.cast(),
+    );
+  }
+
+  Result _terminalSetU64(int handle, TerminalOption option, int? value) {
+    if (value == null) {
+      return ghostty_terminal_set(Pointer.fromAddress(handle), option, nullptr);
+    }
+    _outU64.value = value;
+    return ghostty_terminal_set(
+      Pointer.fromAddress(handle),
+      option,
+      _outU64.cast(),
+    );
+  }
+
   CResult<RgbColor> _terminalGetColor(int handle, TerminalData data) {
     final result = ghostty_terminal_get(
       Pointer.fromAddress(handle),
@@ -1731,6 +1823,44 @@ class NativeBindings implements GhosttyBindings {
       }
 
       return (result, [for (var i = 0; i < len; i++) _graphemeBuf[i]]);
+    });
+  }
+
+  @override
+  CResult<String> gridRefHyperlinkUri(int ref) {
+    return using((arena) {
+      final gridRef = Pointer<GridRef>.fromAddress(ref);
+      final outLen = arena<Size>();
+      var buf = arena<Uint8>(256);
+      var result = ghostty_grid_ref_hyperlink_uri(gridRef, buf, 256, outLen);
+      var len = outLen.value;
+
+      if (result == Result.outOfSpace) {
+        buf = arena<Uint8>(len);
+        result = ghostty_grid_ref_hyperlink_uri(gridRef, buf, len, outLen);
+        len = outLen.value;
+      }
+
+      if (len == 0) return (result, '');
+      return (result, utf8.decode(buf.asTypedList(len)));
+    });
+  }
+
+  @override
+  CResult<({int col, int row})> terminalPointFromGridRef(
+    int terminal,
+    int ref,
+    PointTag pointTag,
+  ) {
+    return using((arena) {
+      final out = arena<PointCoordinate>();
+      final result = ghostty_terminal_point_from_grid_ref(
+        Pointer.fromAddress(terminal),
+        Pointer<GridRef>.fromAddress(ref),
+        pointTag,
+        out,
+      );
+      return (result, (col: out.ref.x, row: out.ref.y));
     });
   }
 

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -46,6 +46,11 @@ class Layouts {
   // GhosttyGridRef
   late final int gridRefSize;
 
+  // GhosttyPointCoordinate
+  late final int pointCoordinateSize;
+  late final int pointCoordinateX;
+  late final int pointCoordinateY;
+
   // GhosttyMouseEncoderSize
   late final int mouseEncoderSizeSize;
   late final int mouseEncoderSizeScreenWidth;
@@ -188,6 +193,9 @@ class Layouts {
     sub = _Struct(types, 'GhosttyPointCoordinate');
     pointX = valueOff + sub['x'];
     pointY = valueOff + sub['y'];
+    pointCoordinateSize = sub.size;
+    pointCoordinateX = sub['x'];
+    pointCoordinateY = sub['y'];
 
     struct = _Struct(types, 'GhosttyRenderStateColors');
     colorsSize = struct.size;

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -867,6 +867,56 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<Style> terminalGetCursorStyle(int handle) {
+    return _terminalGetStyle(handle, .cursorStyle);
+  }
+
+  @override
+  CResult<bool> terminalGetMouseTracking(int handle) {
+    return _terminalGetBool(handle, .mouseTracking);
+  }
+
+  @override
+  CResult<int> terminalGetKittyImageStorageLimit(int handle) {
+    return _terminalGetU64(handle, .kittyImageStorageLimit);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumFile(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumFile);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumTempFile(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumTempFile);
+  }
+
+  @override
+  CResult<bool> terminalGetKittyImageMediumSharedMem(int handle) {
+    return _terminalGetBool(handle, .kittyImageMediumSharedMem);
+  }
+
+  @override
+  Result terminalSetKittyImageStorageLimit(int handle, int? limit) {
+    return _terminalSetU64(handle, .kittyImageStorageLimit, limit);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumFile(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumFile, enabled);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumTempFile(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumTempFile, enabled);
+  }
+
+  @override
+  Result terminalSetKittyImageMediumSharedMem(int handle, {bool? enabled}) {
+    return _terminalSetBool(handle, .kittyImageMediumSharedMem, enabled);
+  }
+
+  @override
   CResult<Uint8List> pasteEncode(String data, {required bool bracketed}) {
     final encoded = utf8.encode(data);
     final dataPtr = _exports.ghostty_wasm_alloc_u8_array(encoded.length);
@@ -1924,6 +1974,57 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<String> gridRefHyperlinkUri(int ref) {
+    const initSize = 256;
+    final outLen = _exports.ghostty_wasm_alloc_usize();
+    var buf = _exports.ghostty_wasm_alloc_u8_array(initSize);
+    var result = Result.fromValue(
+      _exports.ghostty_grid_ref_hyperlink_uri(ref, buf, initSize, outLen),
+    );
+    var len = _mem.readU32(outLen);
+
+    if (result == .outOfSpace) {
+      _exports.ghostty_wasm_free_u8_array(buf, initSize);
+      buf = _exports.ghostty_wasm_alloc_u8_array(len);
+      result = Result.fromValue(
+        _exports.ghostty_grid_ref_hyperlink_uri(ref, buf, len, outLen),
+      );
+      len = _mem.readU32(outLen);
+      final value = len == 0 ? '' : utf8.decode(_mem.readBytes(buf, len));
+      _exports.ghostty_wasm_free_usize(outLen);
+      _exports.ghostty_wasm_free_u8_array(buf, len);
+      return (result, value);
+    }
+
+    final value = len == 0 ? '' : utf8.decode(_mem.readBytes(buf, len));
+    _exports.ghostty_wasm_free_usize(outLen);
+    _exports.ghostty_wasm_free_u8_array(buf, initSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<({int col, int row})> terminalPointFromGridRef(
+    int terminal,
+    int ref,
+    PointTag pointTag,
+  ) {
+    final size = _layout.pointCoordinateSize;
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(size);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_point_from_grid_ref(
+        terminal,
+        ref,
+        pointTag.value,
+        outPtr,
+      ),
+    );
+    final col = _mem.readU16(outPtr + _layout.pointCoordinateX);
+    final row = _mem.readU32(outPtr + _layout.pointCoordinateY);
+    _exports.ghostty_wasm_free_u8_array(outPtr, size);
+    return (result, (col: col, row: row));
+  }
+
+  @override
   CResult<int> formatterTerminalNew(
     int terminal,
     FormatterFormat format, {
@@ -2057,6 +2158,46 @@ class WasmBindings implements GhosttyBindings {
     final value = _mem.readU32(outPtr);
     _exports.ghostty_wasm_free_usize(outPtr);
     return (.fromValue(result), value);
+  }
+
+  CResult<int> _terminalGetU64(int handle, TerminalData data) {
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(8);
+    final result = _exports.ghostty_terminal_get(handle, data.value, outPtr);
+    final value = _mem.readU64(outPtr);
+    _exports.ghostty_wasm_free_u8_array(outPtr, 8);
+    return (.fromValue(result), value);
+  }
+
+  CResult<Style> _terminalGetStyle(int handle, TerminalData data) {
+    final stylePtr = _exports.ghostty_wasm_alloc_u8_array(_layout.styleSize);
+    _mem.writeU32(stylePtr, _layout.styleSize);
+    final result = _exports.ghostty_terminal_get(handle, data.value, stylePtr);
+    final value = _readStyle(stylePtr);
+    _exports.ghostty_wasm_free_u8_array(stylePtr, _layout.styleSize);
+    return (.fromValue(result), value);
+  }
+
+  Result _terminalSetBool(int handle, TerminalOption option, bool? value) {
+    if (value == null) {
+      return .fromValue(_exports.ghostty_terminal_set(handle, option.value, 0));
+    }
+    final ptr = _exports.ghostty_wasm_alloc_u8();
+    _mem.writeU8(ptr, value ? 1 : 0);
+    final result = _exports.ghostty_terminal_set(handle, option.value, ptr);
+    _exports.ghostty_wasm_free_u8(ptr);
+    return .fromValue(result);
+  }
+
+  Result _terminalSetU64(int handle, TerminalOption option, int? value) {
+    if (value == null) {
+      return .fromValue(_exports.ghostty_terminal_set(handle, option.value, 0));
+    }
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(8);
+    _mem.writeU32(ptr, value & 0xFFFFFFFF);
+    _mem.writeU32(ptr + 4, value >> 32);
+    final result = _exports.ghostty_terminal_set(handle, option.value, ptr);
+    _exports.ghostty_wasm_free_u8_array(ptr, 8);
+    return .fromValue(result);
   }
 
   CResult<String> _terminalGetString(int handle, TerminalData data) {

--- a/packages/libghostty/lib/src/impl/terminal/grid_ref.dart
+++ b/packages/libghostty/lib/src/impl/terminal/grid_ref.dart
@@ -20,6 +20,7 @@ class GridRef {
   static final _finalizer = Finalizer<int>(bindings.gridRefFree);
 
   final int _handle;
+  final int _terminalHandle;
   var _disposed = false;
 
   GridRef._(
@@ -27,7 +28,8 @@ class GridRef {
     required int col,
     required int row,
     PointTag pointTag = PointTag.active,
-  }) : _handle = check(
+  }) : _terminalHandle = terminalHandle,
+       _handle = check(
          bindings.terminalGridRef(terminalHandle, pointTag, col, row),
        ) {
     _finalizer.attach(this, _handle, detach: this);
@@ -48,6 +50,14 @@ class GridRef {
   /// Empty if the cell has no text.
   List<int> get graphemes => check(bindings.gridRefGraphemes(_handle));
 
+  /// The hyperlink URI at this position, or null if the cell has no hyperlink.
+  String? get hyperlinkUri {
+    final (code, uri) = bindings.gridRefHyperlinkUri(_handle);
+    if (code == Result.noValue) return null;
+    checkCode(code);
+    return uri.isEmpty ? null : uri;
+  }
+
   /// Whether the cell is the first cell of a wide character.
   bool get isWide => wide == CellWidth.wide;
 
@@ -63,6 +73,21 @@ class GridRef {
   /// The cell's width: [CellWidth.normal], [CellWidth.wide], or
   /// [CellWidth.spacerTail].
   CellWidth get wide => check(bindings.cellGetWide(cell));
+
+  /// Converts this grid reference to coordinates in the given coordinate
+  /// space. Returns null if the reference falls outside the requested
+  /// system (e.g. a scrollback row cannot be expressed in active
+  /// coordinates).
+  ({int col, int row})? pointIn(PointTag pointTag) {
+    final (code, point) = bindings.terminalPointFromGridRef(
+      _terminalHandle,
+      _handle,
+      pointTag,
+    );
+    if (code == Result.noValue) return null;
+    checkCode(code);
+    return point;
+  }
 
   /// Releases this grid reference.
   ///

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -149,6 +149,9 @@ class Terminal with Listenable {
     return _optionalColor(bindings.terminalGetColorCursorDefault(_handle));
   }
 
+  /// The cursor's current SGR style (applied to newly printed characters).
+  Style get cursorStyle => check(bindings.terminalGetCursorStyle(_handle));
+
   /// Effective foreground color (OSC override if active, otherwise default).
   ///
   /// Returns null if no color is configured (neither a default nor an OSC
@@ -173,6 +176,68 @@ class Terminal with Listenable {
 
   /// Total terminal height in pixels (rows * cell height).
   int get heightPx => check(bindings.terminalGetHeightPx(_handle));
+
+  /// Whether any mouse tracking mode is currently active.
+  bool get isMouseTracking => check(bindings.terminalGetMouseTracking(_handle));
+
+  /// Whether the file medium is enabled for Kitty image loading.
+  /// Returns null when Kitty graphics are not compiled in.
+  bool? get isKittyFileMedium {
+    final (code, value) = bindings.terminalGetKittyImageMediumFile(_handle);
+    return code == .noValue ? null : check((code, value));
+  }
+
+  /// Enables or disables the file medium for Kitty image loading.
+  void setKittyFileMedium({required bool enabled}) {
+    checkCode(
+      bindings.terminalSetKittyImageMediumFile(_handle, enabled: enabled),
+    );
+  }
+
+  /// Whether the shared memory medium is enabled for Kitty image loading.
+  /// Returns null when Kitty graphics are not compiled in.
+  bool? get isKittySharedMemMedium {
+    final (code, value) = bindings.terminalGetKittyImageMediumSharedMem(
+      _handle,
+    );
+    return code == .noValue ? null : check((code, value));
+  }
+
+  /// Enables or disables the shared memory medium for Kitty image loading.
+  void setKittySharedMemMedium({required bool enabled}) {
+    checkCode(
+      bindings.terminalSetKittyImageMediumSharedMem(_handle, enabled: enabled),
+    );
+  }
+
+  /// Whether the temporary file medium is enabled for Kitty image loading.
+  /// Returns null when Kitty graphics are not compiled in.
+  bool? get isKittyTempFileMedium {
+    final (code, value) = bindings.terminalGetKittyImageMediumTempFile(_handle);
+    return code == .noValue ? null : check((code, value));
+  }
+
+  /// Enables or disables the temporary file medium for Kitty image loading.
+  void setKittyTempFileMedium({required bool enabled}) {
+    checkCode(
+      bindings.terminalSetKittyImageMediumTempFile(_handle, enabled: enabled),
+    );
+  }
+
+  /// Kitty image storage limit in bytes for the active screen.
+  ///
+  /// Zero means the Kitty graphics protocol is disabled. Returns null when
+  /// Kitty graphics support is not compiled into the library.
+  int? get kittyImageStorageLimit {
+    final (code, value) = bindings.terminalGetKittyImageStorageLimit(_handle);
+    return code == .noValue ? null : check((code, value));
+  }
+
+  /// Sets the Kitty image storage limit in bytes. Zero or null disables
+  /// the Kitty graphics protocol entirely.
+  set kittyImageStorageLimit(int? value) {
+    checkCode(bindings.terminalSetKittyImageStorageLimit(_handle, value));
+  }
 
   /// Current Kitty keyboard protocol flags.
   ///

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -457,6 +457,145 @@ void main() {
     });
   });
 
+  group('terminal cursor style and mouse tracking', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('cursor style returns default style initially', () {
+      final (code, style) = bindings.terminalGetCursorStyle(terminal);
+      expect(code, Result.success);
+      expect(bindings.styleIsDefault(style), isTrue);
+    });
+
+    test('mouse tracking is false initially', () {
+      final (code, tracking) = bindings.terminalGetMouseTracking(terminal);
+      expect(code, Result.success);
+      expect(tracking, isFalse);
+    });
+  });
+
+  group('kitty image config', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('storage limit getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageStorageLimit(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('medium file getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumFile(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('storage limit can be set', () {
+      final result = bindings.terminalSetKittyImageStorageLimit(
+        terminal,
+        1024 * 1024,
+      );
+      expect(result, Result.success);
+    });
+
+    test('medium file can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumFile(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+
+    test('temp file medium getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumTempFile(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('shared mem medium getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumSharedMem(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('temp file medium can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumTempFile(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+
+    test('shared mem medium can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumSharedMem(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+  });
+
+  group('grid ref hyperlink uri', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+      bindings.terminalVtWrite(terminal, Uint8List.fromList('Hello'.codeUnits));
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('returns empty string for cell without hyperlink', () {
+      final (_, ref) = bindings.terminalGridRef(
+        terminal,
+        PointTag.active,
+        0,
+        0,
+      );
+      final (code, uri) = bindings.gridRefHyperlinkUri(ref);
+      expect(code, Result.success);
+      expect(uri, isEmpty);
+    });
+  });
+
+  group('terminal point from grid ref', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+      bindings.terminalVtWrite(terminal, Uint8List.fromList('Hello'.codeUnits));
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('roundtrips active coordinates', () {
+      final (_, ref) = bindings.terminalGridRef(
+        terminal,
+        PointTag.active,
+        3,
+        0,
+      );
+      final (code, point) = bindings.terminalPointFromGridRef(
+        terminal,
+        ref,
+        PointTag.active,
+      );
+      expect(code, Result.success);
+      expect(point.col, 3);
+      expect(point.row, 0);
+    });
+  });
+
   group('formatter', () {
     late int terminal;
 

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -467,6 +467,147 @@ void main() {
     });
   });
 
+  group('terminal cursor style and mouse tracking', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('cursor style returns default style initially', () {
+      final (code, style) = bindings.terminalGetCursorStyle(terminal);
+      expect(code, Result.success);
+      expect(bindings.styleIsDefault(style), isTrue);
+    });
+
+    test('mouse tracking is false initially', () {
+      final (code, tracking) = bindings.terminalGetMouseTracking(terminal);
+      expect(code, Result.success);
+      expect(tracking, isFalse);
+    });
+  });
+
+  group('kitty image config', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('storage limit getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageStorageLimit(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('medium file getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumFile(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('storage limit can be set', () {
+      final result = bindings.terminalSetKittyImageStorageLimit(
+        terminal,
+        1024 * 1024,
+      );
+      expect(result, Result.success);
+    });
+
+    test('medium file can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumFile(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+
+    test('temp file medium getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumTempFile(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('shared mem medium getter returns a value or noValue', () {
+      final (code, _) = bindings.terminalGetKittyImageMediumSharedMem(terminal);
+      expect(code, anyOf(Result.success, Result.noValue));
+    });
+
+    test('temp file medium can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumTempFile(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+
+    test('shared mem medium can be toggled', () {
+      final result = bindings.terminalSetKittyImageMediumSharedMem(
+        terminal,
+        enabled: true,
+      );
+      expect(result, Result.success);
+    });
+  });
+
+  group('grid ref hyperlink uri', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+      bindings.terminalVtWrite(terminal, Uint8List.fromList('Hello'.codeUnits));
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('returns empty string for cell without hyperlink', () {
+      final (_, ref) = bindings.terminalGridRef(
+        terminal,
+        PointTag.active,
+        0,
+        0,
+      );
+      final (code, uri) = bindings.gridRefHyperlinkUri(ref);
+      expect(code, Result.success);
+      expect(uri, isEmpty);
+      bindings.gridRefFree(ref);
+    });
+  });
+
+  group('terminal point from grid ref', () {
+    late int terminal;
+
+    setUp(() {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      terminal = t;
+      bindings.terminalVtWrite(terminal, Uint8List.fromList('Hello'.codeUnits));
+    });
+
+    tearDown(() => bindings.terminalFree(terminal));
+
+    test('roundtrips active coordinates', () {
+      final (_, ref) = bindings.terminalGridRef(
+        terminal,
+        PointTag.active,
+        3,
+        0,
+      );
+      final (code, point) = bindings.terminalPointFromGridRef(
+        terminal,
+        ref,
+        PointTag.active,
+      );
+      expect(code, Result.success);
+      expect(point.col, 3);
+      expect(point.row, 0);
+      bindings.gridRefFree(ref);
+    });
+  });
+
   group('formatter', () {
     late int terminal;
 


### PR DESCRIPTION
Expose new upstream C API surface through the Dart binding layers (interface, native FFI, WASM) and public Terminal/GridRef classes.

- Terminal: `cursorStyle`, `isMouseTracking`, and kitty image configuration (storage limit, file/temp/shared memory mediums) with nullable returns when kitty graphics are disabled at build time
- GridRef: `hyperlinkUri` for extracting OSC 8 hyperlink URIs, and `pointIn()` for converting grid references back to coordinates in a given coordinate system
- `terminalPointFromGridRef` binding for the inverse of `terminalGridRef`