### PR TITLE
feat(libghostty): add Selection support to formatter and migrate flterm

### DIFF
--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -78,7 +78,7 @@ controller.sendText('ls -la\n');
 
 // Selection
 controller.selectAll();
-print(controller.selectedText);
+print(controller.selectedText());
 
 // Clipboard
 controller.paste('hello');

--- a/packages/flterm/lib/src/widgets/terminal_controller.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller.dart
@@ -83,12 +83,6 @@ abstract class TerminalController extends ChangeNotifier
   /// Scrollbar state: total rows, visible rows, and current offset.
   Scrollbar get scrollbar;
 
-  /// Text content of the current selection, or empty if none.
-  ///
-  /// Soft-wrapped lines are joined without newlines in normal mode.
-  /// Block mode inserts a newline after each row.
-  String get selectedText;
-
   @override
   TerminalSelection? get selection;
 
@@ -173,6 +167,21 @@ abstract class TerminalController extends ChangeNotifier
 
   /// Selects all terminal content including scrollback.
   void selectAll();
+
+  /// Returns the text within the current [selection], or empty string
+  /// when there is no selection.
+  ///
+  /// [format] controls the output encoding:
+  /// - [FormatterFormat.plain]: unstyled text, suitable for the clipboard
+  ///   (default).
+  /// - [FormatterFormat.vt]: VT escape sequences preserving colors, styles,
+  ///   and hyperlinks.
+  /// - [FormatterFormat.html]: HTML with inline styles.
+  ///
+  /// In normal selection mode, soft-wrapped lines are joined into a single
+  /// line without an inserted newline. In block mode, every row is kept
+  /// separate regardless of wrapping.
+  String selectedText({FormatterFormat format = .plain});
 
   /// Encodes a key press and sends it via [onOutput].
   ///

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -127,51 +127,6 @@ class TerminalControllerImpl extends TerminalController
   Scrollbar get scrollbar => terminal.scrollbar;
 
   @override
-  String get selectedText {
-    final selection = _selection;
-    if (selection == null) return '';
-
-    final buffer = StringBuffer();
-    final cols = terminal.renderState.cols;
-
-    final total = terminal.totalRows;
-    final maxRow = selection.bottomRow < total
-        ? selection.bottomRow
-        : total - 1;
-
-    for (var row = selection.topRow; row <= maxRow; row++) {
-      final startCol = switch (selection.mode) {
-        .block => selection.topCol,
-        _ => (row == selection.topRow ? selection.topCol : 0),
-      };
-      final endCol = switch (selection.mode) {
-        .block => selection.bottomCol,
-        _ => (row == selection.bottomRow ? selection.bottomCol : cols),
-      };
-
-      for (var col = startCol; col < endCol && col < cols; col++) {
-        final ref = terminal.gridRefAt(col: col, row: row, pointTag: .screen);
-        final wide = ref.wide;
-        if (wide == .spacerTail || wide == .spacerHead) {
-          ref.dispose();
-          continue;
-        }
-        final content = ref.content;
-        ref.dispose();
-        buffer.write(content.isEmpty ? ' ' : content);
-      }
-
-      if (row < maxRow) {
-        if (selection.mode == .block || !_isRowWrapped(row)) {
-          buffer.write('\n');
-        }
-      }
-    }
-
-    return buffer.toString();
-  }
-
-  @override
   TerminalSelection? get selection => _selection;
 
   @override
