### PR TITLE
chore(libghostty): prepare v0.0.8 release

### DIFF
--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.0.8
+
+### Breaking
+
+- **Standalone companions**: rendering, grid lookups, formatting, and
+  encoding moved off `Terminal`. `RenderState` with `RowIterator` /
+  `CellIterator`, `GridRef.at`, `Formatter`, `KittyGraphics.of`, and
+  standalone `KeyEncoder` / `MouseEncoder` replace their `Terminal`
+  method and getter equivalents.
+
+### Added
+
+- **Kitty graphics**: image and placement lookup with resolved render
+  geometry, plus a process-global PNG decoder hook.
+- **Log callback**: process-global sink for the native library's
+  internal log output.
+- **Formatter selection**: restrict output to a coordinate region,
+  including block selections.
+- **Terminal data**: `cursorStyle`, `isMouseTracking`, and Kitty image
+  configuration accessors.
+- **Grid references**: `hyperlinkUri` and `pointIn()` for OSC 8 lookup
+  and coordinate round-tripping.
+
 ## 0.0.7
 
 ### Fixed

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.7
+  libghostty: ^0.0.8
 ```
 
 On web, initialize the WASM module once before using any bindings:

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
- Bump package version to `0.0.8`
- Move rendering, grid lookups, formatting, and encoding off `Terminal` into standalone companions (`RenderState`, `GridRef.at`, `Formatter`, `KittyGraphics.of`, `KeyEncoder`, `MouseEncoder`) (#38)
- Add Kitty graphics image and placement lookup with resolved render geometry (#35), plus a process-global PNG decoder hook (#36)
- Add a process-global log callback for the native library's internal log output (#34)
- Add selection support to `Formatter` for restricting output to a coordinate region (#32)
- Add `Terminal.cursorStyle`, `Terminal.isMouseTracking`, Kitty image configuration, `GridRef.hyperlinkUri`, and `GridRef.pointIn()` (#31)
- Update README version reference