### PR TITLE
fix(flterm): release native render resources on unmount, not detach

### DIFF
--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -382,13 +382,18 @@ class TerminalRenderBox extends RenderBox {
     _offset.removeListener(_onScroll);
     _renderObserver.removeListener(_onRenderObserverChanged);
     _terminal.removeListener(_onTerminalChanged);
+    super.detach();
+  }
+
+  @override
+  void dispose() {
     _atlas.dispose();
     _paintState.rows = 0;
     _paintState.cols = 0;
     _spriteBuilder.dispose();
     _sprites.dispose();
     _renderState.dispose();
-    super.detach();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
Native render resources were being freed in `detach()`, which also runs on transient tree removals like GlobalKey reparenting and route push/pop. Move the cleanup to `RenderObject.dispose()` so it only fires on permanent unmount.