@@ -457,6 +412,43 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
+  String selectedText({FormatterFormat format = .plain}) {
+    final selection = _selection;
+    if (selection == null) return '';
+
+    final cols = terminal.renderState.cols;
+    final total = terminal.totalRows;
+    if (cols <= 0 || total <= 0) return '';
+    final topRow = selection.topRow.clamp(0, total - 1);
+    final bottomRow = selection.bottomRow.clamp(0, total - 1);
+    if (topRow > bottomRow) return '';
+
+    final block = selection.mode == .block;
+    final topCol = selection.topCol.clamp(0, cols - 1);
+    final bottomCol = (selection.bottomCol - 1).clamp(0, cols - 1);
+    if (block && topCol > bottomCol) return '';
+
+    final formatter = terminal.createFormatter(
+      format: format,
+      unwrap: !block,
+      selection: Selection(
+        startCol: topCol,
+        startRow: topRow,
+        endCol: bottomCol,
+        endRow: bottomRow,
+        rectangle: block,
+        pointTag: .screen,
+      ),
+    );
+
+    try {
+      return formatter.format();
+    } finally {
+      formatter.dispose();
+    }
+  }
+
+  @override
   void selectLine(int row, LineSelectMode lineSelectMode) {
     final (:startRow, :endRow, :endCol) = terminal.lineBoundaryAt(row);
     final effectiveEndCol = switch (lineSelectMode) {
@@ -633,13 +625,6 @@ class TerminalControllerImpl extends TerminalController
     _emitOutput(utf8.encode(text));
     clearVirtualMods();
     _onTextInput();
-  }
-
-  bool _isRowWrapped(int row) {
-    final ref = terminal.gridRefAt(col: 0, row: row, pointTag: .screen);
-    final wrapped = ref.rowWrap;
-    ref.dispose();
-    return wrapped;
   }
 
   void _onFocusChanged() {

--- a/packages/flterm/lib/src/widgets/terminal_shortcut_scope.dart
+++ b/packages/flterm/lib/src/widgets/terminal_shortcut_scope.dart
@@ -107,7 +107,7 @@ class TerminalShortcutScope extends StatelessWidget {
           CopyIntent: _ConditionalAction<CopyIntent>(
             isEnabledFn: () => controller.selection != null,
             onInvokeFn: () {
-              final text = controller.selectedText;
+              final text = controller.selectedText();
               if (text.isNotEmpty) {
                 unawaited(Clipboard.setData(ClipboardData(text: text)));
               }

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -29,7 +29,7 @@ void main() {
 
     test('initial state has null selection, empty selectedText, no focus', () {
       expect(controller.selection, isNull);
-      expect(controller.selectedText, '');
+      expect(controller.selectedText(), '');
       expect(controller.hasFocus, isFalse);
     });
 
@@ -162,7 +162,32 @@ void main() {
         endCol: 5,
       );
 
-      expect(controller.selectedText, 'hello');
+      expect(controller.selectedText(), 'hello');
+    });
+
+    test('selectedText honors requested formatter format', () {
+      controller = TerminalControllerImpl(
+        config: const TerminalConfig(cols: 20, rows: 5),
+      );
+      controller.terminal.renderState.update();
+      controller.writeUtf8('\x1b[31mhi\x1b[0m');
+
+      controller.selection = const TerminalSelection(
+        startRow: 0,
+        startCol: 0,
+        endRow: 0,
+        endCol: 2,
+      );
+
+      expect(controller.selectedText(), 'hi');
+      expect(
+        controller.selectedText(format: FormatterFormat.vt),
+        contains('hi'),
+      );
+      expect(
+        controller.selectedText(format: FormatterFormat.html),
+        contains('<'),
+      );
     });
 
     test('selectedText excludes spacer tails from wide characters', () {
@@ -184,7 +209,7 @@ void main() {
         endRow: 0,
         endCol: 6,
       );
-      expect(controller.selectedText, '日本語');
+      expect(controller.selectedText(), '日本語');
 
       controller.selection = const TerminalSelection(
         startRow: 0,
@@ -193,7 +218,7 @@ void main() {
         endCol: 6,
         mode: TerminalSelectionMode.block,
       );
-      expect(controller.selectedText, '日本語');
+      expect(controller.selectedText(), '日本語');
     });
 
     group('scrollback selection', () {
@@ -246,8 +271,8 @@ void main() {
           endCol: 20,
         );
 
-        expect(() => smallController.selectedText, returnsNormally);
-        expect(smallController.selectedText, contains('aaa'));
+        expect(() => smallController.selectedText(), returnsNormally);
+        expect(smallController.selectedText(), contains('aaa'));
       });
 
       test('selectedText extracts from scrollback and screen', () {
@@ -257,7 +282,7 @@ void main() {
 
         smallController.selectAll();
 
-        final text = smallController.selectedText;
+        final text = smallController.selectedText();
         expect(text, contains('aaa'));
         expect(text, contains('bbb'));
         expect(text, contains('ccc'));
@@ -275,7 +300,7 @@ void main() {
 
         wrapController.selectAll();
 
-        final text = wrapController.selectedText;
+        final text = wrapController.selectedText();
         expect(text, 'abcdefgh');
         expect(text, isNot(contains('\n')));
       });
@@ -297,7 +322,7 @@ void main() {
         );
         wrapController.selectAll();
 
-        expect(wrapController.selectedText, 'A日B日C');
+        expect(wrapController.selectedText(), 'A日B日C');
       });
 
       test('selectedText in block mode inserts newlines between rows', () {
@@ -310,7 +335,7 @@ void main() {
           mode: TerminalSelectionMode.block,
         );
 
-        final text = smallController.selectedText;
+        final text = smallController.selectedText();
         final lines = text.split('\n');
         expect(lines.length, 3);
         expect(lines[0], 'aa');
@@ -329,7 +354,7 @@ void main() {
           endCol: 3,
         );
 
-        final text = smallController.selectedText;
+        final text = smallController.selectedText();
         expect(text, contains('aaa'));
         expect(text, contains('bbb'));
         expect(text, isNot(contains('ccc')));

--- a/packages/flterm/test/widgets/terminal_shortcut_scope_test.dart
+++ b/packages/flterm/test/widgets/terminal_shortcut_scope_test.dart
@@ -87,7 +87,7 @@ void main() {
       await _sendCmd(tester, .keyA);
 
       expect(controller.selection, isNotNull);
-      expect(controller.selectedText, 'hello');
+      expect(controller.selectedText(), 'hello');
     });
 
     testWidgets('Cmd+A is no-op when enableSelectAll is false', (tester) async {

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -575,7 +575,7 @@ void main() {
         await tester.pump();
 
         expect(controller.selection, isNotNull);
-        expect(controller.selectedText, contains('hello'));
+        expect(controller.selectedText(), contains('hello'));
       });
 
       testWidgets('triple click selects entire line', (tester) async {
@@ -597,7 +597,7 @@ void main() {
         final sel = controller.selection;
         expect(sel, isNotNull);
         expect(sel!.startCol, 0);
-        expect(controller.selectedText.length, greaterThan('hello'.length));
+        expect(controller.selectedText().length, greaterThan('hello'.length));
       });
 
       testWidgets('mouse drag creates selection', (tester) async {
@@ -617,7 +617,7 @@ void main() {
         await tester.pump();
 
         expect(controller.selection, isNotNull);
-        expect(controller.selectedText, isNotEmpty);
+        expect(controller.selectedText(), isNotEmpty);
       });
     });
 

--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -71,6 +71,7 @@ export 'src/impl/terminal/terminal.dart'
         GridRef,
         RenderState,
         Row,
+        Selection,
         Terminal;
 export 'src/impl/terminal/terminal_mode.dart' show TerminalMode;
 export 'src/listenable.dart' show Listenable;

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -271,6 +271,7 @@ abstract interface class GhosttyBindings {
     bool unwrap = false,
     bool trim = false,
     FormatterExtra extra = const FormatterExtra(),
+    RawSelection? selection,
   });
   void formatterFree(int formatter);
   CResult<String> formatterFormat(int formatter);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -1871,6 +1871,7 @@ class NativeBindings implements GhosttyBindings {
     bool unwrap = false,
     bool trim = false,
     FormatterExtra extra = const FormatterExtra(),
+    RawSelection? selection,
   }) {
     return using((arena) {
       final ptr = arena<Pointer<FormatterImpl>>();
@@ -1898,6 +1899,17 @@ class NativeBindings implements GhosttyBindings {
         ..protection = extra.protection
         ..kitty_keyboard = extra.kittyKeyboard
         ..charsets = extra.charsets;
+
+      if (selection != null) {
+        final sel = arena<Selection>();
+        sel.ref.size = sizeOf<Selection>();
+        sel.ref.start = Pointer<GridRef>.fromAddress(selection.start).ref;
+        sel.ref.end = Pointer<GridRef>.fromAddress(selection.end).ref;
+        sel.ref.rectangle = selection.rectangle;
+        opts.ref.selection = sel;
+      } else {
+        opts.ref.selection = nullptr;
+      }
 
       final result = ghostty_formatter_terminal_new(
         nullptr,

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -29,3 +29,7 @@ typedef UnderlineStyle = SgrUnderline;
 typedef ValueGetter<T> = T Function();
 typedef ValueSetter<T> = void Function(T value);
 typedef VoidCallback = void Function();
+
+/// A selection range addressed by `GridRef` handles. `rectangle` indicates
+/// a rectangular (block) selection rather than a linear one.
+typedef RawSelection = ({int start, int end, bool rectangle});

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -23,6 +23,7 @@ class Layouts {
   late final int formatterOptsUnwrap;
   late final int formatterOptsTrim;
   late final int formatterOptsExtra;
+  late final int formatterOptsSelection;
 
   // GhosttyFormatterTerminalExtra
   late final int formatterTermExtraSize;
@@ -42,6 +43,12 @@ class Layouts {
   late final int formatterScreenExtraProtection;
   late final int formatterScreenExtraKittyKeyboard;
   late final int formatterScreenExtraCharsets;
+
+  // GhosttySelection
+  late final int selectionSize;
+  late final int selectionStart;
+  late final int selectionEnd;
+  late final int selectionRectangle;
 
   // GhosttyGridRef
   late final int gridRefSize;
@@ -149,6 +156,7 @@ class Layouts {
     formatterOptsUnwrap = struct['unwrap'];
     formatterOptsTrim = struct['trim'];
     formatterOptsExtra = struct['extra'];
+    formatterOptsSelection = struct['selection'];
 
     struct = _Struct(types, 'GhosttyFormatterTerminalExtra');
     formatterTermExtraSize = struct.size;
@@ -168,6 +176,12 @@ class Layouts {
     formatterScreenExtraProtection = struct['protection'];
     formatterScreenExtraKittyKeyboard = struct['kitty_keyboard'];
     formatterScreenExtraCharsets = struct['charsets'];
+
+    struct = _Struct(types, 'GhosttySelection');
+    selectionSize = struct.size;
+    selectionStart = struct['start'];
+    selectionEnd = struct['end'];
+    selectionRectangle = struct['rectangle'];
 
     struct = _Struct(types, 'GhosttyGridRef');
     gridRefSize = struct.size;

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -2031,6 +2031,7 @@ class WasmBindings implements GhosttyBindings {
     bool unwrap = false,
     bool trim = false,
     FormatterExtra extra = const FormatterExtra(),
+    RawSelection? selection,
   }) {
     final optsSize = _layout.formatterOptsSize;
     final outPtr = _exports.ghostty_wasm_alloc_opaque();
@@ -2097,6 +2098,23 @@ class WasmBindings implements GhosttyBindings {
       extra.charsets ? 1 : 0,
     );
 
+    var selPtr = 0;
+    if (selection != null) {
+      selPtr = _exports.ghostty_wasm_alloc_u8_array(_layout.selectionSize);
+      _mem.writeU32(selPtr, _layout.selectionSize);
+      final startSrc = selection.start;
+      final endSrc = selection.end;
+      final startDst = selPtr + _layout.selectionStart;
+      final endDst = selPtr + _layout.selectionEnd;
+      _mem.writeBytes(startDst, _mem.readBytes(startSrc, _layout.gridRefSize));
+      _mem.writeBytes(endDst, _mem.readBytes(endSrc, _layout.gridRefSize));
+      _mem.writeU8(
+        selPtr + _layout.selectionRectangle,
+        selection.rectangle ? 1 : 0,
+      );
+    }
+    _mem.writeU32(optsPtr + _layout.formatterOptsSelection, selPtr);
+
     final result = _exports.ghostty_formatter_terminal_new(
       0,
       outPtr,
@@ -2106,6 +2124,9 @@ class WasmBindings implements GhosttyBindings {
     final handle = _mem.readPtr(outPtr);
     _exports.ghostty_wasm_free_opaque(outPtr);
     _exports.ghostty_wasm_free_u8_array(optsPtr, optsSize);
+    if (selPtr != 0) {
+      _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    }
     return (.fromValue(result), handle);
   }
 

--- a/packages/libghostty/lib/src/impl/terminal/formatter.dart
+++ b/packages/libghostty/lib/src/impl/terminal/formatter.dart
@@ -24,7 +24,15 @@ class Formatter {
     bool unwrap = false,
     bool trim = false,
     FormatterExtra extra = const FormatterExtra(),
-  }) : _handle = _create(terminalHandle, format, unwrap, trim, extra) {
+    RawSelection? selection,
+  }) : _handle = _create(
+         terminalHandle,
+         format,
+         unwrap,
+         trim,
+         extra,
+         selection,
+       ) {
     _finalizer.attach(this, _handle, detach: this);
   }
 
@@ -54,6 +62,7 @@ class Formatter {
     bool unwrap,
     bool trim,
     FormatterExtra extra,
+    RawSelection? selection,
   ) {
     return check(
       bindings.formatterTerminalNew(
@@ -62,6 +71,7 @@ class Formatter {
         unwrap: unwrap,
         trim: trim,
         extra: extra,
+        selection: selection,
       ),
     );
   }

--- a/packages/libghostty/lib/src/impl/terminal/selection.dart
+++ b/packages/libghostty/lib/src/impl/terminal/selection.dart
@@ -7,6 +7,12 @@ part of 'terminal.dart';
 /// terminal (write, reset, resize) may invalidate those endpoints;
 /// create a fresh formatter with a new [Selection] after such operations.
 ///
+/// [pointTag] selects the coordinate space the row/column values refer
+/// to. Use [PointTag.active] for the active screen (default),
+/// [PointTag.viewport] for viewport-relative addressing, or
+/// [PointTag.screen] to address the full scrollback plus active screen
+/// by absolute row index.
+///
 /// ```dart
 /// final selection = Selection(
 ///   startCol: 0, startRow: 0,
@@ -35,17 +41,28 @@ class Selection {
   /// than a linear text range.
   final bool rectangle;
 
+  /// Coordinate space the row/column values address.
+  final PointTag pointTag;
+
   const Selection({
     required this.startCol,
     required this.startRow,
     required this.endCol,
     required this.endRow,
     this.rectangle = false,
+    this.pointTag = PointTag.active,
   });
 
   @override
-  int get hashCode =>
-      Object.hash(Selection, startCol, startRow, endCol, endRow, rectangle);
+  int get hashCode => Object.hash(
+    Selection,
+    startCol,
+    startRow,
+    endCol,
+    endRow,
+    rectangle,
+    pointTag,
+  );
 
   @override
   bool operator ==(Object other) =>
@@ -54,10 +71,11 @@ class Selection {
       other.startRow == startRow &&
       other.endCol == endCol &&
       other.endRow == endRow &&
-      other.rectangle == rectangle;
+      other.rectangle == rectangle &&
+      other.pointTag == pointTag;
 
   @override
   String toString() =>
       'Selection($startCol,$startRow -> $endCol,$endRow'
-      '${rectangle ? ', rectangle' : ''})';
+      '${rectangle ? ', rectangle' : ''}, $pointTag)';
 }

--- a/packages/libghostty/lib/src/impl/terminal/selection.dart
+++ b/packages/libghostty/lib/src/impl/terminal/selection.dart
@@ -1,0 +1,63 @@
+part of 'terminal.dart';
+
+/// A range of terminal content between two cell positions.
+///
+/// Endpoints are resolved against the terminal's current page state at
+/// [Terminal.createFormatter]. Subsequent mutating operations on the
+/// terminal (write, reset, resize) may invalidate those endpoints;
+/// create a fresh formatter with a new [Selection] after such operations.
+///
+/// ```dart
+/// final selection = Selection(
+///   startCol: 0, startRow: 0,
+///   endCol: 10, endRow: 0,
+/// );
+/// final formatter = terminal.createFormatter(
+///   format: FormatterFormat.plain,
+///   selection: selection,
+/// );
+/// ```
+@immutable
+class Selection {
+  /// Zero-based column of the selection start (inclusive).
+  final int startCol;
+
+  /// Zero-based row of the selection start (inclusive).
+  final int startRow;
+
+  /// Zero-based column of the selection end (inclusive).
+  final int endCol;
+
+  /// Zero-based row of the selection end (inclusive).
+  final int endRow;
+
+  /// Whether the selection covers a rectangular (block) region rather
+  /// than a linear text range.
+  final bool rectangle;
+
+  const Selection({
+    required this.startCol,
+    required this.startRow,
+    required this.endCol,
+    required this.endRow,
+    this.rectangle = false,
+  });
+
+  @override
+  int get hashCode =>
+      Object.hash(Selection, startCol, startRow, endCol, endRow, rectangle);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Selection &&
+      other.startCol == startCol &&
+      other.startRow == startRow &&
+      other.endCol == endCol &&
+      other.endRow == endRow &&
+      other.rectangle == rectangle;
+
+  @override
+  String toString() =>
+      'Selection($startCol,$startRow -> $endCol,$endRow'
+      '${rectangle ? ', rectangle' : ''})';
+}

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -426,11 +426,13 @@ class Terminal with Listenable {
       _handle,
       col: selection.startCol,
       row: selection.startRow,
+      pointTag: selection.pointTag,
     );
     final end = GridRef._(
       _handle,
       col: selection.endCol,
       row: selection.endRow,
+      pointTag: selection.pointTag,
     );
     try {
       return Formatter._(

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -16,6 +16,7 @@ part 'formatter.dart';
 part 'grid_ref.dart';
 part 'render_state.dart';
 part 'row.dart';
+part 'selection.dart';
 
 @internal
 int terminalHandle(Terminal terminal) => terminal._handle;
@@ -395,7 +396,10 @@ class Terminal with Listenable {
   /// [FormatterFormat.vt] output (cursor position, modes, palette, etc.).
   /// Has no effect on plain text or HTML output.
   ///
-  /// Throws [OutOfMemoryException] if the native allocation fails.
+  /// [selection] restricts the output to the given range. When null, the
+  /// entire active screen is formatted.
+  ///
+  /// Throws [OutOfMemoryException] when the allocation fails.
   ///
   /// ```dart
   /// final fmt = terminal.createFormatter(format: FormatterFormat.plain);
@@ -407,7 +411,45 @@ class Terminal with Listenable {
     bool unwrap = false,
     bool trim = false,
     FormatterExtra extra = const FormatterExtra(),
-  }) => ._(_handle, format: format, unwrap: unwrap, trim: trim, extra: extra);
+    Selection? selection,
+  }) {
+    if (selection == null) {
+      return Formatter._(
+        _handle,
+        format: format,
+        unwrap: unwrap,
+        trim: trim,
+        extra: extra,
+      );
+    }
+    final start = GridRef._(
+      _handle,
+      col: selection.startCol,
+      row: selection.startRow,
+    );
+    final end = GridRef._(
+      _handle,
+      col: selection.endCol,
+      row: selection.endRow,
+    );
+    try {
+      return Formatter._(
+        _handle,
+        format: format,
+        unwrap: unwrap,
+        trim: trim,
+        extra: extra,
+        selection: (
+          start: start._handle,
+          end: end._handle,
+          rectangle: selection.rectangle,
+        ),
+      );
+    } finally {
+      start.dispose();
+      end.dispose();
+    }
+  }
 
   /// Releases all resources held by this terminal instance.
   ///

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -665,5 +665,25 @@ void main() {
 
       expect(withExtras.length, greaterThan(withoutExtras.length));
     });
+
+    test('formatter with selection restricts output', () {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      bindings.terminalVtWrite(
+        t,
+        Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+      );
+      final (_, startRef) = bindings.terminalGridRef(t, PointTag.active, 0, 0);
+      final (_, endRef) = bindings.terminalGridRef(t, PointTag.active, 2, 0);
+      final (_, formatter) = bindings.formatterTerminalNew(
+        t,
+        FormatterFormat.plain,
+        selection: (start: startRef, end: endRef, rectangle: false),
+      );
+      final (_, text) = bindings.formatterFormat(formatter);
+      bindings.formatterFree(formatter);
+      bindings.terminalFree(t);
+      expect(text, contains('ABC'));
+      expect(text, isNot(contains('FGHIJ')));
+    });
   });
 }

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -713,6 +713,35 @@ void main() {
       });
     });
 
+    group('createFormatter', () {
+      test('plain format returns screen content', () {
+        terminal.write(Uint8List.fromList('Hello'.codeUnits));
+        final formatter = terminal.createFormatter(
+          format: FormatterFormat.plain,
+          trim: true,
+        );
+        addTearDown(formatter.dispose);
+        expect(formatter.format(), contains('Hello'));
+      });
+
+      test('selection restricts output to the given range', () {
+        terminal.write(Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits));
+        final formatter = terminal.createFormatter(
+          format: FormatterFormat.plain,
+          selection: const Selection(
+            startCol: 0,
+            startRow: 0,
+            endCol: 2,
+            endRow: 0,
+          ),
+        );
+        addTearDown(formatter.dispose);
+        final text = formatter.format();
+        expect(text, contains('ABC'));
+        expect(text, isNot(contains('FGHIJ')));
+      });
+    });
+
     group('selectCell', () {
       test('reads specific column content', () {
         terminal.write(Uint8List.fromList('ABCDE'.codeUnits));

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -677,5 +677,27 @@ void main() {
 
       expect(withExtras.length, greaterThan(withoutExtras.length));
     });
+
+    test('formatter with selection restricts output', () {
+      final (_, t) = bindings.terminalNew(80, 24, 0);
+      bindings.terminalVtWrite(
+        t,
+        Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+      );
+      final (_, startRef) = bindings.terminalGridRef(t, PointTag.active, 0, 0);
+      final (_, endRef) = bindings.terminalGridRef(t, PointTag.active, 2, 0);
+      final (_, formatter) = bindings.formatterTerminalNew(
+        t,
+        FormatterFormat.plain,
+        selection: (start: startRef, end: endRef, rectangle: false),
+      );
+      final (_, text) = bindings.formatterFormat(formatter);
+      bindings.formatterFree(formatter);
+      bindings.gridRefFree(startRef);
+      bindings.gridRefFree(endRef);
+      bindings.terminalFree(t);
+      expect(text, contains('ABC'));
+      expect(text, isNot(contains('FGHIJ')));
+    });
   });
 }


### PR DESCRIPTION
Add a `Selection` class and thread it through `Terminal.createFormatter()` so callers can restrict formatted output to a specific region, then migrate flterm's `selectedText` to use it.

- `Selection` carries coordinate pairs, a `rectangle` flag for block selections, and a `pointTag` that picks the coordinate space (active screen, viewport, or full screen plus scrollback). Defaults to `PointTag.active`.
- `Terminal.createFormatter()` resolves the coordinates to `GridRef` handles internally and frees them after creation, since the C formatter copies the selection pins by value.
- Binding layer takes raw handles via a `RawSelection` typedef, keeping it a thin transport over the C contract.
- flterm's `TerminalController.selectedText` is now a method that accepts a `FormatterFormat`, so consumers can pull VT or HTML output alongside the default plain text used for the clipboard.
- `TerminalControllerImpl.selectedText` delegates to `Terminal.createFormatter` with a `Selection`, replacing the previous per-cell `GridRef` loop.