### PR TITLE
feat(libghostty): expose Kitty graphics PNG decoder hook

### DIFF
--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -6,6 +6,7 @@
 library;
 
 export 'src/bindings/bindings.dart' show initializeForWeb;
+export 'src/bindings/types/aliases.dart' show DecodedImage, PngDecoder;
 export 'src/bindings/types/types.dart'
     show
         CellColor,

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -171,6 +171,9 @@ abstract interface class GhosttyBindings {
   void sysSetLogToStderr();
   void sysClearLogCallback();
 
+  void sysSetPngDecoder(PngDecoder decoder);
+  void sysClearPngDecoder();
+
   /// Returns an opaque kitty graphics storage handle for [handle], or 0
   /// when kitty graphics are disabled in the native library build.
   int kittyGraphicsGet(int handle);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -53,6 +53,7 @@ class NativeBindings implements GhosttyBindings {
   final _stringBuffers = <int, Map<TerminalOption, _StringBuffer>>{};
 
   NativeCallable? _sysLogCallable;
+  NativeCallable? _sysDecodePngCallable;
 
   final _outU8 = calloc<Uint8>();
   final _outU16 = calloc<Uint16>();
@@ -2375,6 +2376,53 @@ class NativeBindings implements GhosttyBindings {
     ghostty_sys_set(SysOption.log, nullptr);
     _sysLogCallable?.close();
     _sysLogCallable = null;
+  }
+
+  @override
+  void sysSetPngDecoder(PngDecoder decoder) {
+    _sysDecodePngCallable?.close();
+    final callable =
+        NativeCallable<
+          Bool Function(
+            Pointer<Void>,
+            Pointer<Allocator>,
+            Pointer<Uint8>,
+            Size,
+            Pointer<SysImage>,
+          )
+        >.isolateLocal((
+          Pointer<Void> userdata,
+          Pointer<Allocator> allocator,
+          Pointer<Uint8> pngData,
+          int pngLen,
+          Pointer<SysImage> out,
+        ) {
+          try {
+            final bytes = Uint8List.fromList(pngData.asTypedList(pngLen));
+            final decoded = decoder(bytes);
+            if (decoded == null) return false;
+            final rgba = decoded.rgba;
+            final buf = ghostty_alloc(allocator, rgba.length);
+            if (buf == nullptr) return false;
+            buf.asTypedList(rgba.length).setAll(0, rgba);
+            out.ref.width = decoded.width;
+            out.ref.height = decoded.height;
+            out.ref.data = buf;
+            out.ref.data_len = rgba.length;
+            return true;
+          } on Object catch (_) {
+            return false;
+          }
+        }, exceptionalReturn: false);
+    _sysDecodePngCallable = callable;
+    ghostty_sys_set(SysOption.decodePng, callable.nativeFunction.cast());
+  }
+
+  @override
+  void sysClearPngDecoder() {
+    ghostty_sys_set(SysOption.decodePng, nullptr);
+    _sysDecodePngCallable?.close();
+    _sysDecodePngCallable = null;
   }
 
   @override

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import '../../ffi/libghostty_enums.g.dart';
 
 /// Cell wide property.
@@ -38,6 +40,16 @@ typedef RawSelection = ({int start, int end, bool rectangle});
 /// scope and message byte slices have been decoded to Dart strings.
 typedef SysLogCallback =
     void Function(SysLogLevel level, String scope, String message);
+
+/// An image decoded from PNG into top-to-bottom RGBA pixel bytes.
+typedef DecodedImage = ({int width, int height, Uint8List rgba});
+
+/// Callback that decodes PNG bytes to RGBA pixels.
+///
+/// Invoked by libghostty for every Kitty graphics payload received in
+/// PNG form. Returning null signals a decode failure; the library
+/// rejects the payload and no image is stored.
+typedef PngDecoder = DecodedImage? Function(Uint8List pngBytes);
 
 /// Raw placement metadata read from a Kitty graphics placement
 /// iterator.

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -1326,6 +1326,55 @@ class WasmBindings implements GhosttyBindings {
     // same table slot instead of growing the indirect function table.
   }
 
+  int? _sysDecodePngIndex;
+
+  @override
+  void sysSetPngDecoder(PngDecoder decoder) {
+    int trampoline(
+      int userdata,
+      int allocator,
+      int pngPtr,
+      int pngLen,
+      int outPtr,
+    ) {
+      try {
+        final bytes = Uint8List.fromList(_mem.readBytes(pngPtr, pngLen));
+        final decoded = decoder(bytes);
+        if (decoded == null) return 0;
+        final rgba = decoded.rgba;
+        final buf = _exports.ghostty_alloc(allocator, rgba.length);
+        if (buf == 0) return 0;
+        _mem.writeBytes(buf, rgba);
+        // SysImage { u32 width; u32 height; ptr data; size data_len }
+        _mem.writeU32(outPtr, decoded.width);
+        _mem.writeU32(outPtr + 4, decoded.height);
+        _mem.writeU32(outPtr + 8, buf);
+        _mem.writeU32(outPtr + 12, rgba.length);
+        return 1;
+      } on Object catch (_) {
+        return 0;
+      }
+    }
+
+    final index = _registerCallback(
+      trampoline.toJS,
+      ['i32', 'i32', 'i32', 'i32', 'i32'],
+      results: ['i32'],
+      reuseIndex: _sysDecodePngIndex,
+    );
+    _sysDecodePngIndex = index;
+    _exports.ghostty_sys_set(SysOption.decodePng.value, index);
+  }
+
+  @override
+  void sysClearPngDecoder() {
+    _exports.ghostty_sys_set(SysOption.decodePng.value, 0);
+    if (_sysDecodePngIndex case final index?) _table.set(index);
+    // _sysDecodePngIndex is retained so a subsequent sysSetPngDecoder
+    // reuses the same table slot via `reuseIndex` instead of growing
+    // the WASM indirect function table. Matches the log callback path.
+  }
+
   @override
   int kittyGraphicsGet(int handle) {
     final outPtr = _exports.ghostty_wasm_alloc_opaque();

--- a/packages/libghostty/lib/src/impl/sys.dart
+++ b/packages/libghostty/lib/src/impl/sys.dart
@@ -34,6 +34,37 @@ abstract final class LibGhostty {
   /// discarded until another logger is installed.
   static void clearLogger() => bindings.sysClearLogCallback();
 
+  /// Installs [decoder] as the PNG decoder invoked by libghostty when a
+  /// Kitty graphics payload arrives in PNG form.
+  ///
+  /// Replaces any previously installed decoder. Use [clearPngDecoder]
+  /// to stop accepting PNG payloads; with no decoder installed, PNG
+  /// data is rejected by the native library and no image is stored.
+  /// The callback returns null to signal a decode failure, which is
+  /// treated the same as having no decoder installed for that payload.
+  ///
+  /// The [DecodedImage.rgba] buffer is copied into a library-owned
+  /// allocation before the callback returns, so the caller's buffer
+  /// lifetime is not a concern. The callback may be invoked from any
+  /// thread.
+  ///
+  /// ```dart
+  /// LibGhostty.setPngDecoder((pngBytes) {
+  ///   final decoded = decodePngToRgba(pngBytes);
+  ///   if (decoded == null) return null;
+  ///   return (width: decoded.w, height: decoded.h, rgba: decoded.pixels);
+  /// });
+  /// ```
+  static void setPngDecoder(PngDecoder decoder) =>
+      bindings.sysSetPngDecoder(decoder);
+
+  /// Clears the installed PNG decoder and releases resources held by
+  /// the Dart-side callback trampoline.
+  ///
+  /// Safe to call multiple times. After this, PNG payloads are
+  /// rejected until another decoder is installed.
+  static void clearPngDecoder() => bindings.sysClearPngDecoder();
+
   /// Installs [logger] as the sink for internal libghostty log messages.
   ///
   /// Replaces any previously installed logger (including the one set by

--- a/packages/libghostty/lib/src/impl/terminal/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/impl/terminal/kitty_graphics.dart
@@ -12,8 +12,8 @@ part of 'terminal.dart';
 ///
 /// Before any images are stored, Kitty graphics must be enabled on the
 /// terminal by setting a non-zero [Terminal.kittyImageStorageLimit].
-/// PNG payloads additionally require a process-global PNG decoder hook
-/// registered by the embedder.
+/// PNG payloads additionally require a decoder installed via
+/// [LibGhostty.setPngDecoder].
 ///
 /// ```dart
 /// final kitty = terminal.kittyGraphics;
@@ -303,9 +303,9 @@ class KittyImage {
   ///
   /// The layout honors [format] and [compression]: decompressing
   /// zlib-compressed payloads and reinterpreting non-RGB/RGBA formats
-  /// is the caller's responsibility. PNG-format payloads are decoded
-  /// ahead of time by a decoder hook the embedder registers and are
-  /// stored here as RGBA.
+  /// is the caller's responsibility. PNG payloads are decoded ahead of
+  /// time by the callback installed via [LibGhostty.setPngDecoder] and
+  /// are stored here as RGBA.
   Uint8List get pixelData {
     return check(bindings.kittyGraphicsImageGetPixelData(_handle));
   }

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -193,7 +193,7 @@ class Terminal with Listenable {
   ///
   /// Image storage must be enabled before any images are kept: set a
   /// non-zero [kittyImageStorageLimit]. PNG payloads additionally
-  /// require a PNG decoder hook registered by the embedder.
+  /// require a decoder installed via [LibGhostty.setPngDecoder].
   KittyGraphics? get kittyGraphics {
     final handle = bindings.kittyGraphicsGet(_handle);
     return handle == 0 ? null : KittyGraphics._(handle, _handle);

--- a/packages/libghostty/test/impl/terminal/kitty_graphics_test.dart
+++ b/packages/libghostty/test/impl/terminal/kitty_graphics_test.dart
@@ -51,6 +51,77 @@ void main() {
     });
   });
 
+  group('LibGhostty.setPngDecoder', () {
+    late Terminal terminal;
+
+    setUp(() {
+      terminal = Terminal(cols: 80, rows: 24);
+      terminal.kittyImageStorageLimit = 1 << 20;
+    });
+
+    tearDown(LibGhostty.clearPngDecoder);
+
+    test('is invoked with PNG payload and produces an image', () {
+      final pngBytesSeen = <Uint8List>[];
+      LibGhostty.setPngDecoder((bytes) {
+        pngBytesSeen.add(Uint8List.fromList(bytes));
+        // Return a fixed 2x1 RGBA image regardless of input bytes.
+        return (
+          width: 2,
+          height: 1,
+          rgba: Uint8List.fromList([
+            0xff,
+            0x00,
+            0x00,
+            0xff,
+            0x00,
+            0xff,
+            0x00,
+            0xff,
+          ]),
+        );
+      });
+
+      // f=100 (PNG), a=t (transmit), i=55, payload is base64 "hello" bytes.
+      terminal.write(
+        Uint8List.fromList('\x1b_Gf=100,a=t,i=55;aGVsbG8=\x1b\\'.codeUnits),
+      );
+
+      expect(pngBytesSeen, hasLength(1));
+      final image = terminal.kittyGraphics!.image(55);
+      expect(image, isNotNull);
+      expect(image!.width, 2);
+      expect(image.height, 1);
+      expect(image.format, KittyImageFormat.rgba);
+      expect(image.pixelData, hasLength(8));
+    });
+
+    test('returning null rejects the payload', () {
+      LibGhostty.setPngDecoder((_) => null);
+
+      terminal.write(
+        Uint8List.fromList('\x1b_Gf=100,a=t,i=56;aGVsbG8=\x1b\\'.codeUnits),
+      );
+
+      expect(terminal.kittyGraphics!.image(56), isNull);
+    });
+
+    test('clearPngDecoder stops routing to the Dart callback', () {
+      var called = 0;
+      LibGhostty.setPngDecoder((_) {
+        called++;
+        return (width: 1, height: 1, rgba: Uint8List(4));
+      });
+      LibGhostty.clearPngDecoder();
+
+      terminal.write(
+        Uint8List.fromList('\x1b_Gf=100,a=t,i=57;aGVsbG8=\x1b\\'.codeUnits),
+      );
+      expect(called, 0);
+      expect(terminal.kittyGraphics!.image(57), isNull);
+    });
+  });
+
   group('Terminal.kittyGraphics.placements', () {
     late Terminal terminal;
 


### PR DESCRIPTION
Expose a process-global PNG decoder callback so embedders can accept Kitty graphics payloads in PNG form. Without a decoder installed, PNG payloads are rejected by the native library (the prior default); with one installed, each arriving PNG fires a Dart callback that returns the decoded RGBA pixels, and libghostty stores the image for later lookup and placement. The library copies the returned buffer into its own allocation before the callback returns, so the caller keeps no lifetime obligations. Public API adds `LibGhostty.setPngDecoder` and `LibGhostty.clearPngDecoder`; the callback type is `PngDecoder`.
