### PR TITLE
fix(flterm): scale mouse event coordinates by devicePixelRatio

### DIFF
--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -264,7 +264,10 @@ class TerminalControllerImpl extends TerminalController
       ..action = event.action
       ..button = event.button
       ..mods = _currentMods()
-      ..setPosition(x: event.pixelX, y: event.pixelY);
+      ..setPosition(
+        x: event.pixelX * _lastDevicePixelRatio,
+        y: event.pixelY * _lastDevicePixelRatio,
+      );
     _mouseEncoder.sync(terminal);
     final result = _mouseEncoder.encode(_mouseEvent);
     if (result.isEmpty) return;

--- a/packages/flterm/test/widgets/terminal_view_binding_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_binding_test.dart
@@ -274,6 +274,41 @@ void main() {
 
         expect(output, isEmpty);
       });
+
+      test('scales pixel coordinates by devicePixelRatio', () {
+        controller.terminal.writeUtf8('\x1b[?1000h');
+        binding.handleResize(
+          cols: 80,
+          rows: 24,
+          metrics: const CellMetrics(
+            cellWidth: 8,
+            cellHeight: 16,
+            baseline: 12,
+          ),
+          padding: EdgeInsets.zero,
+          devicePixelRatio: 2.0,
+        );
+
+        final output = <Uint8List>[];
+        controller.onOutput = output.add;
+
+        binding.handleMouseEvent((
+          action: .press,
+          button: .left,
+          pixelX: 8.0,
+          pixelY: 16.0,
+        ));
+
+        expect(output, hasLength(1));
+        expect(output.single, [
+          0x1b,
+          0x5b,
+          0x4d,
+          ' '.codeUnitAt(0),
+          '!'.codeUnitAt(0) + 1,
+          '!'.codeUnitAt(0) + 1,
+        ]);
+      });
     });
 
     test('mouseTracking reflects mode changes', () {


### PR DESCRIPTION
The mouse encoder is configured in physical pixels but `handleMouseEvent` was passing logical pixels, so on displays with `devicePixelRatio > 1` clicks in TUIs like htop landed on the wrong row. Scale event coordinates by the last `devicePixelRatio` to match the encoder's units.