### PR TITLE
fix(flterm): dispose kitty image cache

### DIFF
--- a/packages/flterm/lib/src/rendering/kitty_image_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_image_cache.dart
@@ -73,9 +73,11 @@ class KittyImageCache {
   }
 
   void _beginDecode(KittyImage image) {
+    final imageId = image.id;
+    final fingerprint = _fingerprints[imageId];
     final rgba = _ensureRgba(image);
     if (rgba == null) {
-      _entries[image.id] = KittyImageUnsupported();
+      _entries[imageId] = KittyImageUnsupported();
       return;
     }
     decodeImageFromPixels(
@@ -84,7 +86,12 @@ class KittyImageCache {
       image.height,
       PixelFormat.rgba8888,
       (decoded) {
-        _entries[image.id] = KittyImageReady(decoded);
+        if (_fingerprints[imageId] != fingerprint ||
+            _entries[imageId] is! KittyImagePending) {
+          decoded.dispose();
+          return;
+        }
+        _entries[imageId] = KittyImageReady(decoded);
         _onImageReady();
       },
     );

--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -388,6 +388,7 @@ class TerminalRenderBox extends RenderBox {
   @override
   void dispose() {
     _atlas.dispose();
+    _kittyImageCache.dispose();
     _paintState.rows = 0;
     _paintState.cols = 0;
     _spriteBuilder.dispose();

--- a/packages/flterm/test/rendering/kitty_image_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_image_cache_test.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flterm/src/rendering/kitty_image_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('KittyImageCache', () {
+    test('dispose clears ready entries and is idempotent', () async {
+      final cache = KittyImageCache(onImageReady: () {});
+      final image = await _testImage();
+
+      cache.putReady(1, image);
+      expect(cache.lookupById(1), isA<KittyImageReady>());
+
+      cache.dispose();
+      cache.dispose();
+
+      expect(cache.lookupById(1), isNull);
+    });
+  });
+}
+
+Future<ui.Image> _testImage() {
+  final completer = Completer<ui.Image>();
+  ui.decodeImageFromPixels(
+    Uint8List.fromList([0xff, 0xff, 0xff, 0xff]),
+    1,
+    1,
+    ui.PixelFormat.rgba8888,
+    completer.complete,
+  );
+  return completer.future;
+}


### PR DESCRIPTION
Dispose the Kitty image cache with the terminal renderer so ready `ui.Image` entries are released when the render object is permanently unmounted.

Also guard decode callbacks so stale decoded images are disposed if the cache entry changed or was removed before the callback runs.