### PR TITLE
chore(flterm): prepare v0.0.2 release

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.0.2
+
+### Breaking
+
+- **Theme colors move into `ColorPalette`**: `TerminalTheme` no longer
+  takes `background`, `foreground`, and `ansiColors` directly. Build a
+  `ColorPalette` once and pass it in, so palettes are something you
+  can share, swap, or `copyWith` on their own.
+- **Cursor and selection colors can adapt to the cell under them**: the
+  color fields take `DynamicColor?` now. Use
+  `DynamicColor.cellForeground()` / `.cellBackground()` to follow the
+  cell, or `DynamicColor.fixed(c)` for the old static behavior.
+- **`selectedText` is a method**: call `controller.selectedText()` for
+  plain text, or pass a `FormatterFormat` to get VT or HTML for
+  rich-clipboard copy.
+- **Bold no longer switches to the bright palette by default**: expect
+  slightly different bold colors; set `boldIsBright: true` to restore
+  the old behavior.
+
+### Added
+
+- **Kitty graphics**: programs that emit images (previewers, image
+  viewers, some editors) render inside the widget. Cap the cache via
+  `TerminalConfig.kittyImageStorageLimit`; zero disables.
+- **Transparent background**: `TerminalTheme.backgroundOpacity` makes
+  the default background translucent so the terminal can compose over
+  a translucent window or other widgets. `backgroundOpacityCells`
+  extends it to cells with their own bg color.
+- **More theme knobs**: `CursorTheme.text` (glyph color under a block
+  cursor), `TerminalTheme.boldColor` (forced bold color), and
+  `SelectionTheme.foreground` (selected-glyph tint).
+- **`ColorPalette.generated()`**: derives indices 16–255 from your base
+  16 plus background and foreground so the extended palette blends
+  instead of clashing with the fixed xterm cube.
+
+### Changed
+
+- **Dirty-row rendering**: frames rebuild only rows that changed, so
+  idle terminals cost much less CPU.
+
 ## 0.0.1
 
 Initial release.

--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -35,7 +35,7 @@ libghostty-vt engine.
 
 ```yaml
 dependencies:
-  flterm: ^0.0.1
+  flterm: ^0.0.2
 ```
 
 On web, initialize the wasm module once before mounting any terminal:
@@ -93,9 +93,11 @@ Custom themes are constructed directly:
 TerminalView(
   controller: controller,
   theme: TerminalTheme(
-    foreground: const Color(0xFFC5C8C6),
-    background: const Color(0xFF1D1F21),
-    ansiColors: const [/* 16 ANSI colors */],
+    palette: ColorPalette(
+      ansiColors: const [/* 16 ANSI colors */],
+      background: const Color(0xFF1D1F21),
+      foreground: const Color(0xFFC5C8C6),
+    ),
     fontFamily: 'JetBrains Mono',
     fontSize: 14,
     cursor: const CursorTheme(shape: CursorShape.bar),

--- a/packages/flterm/pubspec.yaml
+++ b/packages/flterm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flterm
 description: Flutter terminal widget on top of Ghostty's libghostty-vt engine.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/elias8/libghostty
 repository: https://github.com/elias8/libghostty/tree/main/packages/flterm
 issue_tracker: https://github.com/elias8/libghostty/issues
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   image: ^4.3.0
-  libghostty: ^0.0.7
+  libghostty: ^0.0.8
   meta: ^1.16.0
 
 dev_dependencies:


### PR DESCRIPTION
- Bump package version to `0.0.2`
- Bump `libghostty` dependency to `^0.0.8`
- Move theme colors into a single `ColorPalette` field on `TerminalTheme` (#41)
- Make `CursorTheme` and `SelectionTheme` colors `DynamicColor?` so cursor and selection can adapt to the cell underneath (#42)
- Make `TerminalController.selectedText` a method that accepts a `FormatterFormat` for VT or HTML copy (#32)
- Flip `boldIsBright` default to `false`
- Render Kitty graphics placements alongside terminal text, with `TerminalConfig.kittyImageStorageLimit` for the cache (#37)
- Add `TerminalTheme.backgroundOpacity` and `backgroundOpacityCells` for translucent terminal backgrounds (#40)
- Add `CursorTheme.text`, `TerminalTheme.boldColor`, `SelectionTheme.foreground`, and `ColorPalette.generated()`
- Render only dirty rows, skipping the sprite build when nothing changed (#44)
- Update README version reference and theme example for the new palette field