### PR TITLE
ci: compile libghostty from source by default

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,11 +109,6 @@ jobs:
           mkdir -p ghostty
           tar xzf ghostty.tar.gz -C ghostty --strip-components=1
           rm ghostty.tar.gz
-      - name: build libghostty from source
-        shell: bash
-        run: |
-          sed -i.bak 's/source: prebuilt/source: compile/' pubspec.yaml
-          rm pubspec.yaml.bak
       - run: flutter pub get
       - run: dart pub global activate very_good_cli
       - name: run tests
@@ -186,11 +181,33 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-tags: false
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.pub-cache
           key: pub-flterm-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: pub-flterm-
+      - name: resolve ghostty source
+        id: ghostty
+        shell: bash
+        run: |
+          COMMIT=$(cat packages/libghostty/ghostty.version)
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        id: ghostty-cache
+        with:
+          path: ghostty
+          key: ghostty-src-${{ steps.ghostty.outputs.commit }}
+      - name: download ghostty source
+        if: steps.ghostty-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.commit }}.tar.gz" -o ghostty.tar.gz
+          mkdir -p ghostty
+          tar xzf ghostty.tar.gz -C ghostty --strip-components=1
+          rm ghostty.tar.gz
       - run: flutter pub get
       - name: install very_good_cli
         run: |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,12 +13,12 @@ hooks:
   user_defines:
     libghostty:
       # How to obtain the native library binary.
-      # - `prebuilt` (default): Download from GitHub Releases. Matches what
-      #   downstream pub.dev users get. No zig or ghostty source required.
-      # - `compile`: Build from source using Zig. Use this when actively
-      #   working on libghostty itself or testing unreleased changes.
-      source: prebuilt
-      # How to download source code when source=compile.
-      # - `tarball` (default): Download tarball from GitHub Releases
-      # - `git`: Clone from GitHub
+      # - `compile` (default): Build from source using Zig against the
+      #   pinned `ghostty.version`.
+      # - `prebuilt`: Download from GitHub Releases. Skips the Zig
+      #   toolchain requirement.
+      source: compile
+      # Source download method when `source: compile`.
+      # - `tarball` (default): GitHub Release tarball.
+      # - `git`: Clone from GitHub.
       download: tarball


### PR DESCRIPTION
The workspace pubspec defaulted to `source: prebuilt`, which downloaded the last released libghostty binary whenever contributors or PR checks ran tests. Any flterm change depending on unreleased libghostty features therefore failed in CI despite working locally, as happened with the new formatter `Selection` API.

Flip the workspace default to `source: compile` and set up zig + the pinned ghostty source in the `test-flterm` job (`test-libghostty-native` already had them). Pub.dev consumers are unaffected: they never see the workspace pubspec, so the code-level default in `LibraryProvider.resolve` keeps them on prebuilt.