### PR TITLE
perf(flterm): render only dirty rows

### DIFF
--- a/packages/flterm/lib/src/rendering/atlas/sprite_buffer.dart
+++ b/packages/flterm/lib/src/rendering/atlas/sprite_buffer.dart
@@ -1,61 +1,57 @@
-import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui';
 
 import 'glyph_entry.dart';
 
-Float32List _copyF32(Float32List old, int count, int newLen) {
-  final result = Float32List(newLen);
-  if (count > 0) result.setAll(0, Float32List.sublistView(old, 0, count));
-  return result;
-}
-
-Int32List _copyI32(Int32List old, int count, int newLen) {
-  final result = Int32List(newLen);
-  if (count > 0) result.setAll(0, Int32List.sublistView(old, 0, count));
-  return result;
-}
-
-int _nextPow2(int needed, int current) {
-  var size = current == 0 ? 64 : current;
-  while (size < needed) {
-    size *= 2;
-  }
-  return size;
-}
-
-/// Sprite data for [Canvas.drawRawAtlas] calls.
+/// Sprite data for [Canvas.drawRawAtlas] calls, organized as fixed per-row
+/// slot ranges for incremental row-dirty rebuilds.
 ///
-/// Stores per-sprite transform (scale + translation), source rect (LTRB),
-/// and tint color in pre-allocated typed arrays. Grows lazily on overflow.
-/// Used for text glyphs (regular-width, wide, and emoji) where each sprite
-/// maps a region of the atlas texture to a screen position.
+/// Each row owns a contiguous slice of `stride` slots in the flat buffer.
+/// Dirty rows rewrite their slots via [beginRow]/[add]/[endRow]; clean
+/// rows keep the sprites they had last frame with zero work. [seal]
+/// packs each channel's active slots into a tight array so painters
+/// submit exactly `count` sprites to [Canvas.drawRawAtlas] without
+/// interleaved degenerate quads (Skia does not reliably cull scale-0
+/// RSTransforms, so leaving them in the submission corrupts output).
 ///
