### PR TITLE
feat(libghostty): expose internal log callback

### DIFF
--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -50,6 +50,7 @@ export 'src/ffi/libghostty_enums.g.dart'
         PointTag,
         SgrAttributeTag,
         SizeReportStyle,
+        SysLogLevel,
         TerminalScreen;
 export 'src/impl/build_info.dart' show LibGhosttyBuildInfo;
 export 'src/impl/encode.dart' show FocusEventEncode, SizeReportStyleEncode;
@@ -62,6 +63,7 @@ export 'src/impl/mouse/mouse_event.dart' show MouseEvent;
 export 'src/impl/osc_parser.dart' show OscCommand, OscParser;
 export 'src/impl/paste.dart' show pasteEncode, pasteIsSafe;
 export 'src/impl/sgr_parser.dart' show SgrParser;
+export 'src/impl/sys.dart' show LibGhostty, LogCallback;
 export 'src/impl/terminal/terminal.dart'
     show
         Cell,

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -167,6 +167,10 @@ abstract interface class GhosttyBindings {
   );
   void terminalDisposeCallbacks(int handle);
 
+  void sysSetLogCallback(SysLogCallback callback);
+  void sysSetLogToStderr();
+  void sysClearLogCallback();
+
   CResult<int> renderStateNew();
   void renderStateFree(int handle);
   Result renderStateUpdate(int state, int terminal);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -23,6 +23,8 @@ class NativeBindings implements GhosttyBindings {
   final _callables = <int, Map<TerminalOption, NativeCallable>>{};
   final _stringBuffers = <int, Map<TerminalOption, _StringBuffer>>{};
 
+  NativeCallable? _sysLogCallable;
+
   final _outU8 = calloc<Uint8>();
   final _outU16 = calloc<Uint16>();
   final _outU32 = calloc<Uint32>();
@@ -2309,5 +2311,66 @@ class NativeBindings implements GhosttyBindings {
         calloc.free(buf.str);
       }
     }
+  }
+
+  @override
+  void sysSetLogCallback(SysLogCallback callback) {
+    _installSysLog((userdata, level, scope, scopeLen, msg, msgLen) {
+      try {
+        callback(
+          SysLogLevel.fromValue(level),
+          utf8.decode(scope.asTypedList(scopeLen), allowMalformed: true),
+          utf8.decode(msg.asTypedList(msgLen), allowMalformed: true),
+        );
+      } on Object catch (_) {}
+    });
+  }
+
+  @override
+  void sysSetLogToStderr() {
+    _installSysLog((userdata, level, scope, scopeLen, msg, msgLen) {
+      ghostty_sys_log_stderr(
+        userdata,
+        SysLogLevel.fromValue(level),
+        scope,
+        scopeLen,
+        msg,
+        msgLen,
+      );
+    });
+  }
+
+  @override
+  void sysClearLogCallback() {
+    ghostty_sys_set(SysOption.log, nullptr);
+    _sysLogCallable?.close();
+    _sysLogCallable = null;
+  }
+
+  void _installSysLog(
+    void Function(
+      Pointer<Void> userdata,
+      int level,
+      Pointer<Uint8> scope,
+      int scopeLen,
+      Pointer<Uint8> message,
+      int messageLen,
+    )
+    fn,
+  ) {
+    _sysLogCallable?.close();
+    final callable =
+        NativeCallable<
+          Void Function(
+            Pointer<Void>,
+            UnsignedInt,
+            Pointer<Uint8>,
+            Size,
+            Pointer<Uint8>,
+            Size,
+          )
+        >.isolateLocal(fn);
+    _sysLogCallable = callable;
+    ghostty_sys_set(SysOption.log, callable.nativeFunction.cast());
   }
 }

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -33,3 +33,8 @@ typedef VoidCallback = void Function();
 /// A selection range addressed by `GridRef` handles. `rectangle` indicates
 /// a rectangular (block) selection rather than a linear one.
 typedef RawSelection = ({int start, int end, bool rectangle});
+
+/// Callback invoked for each internal libghostty log message, after the
+/// scope and message byte slices have been decoded to Dart strings.
+typedef SysLogCallback =
+    void Function(SysLogLevel level, String scope, String message);

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -1259,6 +1259,55 @@ class WasmBindings implements GhosttyBindings {
     _exports.ghostty_terminal_set(handle, option.value, index);
   }
 