-/// Transforms encode a uniform scale (inverse DPR to convert physical
-/// atlas pixels to logical pixels) with no rotation.
+/// Packing on [seal] is incremental: only rows from the first dirty
+/// row onward are re-copied; rows before it keep their packed position
+/// because their counts are unchanged.
 class AtlasSprites {
-  Float32List _transforms;
-  Float32List _rects;
-  Int32List _colors;
-  var _count = 0;
+  var _transforms = Float32List(0);
+  var _rects = Float32List(0);
+  var _colors = Int32List(0);
+  var _rowCounts = Int32List(0);
+  var _packedTransforms = Float32List(0);
+  var _packedRects = Float32List(0);
+  var _packedColors = Int32List(0);
+  var _packedStarts = Int32List(0);
+  var _rowCount = 0;
+  var _stride = 0;
+  var _activeSlots = 0;
+  var _currentRow = -1;
+  var _writeOffset = 0;
+  var _firstDirtyRow = 0;
 
-  AtlasSprites(int capacity)
-    : _transforms = Float32List(capacity * 4),
-      _rects = Float32List(capacity * 4),
-      _colors = Int32List(capacity);
+  /// Total number of active sprites across all rows.
+  int get count => _activeSlots;
 
-  int get capacity => _colors.length;
+  /// Whether any row has at least one active sprite.
+  bool get hasSprites => _activeSlots > 0;
 
-  int get count => _count;
+  /// Per-sprite ARGB tints, packed to `count` entries after [seal].
+  Int32List get sealedColors =>
+      Int32List.sublistView(_packedColors, 0, _activeSlots);
 
-  Int32List get sealedColors => .sublistView(_colors, 0, _count);
+  /// Per-sprite source rects (LTRB), packed to `count * 4` floats after [seal].
+  Float32List get sealedRects =>
+      Float32List.sublistView(_packedRects, 0, _activeSlots * 4);
 
-  Float32List get sealedRects => .sublistView(_rects, 0, _count * 4);
+  /// Per-sprite RST transforms, packed to `count * 4` floats after [seal].
+  Float32List get sealedTransforms =>
+      Float32List.sublistView(_packedTransforms, 0, _activeSlots * 4);
 
-  Float32List get sealedTransforms => .sublistView(_transforms, 0, _count * 4);
-
-  /// Appends a sprite at ([x], [y]) using the atlas region from [entry].
-  /// The [inverseDpr] scales from physical atlas pixels to logical pixels.
+  /// Appends a sprite to the current row (must be inside [beginRow]/[endRow]).
   void add(
     double x,
     double y,
@@ -63,128 +59,328 @@ class AtlasSprites {
     double inverseDpr, [
     int argb = 0,
   ]) {
-    if (_count >= _colors.length) _grow(_count + 1);
-    final offset = _count * 4;
-    _transforms[offset] = inverseDpr;
-    _transforms[offset + 1] = 0.0;
-    _transforms[offset + 2] = x;
-    _transforms[offset + 3] = y;
-    _rects[offset] = entry.srcLeft;
-    _rects[offset + 1] = entry.srcTop;
-    _rects[offset + 2] = entry.srcRight;
-    _rects[offset + 3] = entry.srcBottom;
-    _colors[_count] = argb;
-    _count++;
+    assert(_currentRow >= 0, 'add() called outside beginRow/endRow');
+    assert(_writeOffset < _stride, 'row $_currentRow exceeded stride $_stride');
+    final slot = _currentRow * _stride + _writeOffset;
+    final offset4 = slot * 4;
+    _transforms[offset4] = inverseDpr;
+    _transforms[offset4 + 1] = 0.0;
+    _transforms[offset4 + 2] = x;
+    _transforms[offset4 + 3] = y;
+    _rects[offset4] = entry.srcLeft;
+    _rects[offset4 + 1] = entry.srcTop;
+    _rects[offset4 + 2] = entry.srcRight;
+    _rects[offset4 + 3] = entry.srcBottom;
+    _colors[slot] = argb;
+    _writeOffset++;
   }
 
-  /// Resets the sprite count without deallocating.
-  void clear() => _count = 0;
-
-  /// Reallocates all buffers to [capacity], discarding existing data.
-  void resize(int capacity) {
-    _transforms = Float32List(capacity * 4);
-    _rects = Float32List(capacity * 4);
-    _colors = Int32List(capacity);
-    _count = 0;
+  /// Begins rewriting row [row]'s slots. Call only for dirty rows.
+  void beginRow(int row) {
+    _currentRow = row;
+    _writeOffset = 0;
+    if (row < _firstDirtyRow) _firstDirtyRow = row;
   }
 
-  void _grow(int minCount) {
-    final newSize = _nextPow2(minCount * 4, _transforms.length);
-    _transforms = _copyF32(_transforms, _count * 4, newSize);
-    _rects = _copyF32(_rects, _count * 4, newSize);
-    _colors = _copyI32(_colors, _count, newSize ~/ 4);
+  /// Reconfigures the buffer for a grid of [rowCount] rows with [stride]
+  /// slots per row.
+  ///
+  /// Grows on demand; shrinks only when the current buffer is more than
+  /// 4x the new requirement so routine resize drags don't churn
+  /// allocations but a step down from (e.g.) 300x100 to 80x24 releases
+  /// the excess.
+  void configure(int rowCount, int stride) {
+    _rowCount = rowCount;
+    _stride = stride;
+    final totalSlots = rowCount * stride;
+    final need = totalSlots * 4;
+    if (_transforms.length < need || _transforms.length > need * 4) {
+      _transforms = Float32List(need);
+      _rects = Float32List(need);
+      _colors = Int32List(totalSlots);
+    }
+    if (_rowCounts.length < rowCount || _rowCounts.length > rowCount * 4) {
+      _rowCounts = Int32List(rowCount);
+    } else {
+      _rowCounts.fillRange(0, rowCount, 0);
+    }
+    _activeSlots = 0;
+    _currentRow = -1;
+    _writeOffset = 0;
+    _firstDirtyRow = 0;
+  }
+
+  /// Releases all buffers so their memory can be collected. The instance
+  /// must not be used again after this call.
+  void dispose() {
+    _transforms = Float32List(0);
+    _rects = Float32List(0);
+    _colors = Int32List(0);
+    _rowCounts = Int32List(0);
+    _packedTransforms = Float32List(0);
+    _packedRects = Float32List(0);
+    _packedColors = Int32List(0);
+    _packedStarts = Int32List(0);
+    _activeSlots = 0;
+    _rowCount = 0;
+    _stride = 0;
+    _currentRow = -1;
+    _writeOffset = 0;
+    _firstDirtyRow = 0;
+  }
+
+  /// Finishes the current row.
+  void endRow() {
+    assert(_currentRow >= 0, 'endRow() without beginRow()');
+    final oldCount = _rowCounts[_currentRow];
+    final newCount = _writeOffset;
+    _activeSlots += newCount - oldCount;
+    _rowCounts[_currentRow] = newCount;
+    _currentRow = -1;
+  }
+
+  /// Packs active slots into the contiguous arrays returned by
+  /// [sealedTransforms] and friends.
+  ///
+  /// Incremental: rows before [_firstDirtyRow] already sit at the right
+  /// packed offsets from the previous seal, so only rows from that
+  /// point onward are re-copied. When the packed buffer has to grow,
+  /// the prefix is no longer backed by valid data and we restart from
+  /// row 0.
+  void seal() {
+    if (_firstDirtyRow >= _rowCount) return;
+
+    final need = _activeSlots;
+    var start = _firstDirtyRow;
+    if (need > 0 &&
+        (_packedTransforms.length < need * 4 ||
+            _packedTransforms.length > need * 16)) {
+      _packedTransforms = Float32List(need * 4);
+      _packedRects = Float32List(need * 4);
+      _packedColors = Int32List(need);
+      start = 0;
+    }
+    if (_packedStarts.length < _rowCount + 1) {
+      _packedStarts = Int32List(_rowCount + 1);
+      start = 0;
+    }
+
+    var dst = _packedStarts[start];
+    for (var row = start; row < _rowCount; row++) {
+      _packedStarts[row] = dst;
+      final rowCount = _rowCounts[row];
+      if (rowCount > 0) {
+        final srcBase = row * _stride;
+        _packedTransforms.setRange(
+          dst * 4,
+          (dst + rowCount) * 4,
+          _transforms,
+          srcBase * 4,
+        );
+        _packedRects.setRange(
+          dst * 4,
+          (dst + rowCount) * 4,
+          _rects,
+          srcBase * 4,
+        );
+        _packedColors.setRange(dst, dst + rowCount, _colors, srcBase);
+      }
+      dst += rowCount;
+    }
+    _packedStarts[_rowCount] = dst;
+    _firstDirtyRow = _rowCount;
   }
 }
 
-/// Rect and color data for [Canvas.drawVertices] calls.
+/// Rect and color data for [Canvas.drawVertices] calls, organized as
+/// fixed per-row slot ranges.
 ///
-/// Stores LTRB rects compactly during the sprite build phase. At seal
-/// time, [buildVertices] expands them to indexed triangle quads (two
-/// triangles per rect) for efficient GPU submission. Used for cell
-/// backgrounds and text decorations (underlines, strikethroughs, overlines).
+/// Stores LTRB rects during the sprite build phase. [buildVertices]
+/// expands active rects into a tight indexed triangle-quad buffer for
+/// a single [Canvas.drawVertices] call. Used for cell backgrounds and
+/// text decorations (underlines, strikethroughs, overlines).
+///
+/// Expansion on [buildVertices] is incremental: rows before the first
+/// dirty row keep their vertex data from the previous call. A fresh
+/// [Vertices] is constructed only when rect contents actually changed.
 class RectSprites {
-  Float32List _rects;
-  Int32List _colors;
-  var _count = 0;
+  var _rects = Float32List(0);
+  var _colors = Int32List(0);
+  var _rowCounts = Int32List(0);
   var _positions = Float32List(0);
   var _vertexColors = Int32List(0);
+  var _vertexStarts = Int32List(0);
+  Vertices? _cachedVertices;
+  var _rowCount = 0;
+  var _stride = 0;
+  var _activeSlots = 0;
+  var _currentRow = -1;
+  var _writeOffset = 0;
+  var _firstDirtyRow = 0;
 
-  RectSprites(int capacity)
-    : _rects = Float32List(capacity * 4),
-      _colors = Int32List(capacity);
+  /// The [Vertices] produced by the most recent [buildVertices] call,
+  /// or null when no row has an active rect.
+  Vertices? get cachedVertices => _cachedVertices;
 
-  int get count => _count;
+  /// Total number of active rects across all rows.
+  int get count => _activeSlots;
 
-  Int32List get sealedColors => .sublistView(_colors, 0, _count);
+  /// Whether any row has at least one active rect.
+  bool get hasSprites => _activeSlots > 0;
 
-  Float32List get sealedRects => .sublistView(_rects, 0, _count * 4);
-
-  /// Appends a colored rect defined by left, top, right, bottom edges.
+  /// Appends a colored rect to the current row.
   void add(double left, double top, double right, double bottom, int argb) {
-    if (_count >= _colors.length) _grow(_count + 1);
-    final offset = _count * 4;
-    _rects[offset] = left;
-    _rects[offset + 1] = top;
-    _rects[offset + 2] = right;
-    _rects[offset + 3] = bottom;
-    _colors[_count] = argb;
-    _count++;
+    assert(_currentRow >= 0, 'add() called outside beginRow/endRow');
+    assert(_writeOffset < _stride, 'row $_currentRow exceeded stride $_stride');
+    final slot = _currentRow * _stride + _writeOffset;
+    final offset4 = slot * 4;
+    _rects[offset4] = left;
+    _rects[offset4 + 1] = top;
+    _rects[offset4 + 2] = right;
+    _rects[offset4 + 3] = bottom;
+    _colors[slot] = argb;
+    _writeOffset++;
   }
 
-  /// Expands LTRB rects to indexed triangle quads for [Canvas.drawVertices].
-  Vertices? buildVertices(Uint16List indices) {
-    if (_count == 0) return null;
-    final posLen = _count * 8;
-    final colLen = _count * 4;
-    if (_positions.length < posLen) _positions = Float32List(posLen);
-    if (_vertexColors.length < colLen) _vertexColors = Int32List(colLen);
+  /// Begins rewriting row [row]'s slots. Call only for dirty rows.
+  void beginRow(int row) {
+    _currentRow = row;
+    _writeOffset = 0;
+    if (row < _firstDirtyRow) _firstDirtyRow = row;
+  }
 
-    for (var rect = 0; rect < _count; rect++) {
-      final srcOffset = rect * 4;
-      final left = _rects[srcOffset];
-      final top = _rects[srcOffset + 1];
-      final right = _rects[srcOffset + 2];
-      final bottom = _rects[srcOffset + 3];
-      final posOffset = rect * 8;
-      _positions[posOffset] = left;
-      _positions[posOffset + 1] = top;
-      _positions[posOffset + 2] = right;
-      _positions[posOffset + 3] = top;
-      _positions[posOffset + 4] = right;
-      _positions[posOffset + 5] = bottom;
-      _positions[posOffset + 6] = left;
-      _positions[posOffset + 7] = bottom;
-      final argb = _colors[rect];
-      final colOffset = rect * 4;
-      _vertexColors[colOffset] = argb;
-      _vertexColors[colOffset + 1] = argb;
-      _vertexColors[colOffset + 2] = argb;
-      _vertexColors[colOffset + 3] = argb;
+  /// Walks per-row active rects and expands them into a tight indexed
+  /// triangle-quad buffer for [Canvas.drawVertices].
+  ///
+  /// Returns null when no row has any active rect. Returns the cached
+  /// [Vertices] unchanged when no row has been dirtied since the last
+  /// call (skipping the per-cell expand and the [Vertices.raw] alloc).
+  Vertices? buildVertices(Uint16List indices) {
+    if (_firstDirtyRow >= _rowCount) return _cachedVertices;
+
+    final posLen = _activeSlots * 8;
+    final colLen = _activeSlots * 4;
+    var start = _firstDirtyRow;
+    if (_activeSlots > 0 &&
+        (_positions.length < posLen || _positions.length > posLen * 4)) {
+      _positions = Float32List(posLen);
+      _vertexColors = Int32List(colLen);
+      start = 0;
+    }
+    if (_vertexStarts.length < _rowCount + 1) {
+      _vertexStarts = Int32List(_rowCount + 1);
+      start = 0;
     }
 
-    return Vertices.raw(
+    var dst = _vertexStarts[start];
+    for (var row = start; row < _rowCount; row++) {
+      _vertexStarts[row] = dst;
+      final rowCount = _rowCounts[row];
+      if (rowCount > 0) {
+        final srcBase = row * _stride;
+        for (var i = 0; i < rowCount; i++) {
+          final srcOffset = (srcBase + i) * 4;
+          final left = _rects[srcOffset];
+          final top = _rects[srcOffset + 1];
+          final right = _rects[srcOffset + 2];
+          final bottom = _rects[srcOffset + 3];
+          final posOffset = dst * 8;
+          _positions[posOffset] = left;
+          _positions[posOffset + 1] = top;
+          _positions[posOffset + 2] = right;
+          _positions[posOffset + 3] = top;
+          _positions[posOffset + 4] = right;
+          _positions[posOffset + 5] = bottom;
+          _positions[posOffset + 6] = left;
+          _positions[posOffset + 7] = bottom;
+          final argb = _colors[srcBase + i];
+          final colOffset = dst * 4;
+          _vertexColors[colOffset] = argb;
+          _vertexColors[colOffset + 1] = argb;
+          _vertexColors[colOffset + 2] = argb;
+          _vertexColors[colOffset + 3] = argb;
+          dst++;
+        }
+      }
+    }
+    _vertexStarts[_rowCount] = dst;
+    _firstDirtyRow = _rowCount;
+
+    _cachedVertices?.dispose();
+    if (_activeSlots == 0) return _cachedVertices = null;
+    return _cachedVertices = Vertices.raw(
       VertexMode.triangles,
       Float32List.sublistView(_positions, 0, posLen),
       colors: Int32List.sublistView(_vertexColors, 0, colLen),
-      indices: Uint16List.sublistView(indices, 0, _count * 6),
+      indices: Uint16List.sublistView(indices, 0, _activeSlots * 6),
     );
   }
 
-  /// Resets the rect count without deallocating.
-  void clear() => _count = 0;
+  /// Reconfigures the buffer for [rowCount] rows with [stride] slots per row.
+  ///
+  /// Grows on demand; shrinks only when the current buffer is more than
+  /// 4x the new requirement.
+  void configure(int rowCount, int stride) {
+    _rowCount = rowCount;
+    _stride = stride;
+    final totalSlots = rowCount * stride;
+    final need = totalSlots * 4;
+    if (_rects.length < need || _rects.length > need * 4) {
+      _rects = Float32List(need);
+      _colors = Int32List(totalSlots);
+    }
+    if (_rowCounts.length < rowCount || _rowCounts.length > rowCount * 4) {
+      _rowCounts = Int32List(rowCount);
+    } else {
+      _rowCounts.fillRange(0, rowCount, 0);
+    }
+    _activeSlots = 0;
+    _currentRow = -1;
+    _writeOffset = 0;
+    _firstDirtyRow = 0;
+    _cachedVertices?.dispose();
+    _cachedVertices = null;
+  }
 
-  void _grow(int minCount) {
-    final newSize = _nextPow2(minCount * 4, _rects.length);
-    _rects = _copyF32(_rects, _count * 4, newSize);
-    _colors = _copyI32(_colors, _count, newSize ~/ 4);
+  /// Releases all buffers and any cached [Vertices]. The instance must
+  /// not be used again after this call.
+  void dispose() {
+    _rects = Float32List(0);
+    _colors = Int32List(0);
+    _rowCounts = Int32List(0);
+    _positions = Float32List(0);
+    _vertexColors = Int32List(0);
+    _vertexStarts = Int32List(0);
+    _cachedVertices?.dispose();
+    _cachedVertices = null;
+    _activeSlots = 0;
+    _rowCount = 0;
+    _stride = 0;
+    _currentRow = -1;
+    _writeOffset = 0;
+    _firstDirtyRow = 0;
+  }
+
+  /// Finishes the current row.
+  void endRow() {
+    assert(_currentRow >= 0, 'endRow() without beginRow()');
+    final oldCount = _rowCounts[_currentRow];
+    final newCount = _writeOffset;
+    _activeSlots += newCount - oldCount;
+    _rowCounts[_currentRow] = newCount;
+    _currentRow = -1;
   }
 }
 
-/// Assembled sprite data for all terminal visual layers.
+/// Assembled sprite data for all terminal visual layers, organized as
+/// fixed per-row slot ranges for incremental row-dirty rebuilds.
 ///
 /// Written by [SpriteBuilder] during the update phase. Read by painters
-/// during the paint phase. After [SpriteBuilder.build] completes, call
-/// [seal] to finalize vertex data for backgrounds and decorations.
+/// during the paint phase. Dirty rows are rewritten via
+/// [beginRow]/[endRow]; clean rows are left untouched across frames.
+/// [seal] packs each channel's active slots into tight buffers (atlas
+/// channels for [Canvas.drawRawAtlas], rect channels for
+/// [Canvas.drawVertices]).
 ///
 /// Contains six sprite channels, each consumed by a dedicated painter:
 /// [regular] and [wide] for text, [emoji] for full-color glyphs,
@@ -209,58 +405,100 @@ class SpriteBuffer {
   /// Rect-based decorations (strikethroughs, overlines).
   final RectSprites decoration;
 
-  Vertices? _backgroundVertices;
-  Vertices? _decorationVertices;
-
   var _indices = Uint16List(0);
 
   SpriteBuffer()
-    : wide = AtlasSprites(64),
-      emoji = AtlasSprites(32),
-      regular = AtlasSprites(256),
-      background = RectSprites(64),
-      underline = AtlasSprites(64),
-      decoration = RectSprites(64);
+    : regular = AtlasSprites(),
+      wide = AtlasSprites(),
+      emoji = AtlasSprites(),
+      background = RectSprites(),
+      underline = AtlasSprites(),
+      decoration = RectSprites();
 
   /// Finalized background vertex data, available after [seal].
-  Vertices? get backgroundVertices => _backgroundVertices;
+  Vertices? get backgroundVertices => background.cachedVertices;
 
   /// Finalized decoration vertex data, available after [seal].
-  Vertices? get decorationVertices => _decorationVertices;
+  Vertices? get decorationVertices => decoration.cachedVertices;
 
-  /// Resets all sprite counts for the next frame.
-  void clear() {
-    wide.clear();
-    emoji.clear();
-    regular.clear();
-    underline.clear();
-    background.clear();
-    decoration.clear();
+  /// Begins rewriting row [row] across every channel.
+  ///
+  /// Call once per dirty row, followed by the emit calls and [endRow].
+  /// Clean rows must not be bracketed: their slots stay untouched.
+  void beginRow(int row) {
+    regular.beginRow(row);
+    wide.beginRow(row);
+    emoji.beginRow(row);
+    background.beginRow(row);
+    underline.beginRow(row);
+    decoration.beginRow(row);
   }
 
-  /// Grows atlas sprite capacity if needed for [minCapacity] cells.
-  void resize(int minCapacity) {
-    if (minCapacity <= regular.capacity) return;
-    final capacity = _nextPow2(minCapacity, regular.capacity);
-    regular.resize(capacity);
-    wide.resize(capacity);
-    emoji.resize(capacity);
+  /// Reconfigures all channels for a grid of [rows] rows and [cols]
+  /// columns.
+  ///
+  /// Stride per channel is the per-row upper bound on sprite emits:
+  /// `cols + 1` for text/background/underline channels (cells emit
+  /// at most once plus one end-of-row flush), and `2 * cols + 1` for
+  /// decorations (a cell can emit both strikethrough and overline).
+  void configure(int rows, int cols) {
+    final atlasStride = cols + 1;
+    regular.configure(rows, atlasStride);
+    wide.configure(rows, atlasStride);
+    emoji.configure(rows, atlasStride);
+    background.configure(rows, atlasStride);
+    underline.configure(rows, atlasStride);
+    decoration.configure(rows, 2 * cols + 1);
   }
 
-  /// Builds vertex data for backgrounds and decorations.
+  /// Releases buffers, sized arrays and cached [Vertices] for all
+  /// channels. The buffer must not be used again after this call.
+  void dispose() {
+    regular.dispose();
+    wide.dispose();
+    emoji.dispose();
+    background.dispose();
+    underline.dispose();
+    decoration.dispose();
+    _indices = Uint16List(0);
+  }
+
+  /// Ends the row started by [beginRow] across every channel.
+  void endRow() {
+    regular.endRow();
+    wide.endRow();
+    emoji.endRow();
+    background.endRow();
+    underline.endRow();
+    decoration.endRow();
+  }
+
+  /// Packs atlas channels and builds vertex data for rect channels.
   void seal() {
-    final maxRects = max(background.count, decoration.count);
+    regular.seal();
+    wide.seal();
+    emoji.seal();
+    underline.seal();
+    final maxRects = background.count > decoration.count
+        ? background.count
+        : decoration.count;
     if (maxRects > 0) _ensureIndices(maxRects);
-    _backgroundVertices = background.buildVertices(_indices);
-    _decorationVertices = decoration.buildVertices(_indices);
+    background.buildVertices(_indices);
+    decoration.buildVertices(_indices);
   }
 
   void _ensureIndices(int rectCount) {
     final needed = rectCount * 6;
     if (_indices.length >= needed) return;
-    final size = _nextPow2(needed, _indices.length);
+    // Power-of-two growth amortizes churn when rect counts drift across
+    // frames.
+    var size = _indices.isEmpty ? 384 : _indices.length;
+    while (size < needed) {
+      size *= 2;
+    }
     final indices = Uint16List(size);
-    for (var i = 0; i < size ~/ 6; i++) {
+    final quadCount = size ~/ 6;
+    for (var i = 0; i < quadCount; i++) {
       final base = i * 4;
       final offset = i * 6;
       indices[offset] = base;

--- a/packages/flterm/lib/src/rendering/painters/emoji_painter.dart
+++ b/packages/flterm/lib/src/rendering/painters/emoji_painter.dart
@@ -22,14 +22,13 @@ class EmojiPainter implements TerminalPainter {
   void paint(Canvas canvas) {
     final image = _atlas.image;
     final emoji = _sprites.emoji;
-    if (image == null || emoji.count == 0) return;
-
+    if (image == null || !emoji.hasSprites) return;
     canvas.drawRawAtlas(
       image,
       emoji.sealedTransforms,
       emoji.sealedRects,
       null,
-      .src,
+      BlendMode.src,
       null,
       _paint,
     );

--- a/packages/flterm/lib/src/rendering/painters/terminal_text_painter.dart
+++ b/packages/flterm/lib/src/rendering/painters/terminal_text_painter.dart
@@ -27,11 +27,7 @@ class TerminalTextPainter implements TerminalPainter {
     final image = _atlas.image;
     if (image == null) return;
 
-    final hasRegular = _regular.count > 0;
-    final hasWide = _wide.count > 0;
-    if (!hasRegular && !hasWide) return;
-
-    if (hasRegular) {
+    if (_regular.hasSprites) {
       canvas.drawRawAtlas(
         image,
         _regular.sealedTransforms,
@@ -42,8 +38,7 @@ class TerminalTextPainter implements TerminalPainter {
         _paint,
       );
     }
-
-    if (hasWide) {
+    if (_wide.hasSprites) {
       canvas.drawRawAtlas(
         image,
         _wide.sealedTransforms,

--- a/packages/flterm/lib/src/rendering/painters/underline_painter.dart
+++ b/packages/flterm/lib/src/rendering/painters/underline_painter.dart
@@ -22,12 +22,13 @@ class UnderlinePainter implements TerminalPainter {
   @override
   void paint(Canvas canvas) {
     final image = _atlas.image;
-    if (image == null || _sprites.underline.count == 0) return;
+    final underline = _sprites.underline;
+    if (image == null || !underline.hasSprites) return;
     canvas.drawRawAtlas(
       image,
-      _sprites.underline.sealedTransforms,
-      _sprites.underline.sealedRects,
-      _sprites.underline.sealedColors,
+      underline.sealedTransforms,
+      underline.sealedRects,
+      underline.sealedColors,
       BlendMode.modulate,
       null,
       _paint,

--- a/packages/flterm/lib/src/rendering/sprite_builder.dart
+++ b/packages/flterm/lib/src/rendering/sprite_builder.dart
@@ -41,6 +41,63 @@ bool _isOperator(int cp) {
       cp > 0x7A;
 }
 
+/// Tracks per-row dirtiness from sources outside libghostty's own
+/// row-dirty flag, such as selection changes.
+///
+/// [SpriteBuilder] combines this with [RowIterator.dirty] when deciding
+/// whether to re-emit each row, and clears it at the end of every
+/// [SpriteBuilder.build].
+class RowDirtyTracker {
+  var _rows = Uint8List(0);
+  var _anyDirty = false;
+
+  /// Whether any row is currently marked dirty.
+  bool get anyDirty => _anyDirty;
+
+  /// Whether [row] is marked dirty. Out-of-range rows read as clean.
+  bool isDirty(int row) => row >= 0 && row < _rows.length && _rows[row] != 0;
+
+  /// Marks every row dirty.
+  void markAll() {
+    if (_rows.isEmpty) return;
+    _rows.fillRange(0, _rows.length, 1);
+    _anyDirty = true;
+  }
+
+  /// Marks rows `[from, toExclusive)` dirty, clamped to the tracker's
+  /// current row count.
+  void markRange(int from, int toExclusive) {
+    final start = from < 0 ? 0 : from;
+    final end = toExclusive > _rows.length ? _rows.length : toExclusive;
+    if (start >= end) return;
+    _rows.fillRange(start, end, 1);
+    _anyDirty = true;
+  }
+
+  /// Marks a single [row] dirty. Out-of-range rows are ignored.
+  void markRow(int row) {
+    if (row < 0 || row >= _rows.length) return;
+    _rows[row] = 1;
+    _anyDirty = true;
+  }
+
+  /// Resizes to track [rowCount] rows and clears all flags.
+  void resize(int rowCount) {
+    if (_rows.length != rowCount) {
+      _rows = Uint8List(rowCount);
+    } else {
+      _rows.fillRange(0, rowCount, 0);
+    }
+    _anyDirty = false;
+  }
+
+  void _clear() {
+    if (!_anyDirty) return;
+    _rows.fillRange(0, _rows.length, 0);
+    _anyDirty = false;
+  }
+}
+
 /// Builds all sprite data for one terminal frame.
 ///
 /// Reads terminal cells via [RenderState] (walked with pre-allocated
@@ -64,6 +121,7 @@ class SpriteBuilder {
   final _RowCursor _cursor;
   final RowIterator _rows;
   final CellIterator _cells;
+  final RowDirtyTracker _dirtyRows;
 
   // Per-frame cached values used in the per-cell hot loop.
   late double _cellWidth;
@@ -87,18 +145,23 @@ class SpriteBuilder {
     : _styleCache = _StyleCache(_state),
       _cursor = _RowCursor(),
       _rows = RowIterator(),
-      _cells = CellIterator();
+      _cells = CellIterator(),
+      _dirtyRows = RowDirtyTracker();
 
-  /// Rebuilds all sprites from [renderState].
+  /// Per-row dirty contributions from flterm-side sources (selection,
+  /// blink, theme, atlas reconfigure). Combined with libghostty's own
+  /// row-dirty flag during [build].
+  RowDirtyTracker get dirtyRows => _dirtyRows;
+
+  /// Updates sprites for the current frame.
   ///
-  /// Clears existing sprite data, iterates every cell in the viewport,
-  /// and populates the sprite buffer with glyph, background, and
-  /// decoration entries. Finalizes the atlas image at the end.
-  ///
-  /// After returning, [SpriteBuffer] and [GlyphAtlas.image] are ready
-  /// for painters.
-  void build(RenderState renderState) {
-    _sprites.clear();
+  /// A row is re-emitted when [dirty] is not [DirtyState.partial], when
+  /// libghostty flags it via [RowIterator.dirty], or when any
+  /// flterm-side source has marked it via [dirtyRows]. Callers must not
+  /// invoke [build] when the snapshot is [DirtyState.clean] and
+  /// [dirtyRows] is empty; that case is handled one level up by
+  /// skipping the build entirely.
+  void build(RenderState renderState, {required DirtyState dirty}) {
     _cellWidth = _state.metrics.cellWidth;
     _cellHeight = _state.metrics.cellHeight;
     _underlineThickness = _state.metrics.underlineThickness;
@@ -115,19 +178,36 @@ class SpriteBuilder {
     _selection = _state.selection;
     _styleCache.beginFrame();
 
+    final rebuildAll = dirty != DirtyState.partial;
+
     _rows.reset(renderState);
     var row = 0;
     while (_rows.next()) {
       if (row >= _state.rows) break;
-      _cursor.reset(row, _cellHeight, _bgArgb);
-      _cells.reset(_rows);
-      _buildRow(_cells);
-      _rows.dirty = false;
+      if (rebuildAll || _rows.dirty || _dirtyRows.isDirty(row)) {
+        _sprites.beginRow(row);
+        _cursor.reset(row, _cellHeight, _bgArgb);
+        _cells.reset(_rows);
+        _buildRow(_cells);
+        _sprites.endRow();
+        _rows.dirty = false;
+      }
       row++;
     }
+    _dirtyRows._clear();
 
     _atlas.ensureImage();
     _sprites.seal();
+  }
+
+  /// Reconfigures sprite storage for the current grid size.
+  ///
+  /// Called by the render object when the grid dimensions change. The
+  /// caller is responsible for triggering a [DirtyState.full] build on
+  /// the next paint so every row is re-emitted into the fresh layout.
+  void configure(int rows, int cols) {
+    _sprites.configure(rows, cols);
+    _dirtyRows.resize(rows);
   }
 
   /// Releases the owned [RowIterator] and [CellIterator] handles.
@@ -148,21 +228,19 @@ class SpriteBuilder {
       final isWide = cells.wide == .wide;
       final selected = _isCellSelected(cursor.row, cursor.col);
       final styleChanged = cells.styleId != cursor.prevStyleId;
-      final selectionChanged = selected != cursor.prevSelected;
+      final stateChanged = styleChanged || selected != cursor.prevSelected;
 
-      if (styleChanged || selectionChanged) _flushOperatorRun(cursor);
-
-      if (styleChanged) {
-        final (fg, bg, style, explicitBg) = _styleCache.resolve(cells);
-        cursor.prevStyleId = cells.styleId;
-        cursor.baseForeground = fg;
-        cursor.baseBackground = bg;
-        cursor.baseBackgroundExplicit = explicitBg;
-        cursor.backgroundInverse = style.inverse;
-        cursor.style = style;
-      }
-
-      if (styleChanged || selectionChanged) {
+      if (stateChanged) {
+        _flushOperatorRun(cursor);
+        if (styleChanged) {
+          final (fg, bg, style, explicitBg) = _styleCache.resolve(cells);
+          cursor.prevStyleId = cells.styleId;
+          cursor.baseForeground = fg;
+          cursor.baseBackground = bg;
+          cursor.baseBackgroundExplicit = explicitBg;
+          cursor.backgroundInverse = style.inverse;
+          cursor.style = style;
+        }
         if (selected) {
           final sel = _state.theme.selection;
           cursor.foreground = _resolveSelectionColor(
@@ -226,30 +304,6 @@ class SpriteBuilder {
         _resolveBgArgb(cursor.bgRunArgb, cursor.bgRunInverse),
       );
     }
-  }
-
-  bool _isCellSelected(int row, int col) {
-    final sel = _selection;
-    if (sel == null) return false;
-    return sel.contains(row + _state.viewportOffset, col);
-  }
-
-  // Resolves a selection override (foreground or background) against the
-  // current cell. Defaults let selection invert the cell visually: when no
-  // override is set, selection fg falls back to the terminal background and
-  // selection bg to the terminal foreground.
-  int _resolveSelectionColor(
-    _RowCursor cursor,
-    DynamicColor? override,
-    int fallbackArgb,
-  ) {
-    if (override == null) return fallbackArgb;
-    return override
-        .resolve(
-          cellForeground: Color(cursor.baseForeground),
-          cellBackground: Color(cursor.baseBackground),
-        )
-        .toARGB32();
   }
 
   void _emitCodepoint(int codepoint, double x, Style style, _RowCursor cursor) {
@@ -493,6 +547,12 @@ class SpriteBuilder {
     cursor.operatorRun.clear();
   }
 
+  bool _isCellSelected(int row, int col) {
+    final selection = _selection;
+    if (selection == null) return false;
+    return selection.contains(row + _state.viewportOffset, col);
+  }
+
   /// Applies [_cellOpacityAlpha] to [argb] when cell-level opacity is
   /// enabled and the run is not inverse. Inverse runs stay opaque so
   /// swapped fg/bg cells remain readable.
@@ -501,6 +561,24 @@ class SpriteBuilder {
     final currentAlpha = (argb >>> 24) & 0xFF;
     final newAlpha = (currentAlpha * _cellOpacityAlpha + 127) ~/ 255;
     return (newAlpha << 24) | (argb & 0x00FFFFFF);
+  }
+
+  // Resolves a selection override (foreground or background) against the
+  // current cell. Defaults let selection invert the cell visually: when no
+  // override is set, selection fg falls back to the terminal background and
+  // selection bg to the terminal foreground.
+  int _resolveSelectionColor(
+    _RowCursor cursor,
+    DynamicColor? override,
+    int fallbackArgb,
+  ) {
+    if (override == null) return fallbackArgb;
+    return override
+        .resolve(
+          cellForeground: Color(cursor.baseForeground),
+          cellBackground: Color(cursor.baseBackground),
+        )
+        .toARGB32();
   }
 }
 

--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -188,7 +188,6 @@ class TerminalRenderBox extends RenderBox {
   OnResize? _onResize;
   var _performingLayout = false;
   var _needsContentSync = false;
-  var _needsSpriteRebuild = false;
   var _stickToBottom = true;
   var _lastScrollbackRows = 0;
   var _lastCursor = const Cursor();
@@ -271,7 +270,7 @@ class TerminalRenderBox extends RenderBox {
   set blinkVisible(bool value) {
     if (_paintState.blinkVisible == value) return;
     _paintState.blinkVisible = value;
-    _needsSpriteRebuild = true;
+    _spriteBuilder.dirtyRows.markAll();
     markNeedsPaint();
   }
 
@@ -387,6 +386,7 @@ class TerminalRenderBox extends RenderBox {
     _paintState.rows = 0;
     _paintState.cols = 0;
     _spriteBuilder.dispose();
+    _sprites.dispose();
     _renderState.dispose();
     super.detach();
   }
@@ -446,8 +446,8 @@ class TerminalRenderBox extends RenderBox {
       _paintState.cols = newCols;
       _paintState.rows = newRows;
       _paintState.devicePixelRatio = dpr;
-      _sprites.resize(newRows * newCols);
       if (newCols > 0 && newRows > 0) {
+        _spriteBuilder.configure(newRows, newCols);
         // Cell size is reported in physical pixels so size-report
         // escapes and Kitty graphics geometry match a native terminal
         // at the same DPI.
@@ -465,9 +465,13 @@ class TerminalRenderBox extends RenderBox {
 
     _syncScrollLayout();
 
-    // Only rebuild sprites when grid dimensions or atlas changed.
-    // Sub-cell pixel resize steps skip the expensive sprite build.
-    if (gridChanged || atlasReconfigured) _markTerminalDirty();
+    // Grid or atlas changes invalidate every row's sprite slot layout
+    // (grid) or atlas rect references (atlas), so re-emit every row on
+    // the next paint. Sub-cell pixel resize steps skip the work.
+    if (gridChanged || atlasReconfigured) {
+      _spriteBuilder.dirtyRows.markAll();
+      _markTerminalDirty();
+    }
 
     _performingLayout = false;
   }
@@ -495,11 +499,20 @@ class TerminalRenderBox extends RenderBox {
     final newSelection = _renderObserver.selection;
     _paintState.selection = newSelection;
     _paintState.cursorFocused = _renderObserver.hasFocus;
-    // Selection membership changes each cell's bg and fg, so rebuild
-    // sprites when the selection actually moves.
-    if (previousSelection != newSelection) _needsSpriteRebuild = true;
+    if (previousSelection != newSelection) {
+      _markSelectionRowsDirty(previousSelection);
+      _markSelectionRowsDirty(newSelection);
+    }
     _resolveCursorGlyph();
     markNeedsPaint();
+  }
+
+  void _markSelectionRowsDirty(TerminalSelection? selection) {
+    if (selection == null || _paintState.rows == 0) return;
+    final viewportOffset = _terminal.scrollbar.offset;
+    final top = selection.topRow - viewportOffset;
+    final bottom = selection.bottomRow - viewportOffset;
+    _spriteBuilder.dirtyRows.markRange(top, bottom + 1);
   }
 
   void _onScroll() {
@@ -559,16 +572,17 @@ class TerminalRenderBox extends RenderBox {
       _paintState.cursor = cursor.copyWith(visible: false);
       _paintState.cursorWide = false;
       _paintState.cursorGlyphEntry = null;
-      _resolveCursorFillColor(null);
       return;
     }
 
-    var col = cursor.col;
-    if (cursor.wideTail && col > 0) col -= 1;
-    final effectiveCursor = col != cursor.col
-        ? cursor.copyWith(col: col)
+    final effectiveCursor = cursor.wideTail && cursor.col > 0
+        ? cursor.copyWith(col: cursor.col - 1)
         : cursor;
-    final ref = GridRef.at(_terminal, col: col, row: cursor.row);
+    final ref = GridRef.at(
+      _terminal,
+      col: effectiveCursor.col,
+      row: effectiveCursor.row,
+    );
     final cursorCell = CursorCell(ref.content, ref.style, wide: ref.isWide);
     ref.dispose();
 
@@ -684,25 +698,18 @@ class TerminalRenderBox extends RenderBox {
     _stickToBottom = maxExtent <= 0 || _offset.pixels >= maxExtent - cellHeight;
   }
 
-  // Reads terminal state and builds sprites for the current frame.
-  //
-  // Called at the start of paint(). After this method returns, all painters
-  // read only from pre-built sprite data with zero terminal access.
-  //
-  // Content sync: snapshots the terminal, reads colors, builds sprites,
-  // resolves cursor. Triggered by terminal output, scroll, theme, or resize.
-  //
-  // Sprite-only rebuild: re-iterates the existing snapshot to rebuild
-  // sprites without FFI overhead. Triggered by blink visibility changes
-  // when no content change is pending.
+  // Reads terminal state and builds sprites for the current frame. The
+  // build runs when libghostty reports any change OR when a flterm-side
+  // source (selection, blink, atlas reconfigure, layout) has marked
+  // rows dirty via [_spriteBuilder.dirtyRows].
   void _syncTerminalState() {
     if (_paintState.rows == 0) return;
 
+    final dirtyRows = _spriteBuilder.dirtyRows;
     if (_needsContentSync) {
       _needsContentSync = false;
-      _needsSpriteRebuild = false;
 
-      _renderState.update(_terminal);
+      final dirty = _renderState.update(_terminal);
 
       final scrollbar = _terminal.scrollbar;
       _paintState.viewportOffset = scrollbar.offset;
@@ -714,13 +721,14 @@ class TerminalRenderBox extends RenderBox {
           _terminal.background?.toArgb32 ??
           _paintState.theme.background.toARGB32();
 
-      _spriteBuilder.build(_renderState);
-      _renderState.dirty = DirtyState.clean;
+      if (dirty != .clean || dirtyRows.anyDirty) {
+        _spriteBuilder.build(_renderState, dirty: dirty);
+        _renderState.dirty = .clean;
+      }
 
       _resolveCursor(_renderState, scrollbar);
-    } else if (_needsSpriteRebuild) {
-      _needsSpriteRebuild = false;
-      _spriteBuilder.build(_renderState);
+    } else if (dirtyRows.anyDirty) {
+      _spriteBuilder.build(_renderState, dirty: .partial);
     }
 
     _syncKittyPlacements();

--- a/packages/flterm/test/rendering/row_dirty_tracker_test.dart
+++ b/packages/flterm/test/rendering/row_dirty_tracker_test.dart
@@ -1,0 +1,87 @@
+import 'package:flterm/src/rendering/sprite_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RowDirtyTracker', () {
+    test('resize clears previous marks', () {
+      final tracker = RowDirtyTracker()..resize(4);
+      tracker.markRow(2);
+      expect(tracker.anyDirty, isTrue);
+
+      tracker.resize(6);
+
+      expect(tracker.anyDirty, isFalse);
+      for (var r = 0; r < 6; r++) {
+        expect(tracker.isDirty(r), isFalse);
+      }
+    });
+
+    test('markRow flags a single row', () {
+      final tracker = RowDirtyTracker()..resize(4);
+      tracker.markRow(2);
+
+      expect(tracker.anyDirty, isTrue);
+      expect(tracker.isDirty(2), isTrue);
+      expect(tracker.isDirty(0), isFalse);
+      expect(tracker.isDirty(3), isFalse);
+    });
+
+    test('markRow ignores out-of-range indices', () {
+      final tracker = RowDirtyTracker()..resize(4);
+      tracker.markRow(-1);
+      tracker.markRow(99);
+
+      expect(tracker.anyDirty, isFalse);
+    });
+
+    test('markRange flags an inclusive-exclusive range', () {
+      final tracker = RowDirtyTracker()..resize(10);
+      tracker.markRange(3, 7);
+
+      for (var r = 0; r < 10; r++) {
+        expect(tracker.isDirty(r), r >= 3 && r < 7);
+      }
+    });
+
+    test('markRange clips out-of-range ends', () {
+      final tracker = RowDirtyTracker()..resize(5);
+      tracker.markRange(-5, 3);
+      tracker.markRange(4, 100);
+
+      expect(tracker.isDirty(0), isTrue);
+      expect(tracker.isDirty(2), isTrue);
+      expect(tracker.isDirty(3), isFalse);
+      expect(tracker.isDirty(4), isTrue);
+    });
+
+    test('markAll flags every row', () {
+      final tracker = RowDirtyTracker()..resize(5);
+      tracker.markAll();
+
+      expect(tracker.anyDirty, isTrue);
+      for (var r = 0; r < 5; r++) {
+        expect(tracker.isDirty(r), isTrue);
+      }
+    });
+
+    test('resize reuses existing buffer when big enough', () {
+      final tracker = RowDirtyTracker()..resize(100);
+      tracker.markAll();
+
+      // Shrink and re-expand: resize clears all marks regardless.
+      tracker.resize(10);
+      for (var r = 0; r < 10; r++) {
+        expect(tracker.isDirty(r), isFalse);
+      }
+
+      tracker.resize(50);
+      expect(tracker.anyDirty, isFalse);
+    });
+
+    test('anyDirty stays false when no mark lands', () {
+      final tracker = RowDirtyTracker()..resize(3);
+      tracker.markRange(5, 10); // entirely out of range
+      expect(tracker.anyDirty, isFalse);
+    });
+  });
+}

--- a/packages/flterm/test/rendering/sprite_buffer_test.dart
+++ b/packages/flterm/test/rendering/sprite_buffer_test.dart
@@ -6,244 +6,308 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AtlasSprites', () {
-    test('add writes transform, rect, and color data', () {
-      final sprites = AtlasSprites(4);
-      final entry = _entry(
-        srcLeft: 10,
-        srcTop: 20,
-        srcRight: 18,
-        srcBottom: 36,
-      );
+    test('count and hasSprites are zero before any emit', () {
+      final sprites = AtlasSprites()..configure(4, 4);
+      sprites.seal();
+      expect(sprites.count, 0);
+      expect(sprites.hasSprites, isFalse);
+      expect(sprites.sealedTransforms.length, 0);
+    });
 
-      sprites.add(100.0, 200.0, entry, 0.5, 0xFFAABBCC);
+    test('seal packs active slots across rows', () {
+      final sprites = AtlasSprites()..configure(4, 3);
+      sprites.beginRow(1);
+      sprites.add(
+        100.0,
+        200.0,
+        _entry(srcLeft: 10, srcTop: 20, srcRight: 18, srcBottom: 36),
+        0.5,
+        0xFFAABBCC,
+      );
+      sprites.endRow();
+      sprites.seal();
 
       expect(sprites.count, 1);
+      expect(sprites.sealedTransforms.length, 4);
       expect(sprites.sealedTransforms[0], 0.5);
-      expect(sprites.sealedTransforms[1], 0.0);
       expect(sprites.sealedTransforms[2], 100.0);
       expect(sprites.sealedTransforms[3], 200.0);
       expect(sprites.sealedRects[0], 10.0);
-      expect(sprites.sealedRects[1], 20.0);
-      expect(sprites.sealedRects[2], 18.0);
-      expect(sprites.sealedRects[3], 36.0);
-      expect(sprites.sealedColors[0], _si(0xFFAABBCC));
+      expect(sprites.sealedColors[0], 0xFFAABBCC.toSigned(32));
     });
 
-    test('add defaults argb to zero', () {
-      final sprites = AtlasSprites(4);
-      sprites.add(0, 0, _entry(), 1.0);
+    test('seal drops unused tail slots', () {
+      final sprites = AtlasSprites()..configure(2, 4);
+      sprites.beginRow(0);
+      sprites.add(10, 20, _entry(), 1.0);
+      sprites.endRow();
+      sprites.seal();
 
-      expect(sprites.sealedColors[0], 0);
+      expect(sprites.sealedTransforms.length, 4);
+      expect(sprites.sealedTransforms[0], 1.0);
     });
 
-    test('multiple adds write at sequential offsets', () {
-      final sprites = AtlasSprites(4);
-      final entry1 = _entry();
-      final entry2 = _entry(
-        srcLeft: 10,
-        srcTop: 10,
-        srcRight: 18,
-        srcBottom: 26,
-      );
+    test('shrinking a row drops dropped sprites from the packed output', () {
+      final sprites = AtlasSprites()..configure(2, 4);
+      sprites.beginRow(0);
+      sprites.add(10, 0, _entry(), 1.0, 0x11111111);
+      sprites.add(20, 0, _entry(), 1.0, 0x22222222);
+      sprites.add(30, 0, _entry(), 1.0, 0x33333333);
+      sprites.endRow();
+      sprites.seal();
+      expect(sprites.count, 3);
 
-      sprites.add(10.0, 20.0, entry1, 1.0, 0xFF111111);
-      sprites.add(30.0, 40.0, entry2, 1.0, 0xFF222222);
+      sprites.beginRow(0);
+      sprites.add(40, 0, _entry(), 1.0, 0x44444444);
+      sprites.endRow();
+      sprites.seal();
+
+      expect(sprites.count, 1);
+      expect(sprites.sealedTransforms.length, 4);
+      expect(sprites.sealedTransforms[2], 40.0);
+    });
+
+    test('configure resets active slot count when reusing the buffer', () {
+      final sprites = AtlasSprites()..configure(4, 6);
+      sprites.beginRow(3);
+      sprites.add(1, 2, _entry(), 1.0);
+      sprites.endRow();
+      sprites.seal();
+      expect(sprites.count, 1);
+
+      sprites.configure(2, 3);
+      sprites.seal();
+      expect(sprites.count, 0);
+      expect(sprites.sealedTransforms.length, 0);
+    });
+
+    test('dispose releases buffers and resets counters', () {
+      final sprites = AtlasSprites()..configure(4, 6);
+      sprites.beginRow(0);
+      sprites.add(1, 2, _entry(), 1.0);
+      sprites.endRow();
+      sprites.seal();
+
+      sprites.dispose();
+
+      expect(sprites.count, 0);
+      expect(sprites.hasSprites, isFalse);
+      expect(sprites.sealedTransforms.length, 0);
+    });
+
+    test('repeat seal with no dirty rows keeps packed contents stable', () {
+      final sprites = AtlasSprites()..configure(3, 4);
+      sprites.beginRow(1);
+      sprites.add(7, 8, _entry(), 1.0, 0xFFAABBCC);
+      sprites.endRow();
+      sprites.seal();
+
+      sprites.seal();
+      sprites.seal();
+
+      expect(sprites.count, 1);
+      expect(sprites.sealedTransforms[2], 7.0);
+      expect(sprites.sealedTransforms[3], 8.0);
+      expect(sprites.sealedColors[0], 0xFFAABBCC.toSigned(32));
+    });
+
+    test('incremental seal preserves clean row prefix', () {
+      final sprites = AtlasSprites()..configure(3, 4);
+      sprites.beginRow(0);
+      sprites.add(1, 2, _entry(), 1.0, 0xFF111111);
+      sprites.endRow();
+      sprites.beginRow(2);
+      sprites.add(3, 4, _entry(), 1.0, 0xFF333333);
+      sprites.endRow();
+      sprites.seal();
+      expect(sprites.count, 2);
+
+      // Rewrite only row 2.
+      sprites.beginRow(2);
+      sprites.add(9, 9, _entry(), 1.0, 0xFF999999);
+      sprites.endRow();
+      sprites.seal();
 
       expect(sprites.count, 2);
-      expect(sprites.sealedTransforms[4], 1.0);
-      expect(sprites.sealedTransforms[6], 30.0);
-      expect(sprites.sealedTransforms[7], 40.0);
-      expect(sprites.sealedRects[4], 10.0);
-      expect(sprites.sealedRects[5], 10.0);
-      expect(sprites.sealedColors[1], _si(0xFF222222));
-    });
-
-    test('grows when capacity exceeded', () {
-      final sprites = AtlasSprites(2);
-
-      for (var index = 0; index < 10; index++) {
-        sprites.add(index.toDouble(), 0, _entry(), 1.0, index);
-      }
-
-      expect(sprites.count, 10);
-      for (var index = 0; index < 10; index++) {
-        expect(sprites.sealedTransforms[index * 4 + 2], index.toDouble());
-        expect(sprites.sealedColors[index], index);
-      }
-    });
-
-    test('grows correctly from zero capacity', () {
-      final sprites = AtlasSprites(0);
-
-      for (var index = 0; index < 5; index++) {
-        sprites.add(index.toDouble(), 0, _entry(), 1.0, index);
-      }
-
-      expect(sprites.count, 5);
-      for (var index = 0; index < 5; index++) {
-        expect(sprites.sealedTransforms[index * 4 + 2], index.toDouble());
-      }
-    });
-
-    test('sealed views reflect current count', () {
-      final sprites = AtlasSprites(8);
-
-      expect(sprites.sealedTransforms.length, 0);
-      expect(sprites.sealedRects.length, 0);
-      expect(sprites.sealedColors.length, 0);
-
-      sprites.add(0, 0, _entry(), 1.0, 0xFF000000);
-      sprites.add(10, 20, _entry(), 1.0, 0xFF111111);
-
-      expect(sprites.sealedTransforms.length, 8);
-      expect(sprites.sealedRects.length, 8);
-      expect(sprites.sealedColors.length, 2);
+      // Row 0 preserved at packed offset 0.
+      expect(sprites.sealedColors[0], 0xFF111111.toSigned(32));
+      expect(sprites.sealedTransforms[2], 1.0);
+      // Row 2 rewritten at packed offset 1.
+      expect(sprites.sealedColors[1], 0xFF999999.toSigned(32));
+      expect(sprites.sealedTransforms[4 + 2], 9.0);
     });
   });
 
   group('RectSprites', () {
-    test('add writes LTRB and color data', () {
-      final sprites = RectSprites(4);
-      sprites.add(10.0, 20.0, 30.0, 40.0, 0xFFFF0000);
-
-      expect(sprites.count, 1);
-      expect(sprites.sealedRects[0], 10.0);
-      expect(sprites.sealedRects[1], 20.0);
-      expect(sprites.sealedRects[2], 30.0);
-      expect(sprites.sealedRects[3], 40.0);
-      expect(sprites.sealedColors[0], _si(0xFFFF0000));
+    test('count and hasSprites are zero before any emit', () {
+      final sprites = RectSprites()..configure(2, 3);
+      expect(sprites.count, 0);
+      expect(sprites.hasSprites, isFalse);
     });
 
-    test('grows when capacity exceeded', () {
-      final sprites = RectSprites(2);
-
-      for (var index = 0; index < 10; index++) {
-        sprites.add(index.toDouble(), 0, 100, 50, index);
-      }
-
-      expect(sprites.count, 10);
-      for (var index = 0; index < 10; index++) {
-        expect(sprites.sealedRects[index * 4], index.toDouble());
-        expect(sprites.sealedColors[index], index);
-      }
+    test('add and endRow update the active count', () {
+      final sprites = RectSprites()..configure(2, 3);
+      sprites.beginRow(0);
+      sprites.add(0, 0, 1, 1, 0xFFAA0000);
+      sprites.endRow();
+      sprites.beginRow(1);
+      sprites.add(2, 2, 3, 3, 0xFF00BB00);
+      sprites.add(4, 4, 5, 5, 0xFF0000CC);
+      sprites.endRow();
+      expect(sprites.count, 3);
     });
 
-    test('grows correctly from zero capacity', () {
-      final sprites = RectSprites(0);
-
-      for (var index = 0; index < 5; index++) {
-        sprites.add(index.toDouble(), 0, 100, 50, index);
-      }
-
-      expect(sprites.count, 5);
-      for (var index = 0; index < 5; index++) {
-        expect(sprites.sealedRects[index * 4], index.toDouble());
-      }
-    });
-
-    test('buildVertices returns null when empty', () {
-      final sprites = RectSprites(4);
+    test('buildVertices returns null when no row is active', () {
+      final sprites = RectSprites()..configure(2, 3);
       expect(sprites.buildVertices(Uint16List(0)), isNull);
     });
 
-    test('buildVertices expands LTRB to indexed triangle quads', () {
-      final sprites = RectSprites(4);
-      sprites.add(10.0, 20.0, 30.0, 40.0, 0xFFFF0000);
-
+    test('buildVertices returns non-null once any row is active', () {
+      final sprites = RectSprites()..configure(2, 3);
+      sprites.beginRow(0);
+      sprites.add(10, 20, 30, 40, 0xFFFF0000);
+      sprites.endRow();
       final indices = Uint16List.fromList([0, 1, 2, 0, 2, 3]);
-      final vertices = sprites.buildVertices(indices);
+      expect(sprites.buildVertices(indices), isNotNull);
+    });
 
-      expect(vertices, isNotNull);
+    test('shrinking a row decreases the active count', () {
+      final sprites = RectSprites()..configure(1, 4);
+      sprites.beginRow(0);
+      sprites.add(10, 10, 20, 20, 0xFFFF0000);
+      sprites.add(30, 30, 40, 40, 0xFF00FF00);
+      sprites.endRow();
+      expect(sprites.count, 2);
+
+      sprites.beginRow(0);
+      sprites.add(50, 50, 60, 60, 0xFF0000FF);
+      sprites.endRow();
+      expect(sprites.count, 1);
+    });
+
+    test(
+      'buildVertices resets starts when active slots drop to 0 then grow',
+      () {
+        final sprites = RectSprites()..configure(10, 5);
+        final indices = Uint16List(600);
+        for (var i = 0; i < 100; i++) {
+          final base = i * 4;
+          final offset = i * 6;
+          indices[offset] = base;
+          indices[offset + 1] = base + 1;
+          indices[offset + 2] = base + 2;
+          indices[offset + 3] = base;
+          indices[offset + 4] = base + 2;
+          indices[offset + 5] = base + 3;
+        }
+
+        sprites.beginRow(0);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.endRow();
+        sprites.beginRow(5);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.endRow();
+        sprites.buildVertices(indices);
+
+        sprites.beginRow(0);
+        sprites.endRow();
+        sprites.beginRow(5);
+        sprites.endRow();
+        expect(sprites.buildVertices(indices), isNull);
+
+        sprites.beginRow(7);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.add(0, 0, 10, 10, 0xFF000000);
+        sprites.endRow();
+        expect(sprites.buildVertices(indices), isNotNull);
+        expect(sprites.count, 2);
+      },
+    );
+
+    test('buildVertices returns cached Vertices when nothing dirtied', () {
+      final sprites = RectSprites()..configure(2, 3);
+      sprites.beginRow(0);
+      sprites.add(10, 20, 30, 40, 0xFFFF0000);
+      sprites.endRow();
+      final indices = Uint16List.fromList([0, 1, 2, 0, 2, 3]);
+      final first = sprites.buildVertices(indices);
+
+      final second = sprites.buildVertices(indices);
+
+      expect(identical(first, second), isTrue);
+    });
+
+    test('dispose releases buffers', () {
+      final sprites = RectSprites()..configure(2, 3);
+      sprites.beginRow(0);
+      sprites.add(1, 2, 3, 4, 0xFFAA0000);
+      sprites.endRow();
+
+      sprites.dispose();
+
+      expect(sprites.count, 0);
+      expect(sprites.hasSprites, isFalse);
     });
   });
 
   group('SpriteBuffer', () {
-    test('clear resets all counts to 0', () {
-      final buffer = SpriteBuffer();
-      buffer.regular.add(0, 0, _entry(), 1.0, 0xFF000000);
-      buffer.wide.add(0, 0, _entry(), 1.0, 0xFF000000);
-      buffer.emoji.add(0, 0, _entry(), 1.0);
-      buffer.background.add(0, 0, 100, 50, 0xFF000000);
-      buffer.decoration.add(0, 0, 100, 50, 0xFF000000);
-
-      buffer.clear();
-
+    test('configure resets active count across every channel', () {
+      final buffer = SpriteBuffer()..configure(4, 10);
+      buffer.seal();
       expect(buffer.regular.count, 0);
       expect(buffer.wide.count, 0);
       expect(buffer.emoji.count, 0);
       expect(buffer.background.count, 0);
+      expect(buffer.underline.count, 0);
       expect(buffer.decoration.count, 0);
     });
 
-    test('resize grows capacity when needed', () {
-      final buffer = SpriteBuffer();
-      final initialCapacity = buffer.regular.capacity;
-
-      buffer.resize(initialCapacity * 2);
-      expect(
-        buffer.regular.capacity,
-        greaterThanOrEqualTo(initialCapacity * 2),
-      );
-    });
-
-    test('resize is no-op when capacity already sufficient', () {
-      final buffer = SpriteBuffer();
-      final initialCapacity = buffer.regular.capacity;
-
-      buffer.resize(1);
-      expect(buffer.regular.capacity, initialCapacity);
-    });
-
-    test('seal builds vertex data for backgrounds and decorations', () {
-      final buffer = SpriteBuffer();
-      final entry = _entry(srcLeft: 5, srcTop: 10, srcRight: 13, srcBottom: 26);
-
-      buffer.regular.add(100.0, 200.0, entry, 0.5, 0xFF112233);
-      buffer.regular.add(110.0, 200.0, entry, 0.5, 0xFF445566);
-      buffer.wide.add(0, 0, entry, 1.0, 0xFF778899);
+    test('seal builds backgroundVertices when any row has bg rects', () {
+      final buffer = SpriteBuffer()..configure(2, 4);
+      buffer.beginRow(0);
+      buffer.regular.add(0, 0, _entry(), 1.0, 0xFF111111);
       buffer.background.add(0, 0, 100, 50, 0xFFAABBCC);
-
+      buffer.endRow();
       buffer.seal();
 
-      expect(buffer.regular.sealedTransforms.length, 8);
-      expect(buffer.regular.sealedRects.length, 8);
-      expect(buffer.regular.sealedColors.length, 2);
-      expect(buffer.wide.sealedColors.length, 1);
-      expect(buffer.emoji.sealedTransforms.length, 0);
       expect(buffer.backgroundVertices, isNotNull);
       expect(buffer.decorationVertices, isNull);
     });
 
-    test('sealed data contains correct values', () {
-      final buffer = SpriteBuffer();
-      final entry = _entry(srcLeft: 5, srcTop: 10, srcRight: 13, srcBottom: 26);
-
-      buffer.regular.add(100.0, 200.0, entry, 0.5, 0xFF112233);
+    test('clean rows keep sprites across a partial rebuild', () {
+      final buffer = SpriteBuffer()..configure(3, 4);
+      buffer.beginRow(0);
+      buffer.regular.add(1, 2, _entry(), 0.5, 0xFF112233);
+      buffer.endRow();
+      buffer.beginRow(2);
+      buffer.regular.add(3, 4, _entry(), 0.5, 0xFF445566);
+      buffer.endRow();
       buffer.seal();
 
-      expect(buffer.regular.sealedTransforms[0], 0.5);
-      expect(buffer.regular.sealedTransforms[2], 100.0);
-      expect(buffer.regular.sealedTransforms[3], 200.0);
-      expect(buffer.regular.sealedRects[0], 5.0);
-      expect(buffer.regular.sealedRects[1], 10.0);
-      expect(buffer.regular.sealedRects[2], 13.0);
-      expect(buffer.regular.sealedRects[3], 26.0);
-      expect(buffer.regular.sealedColors[0], _si(0xFF112233));
+      // Only row 2 is dirty; row 0's sprite stays.
+      buffer.beginRow(2);
+      buffer.regular.add(9, 9, _entry(), 0.5, 0xFF778899);
+      buffer.endRow();
+      buffer.seal();
+
+      expect(buffer.regular.count, 2);
     });
 
-    test('handles 1000 sprites without crash', () {
-      final buffer = SpriteBuffer();
-      final entry = _entry();
-
-      for (var index = 0; index < 1000; index++) {
-        buffer.regular.add(index.toDouble(), 0, entry, 1.0, index);
-      }
-
-      expect(buffer.regular.count, 1000);
-
+    test('dispose releases every channel', () {
+      final buffer = SpriteBuffer()..configure(2, 4);
+      buffer.beginRow(0);
+      buffer.regular.add(0, 0, _entry(), 1.0, 0xFF111111);
+      buffer.background.add(0, 0, 100, 50, 0xFFAABBCC);
+      buffer.endRow();
       buffer.seal();
-      expect(buffer.regular.sealedTransforms.length, 4000);
-      expect(buffer.regular.sealedColors.length, 1000);
+
+      buffer.dispose();
+
+      expect(buffer.regular.count, 0);
+      expect(buffer.background.count, 0);
+      expect(buffer.backgroundVertices, isNull);
     });
   });
 }
@@ -260,5 +324,3 @@ GlyphEntry _entry({
   srcBottom: srcBottom,
   bearingY: 0,
 );
-
-int _si(int argb) => argb.toSigned(32);


### PR DESCRIPTION
Each sprite channel owns a fixed per-row slot range. Frames rewrite only rows flagged dirty by libghostty or by flterm-side sources like selection; clean rows keep the sprites they had from the previous frame. When nothing is dirty the sprite build is skipped entirely.

- Grid and atlas reconfigure mark every row dirty so the next paint redraws from scratch.
- Selection moves mark the affected rows dirty instead of rebuilding the full viewport.
- Sprite buffers resize in place across grid changes rather than reallocating.