+  int? _sysLogIndex;
+
+  @override
+  void sysSetLogCallback(SysLogCallback callback) {
+    _installSysLog((userdata, level, scopePtr, scopeLen, msgPtr, msgLen) {
+      try {
+        callback(
+          SysLogLevel.fromValue(level),
+          utf8.decode(_mem.readBytes(scopePtr, scopeLen), allowMalformed: true),
+          utf8.decode(_mem.readBytes(msgPtr, msgLen), allowMalformed: true),
+        );
+      } on Object catch (_) {}
+    });
+  }
+
+  @override
+  void sysSetLogToStderr() {
+    // ignore: unnecessary_lambdas
+    _installSysLog((userdata, level, scopePtr, scopeLen, msgPtr, msgLen) {
+      _exports.ghostty_sys_log_stderr(
+        userdata,
+        level,
+        scopePtr,
+        scopeLen,
+        msgPtr,
+        msgLen,
+      );
+    });
+  }
+
+  @override
+  void sysClearLogCallback() {
+    _exports.ghostty_sys_set(SysOption.log.value, 0);
+    if (_sysLogIndex case final index?) _table.set(index);
+  }
+
+  void _installSysLog(void Function(int, int, int, int, int, int) fn) {
+    final index = _registerCallback(fn.toJS, [
+      'i32',
+      'i32',
+      'i32',
+      'i32',
+      'i32',
+      'i32',
+    ], reuseIndex: _sysLogIndex);
+    _sysLogIndex = index;
+    _exports.ghostty_sys_set(SysOption.log.value, index);
+  }
+
   @override
   void terminalDisposeCallbacks(int handle) {
     final map = _callbacks.remove(handle);

--- a/packages/libghostty/lib/src/impl/sys.dart
+++ b/packages/libghostty/lib/src/impl/sys.dart
@@ -1,0 +1,52 @@
+import '../bindings/bindings.dart';
+
+/// Callback invoked by libghostty to emit an internal log message.
+///
+/// Messages originate from the native library's Zig side and cover events
+/// like unknown control sequences, kitty graphics decoding errors, and
+/// other diagnostics. The debug level is only emitted by debug builds of
+/// the native library; release builds compile those calls out entirely.
+///
+/// Byte slices received from the C ABI are already decoded into Dart
+/// strings before this callback runs. The callback may be invoked from
+/// any thread.
+typedef LogCallback = SysLogCallback;
+
+/// Process-global configuration hooks for the native libghostty library.
+///
+/// These settings are installed once at startup and affect every
+/// [Terminal] instance in the process. Install them before creating any
+/// terminal that relies on them.
+///
+/// ```dart
+/// void main() {
+///   LibGhostty.setLogger((level, scope, message) {
+///     debugPrint('[$level]$scope: $message');
+///   });
+///   runApp(const MyApp());
+/// }
+/// ```
+abstract final class LibGhostty {
+  /// Clears the installed logger and releases resources held by the
+  /// Dart-side callback trampoline.
+  ///
+  /// Safe to call multiple times. After this, log output is silently
+  /// discarded until another logger is installed.
+  static void clearLogger() => bindings.sysClearLogCallback();
+
+  /// Installs [logger] as the sink for internal libghostty log messages.
+  ///
+  /// Replaces any previously installed logger (including the one set by
+  /// [useStderrLogger]). Use [clearLogger] to stop receiving log messages;
+  /// with no logger installed, log output is silently discarded.
+  static void setLogger(LogCallback logger) {
+    bindings.sysSetLogCallback(logger);
+  }
+
+  /// Installs the native library's built-in stderr log sink.
+  ///
+  /// Each message is formatted as `[level](scope): message` and written
+  /// to stderr. Equivalent to registering a logger that delegates to
+  /// `ghostty_sys_log_stderr`. Replaces any previously installed logger.
+  static void useStderrLogger() => bindings.sysSetLogToStderr();
+}

--- a/packages/libghostty/test/impl/sys_test.dart
+++ b/packages/libghostty/test/impl/sys_test.dart
@@ -1,0 +1,81 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LibGhostty', () {
+    late Terminal terminal;
+
+    setUp(() => terminal = Terminal(cols: 80, rows: 24));
+    tearDown(LibGhostty.clearLogger);
+
+    test(
+      'setLogger receives log emissions with decoded level/scope/message',
+      () {
+        final captured = <_LogEntry>[];
+        LibGhostty.setLogger((level, scope, message) {
+          captured.add((level: level, scope: scope, message: message));
+        });
+
+        terminal.write(_logTrigger);
+
+        expect(captured, isNotEmpty);
+        expect(captured.single.level, SysLogLevel.warning);
+        expect(captured.single.scope, 'stream');
+        expect(captured.single.message, contains('invalid C0 character'));
+      },
+    );
+
+    test('setLogger replaces a previously installed logger', () {
+      final first = <String>[];
+      final second = <String>[];
+      LibGhostty.setLogger((_, _, msg) => first.add(msg));
+      LibGhostty.setLogger((_, _, msg) => second.add(msg));
+
+      terminal.write(_logTrigger);
+
+      expect(first, isEmpty);
+      expect(second, isNotEmpty);
+    });
+
+    test('clearLogger stops delivering messages', () {
+      final captured = <String>[];
+      LibGhostty.setLogger((_, _, msg) => captured.add(msg));
+      LibGhostty.clearLogger();
+
+      terminal.write(_logTrigger);
+
+      expect(captured, isEmpty);
+    });
+
+    test('clearLogger is safe without a prior setLogger', () {
+      LibGhostty.clearLogger();
+      LibGhostty.clearLogger();
+    });
+
+    test('useStderrLogger accepts emissions without crashing', () {
+      LibGhostty.useStderrLogger();
+      expect(() => terminal.write(_logTrigger), returnsNormally);
+    });
+
+    test('useStderrLogger replaces a previously installed logger', () {
+      final captured = <String>[];
+      LibGhostty.setLogger((_, _, msg) => captured.add(msg));
+      LibGhostty.useStderrLogger();
+
+      terminal.write(_logTrigger);
+
+      expect(captured, isEmpty);
+    });
+  });
+}
+
+/// Byte that reliably triggers a `stream`-scoped warning from the native
+/// parser ("invalid C0 character, ignoring: 0x3").
+final _logTrigger = Uint8List.fromList([0x03]);
+
+typedef _LogEntry = ({SysLogLevel level, String scope, String message});


### PR DESCRIPTION
Expose a process global log sink so embedders can redirect or silence the native library's internal log output. Without a logger installed, messages are discarded (the prior default); with one installed, each emit fires a Dart callback with the level, scope, and already decoded UTF8 message. Public API sits on a new `LibGhostty` namespace with `setLogger`, `useStderrLogger` (built-in `ghostty_sys_log_stderr`), and `clearLogger`.
