### PR TITLE
refactor(flterm): add scoped render cache

### DIFF
--- a/packages/flterm/lib/flterm.dart
+++ b/packages/flterm/lib/flterm.dart
@@ -43,6 +43,7 @@ export 'src/foundation/terminal_theme.dart'
         SelectionTheme,
         TerminalTheme;
 export 'src/widgets/terminal_controller.dart' show TerminalController;
+export 'src/widgets/terminal_scope.dart' show TerminalScope;
 export 'src/widgets/terminal_scroll_controller.dart'
     show TerminalScrollController, TerminalScrollPosition;
 export 'src/widgets/terminal_view.dart' show TerminalView;

--- a/packages/flterm/lib/src/rendering/terminal_render_cache.dart
+++ b/packages/flterm/lib/src/rendering/terminal_render_cache.dart
@@ -1,0 +1,136 @@
+import 'dart:ui' show FontWeight;
+
+import 'package:meta/meta.dart';
+
+import '../foundation.dart';
+import 'atlas/glyph_atlas.dart';
+
+class TerminalGlyphAtlasHandle {
+  final TerminalRenderCache _owner;
+  final TerminalRenderCacheKey key;
+  final _GlyphAtlasEntry _entry;
+  var _released = false;
+
+  TerminalGlyphAtlasHandle._(this._owner, this.key, this._entry);
+
+  GlyphAtlas get atlas => _entry.atlas;
+
+  void release() {
+    if (_released) return;
+    _released = true;
+    _owner._releaseGlyphAtlas(key, _entry);
+  }
+}
+
+/// Owns render resources that can be shared by compatible terminal views.
+///
+/// This type is internal; public sharing is exposed through `TerminalScope`.
+class TerminalRenderCache {
+  final _glyphAtlases = <TerminalRenderCacheKey, _GlyphAtlasEntry>{};
+
+  TerminalGlyphAtlasHandle acquireGlyphAtlas(TerminalRenderCacheKey key) {
+    final entry = _glyphAtlases.putIfAbsent(key, () {
+      final atlas = GlyphAtlas(
+        fontSize: key.fontSize,
+        fontWeight: key.fontWeight,
+        fontFamily: key.fontFamily,
+        fontFamilyFallback: key.fontFamilyFallback,
+      )..configure(dpr: key.devicePixelRatio, metrics: key.metrics);
+      return _GlyphAtlasEntry(atlas);
+    });
+    entry.references++;
+    return TerminalGlyphAtlasHandle._(this, key, entry);
+  }
+
+  void dispose() {
+    for (final entry in _glyphAtlases.values) {
+      entry.atlas.dispose();
+    }
+    _glyphAtlases.clear();
+  }
+
+  void _releaseGlyphAtlas(
+    TerminalRenderCacheKey key,
+    _GlyphAtlasEntry releasedEntry,
+  ) {
+    final entry = _glyphAtlases[key];
+    if (entry == null) return;
+    if (!identical(entry, releasedEntry)) return;
+
+    entry.references--;
+    if (entry.references > 0) return;
+
+    _glyphAtlases.remove(key);
+    entry.atlas.dispose();
+  }
+}
+
+@immutable
+class TerminalRenderCacheKey {
+  final double fontSize;
+  final FontWeight fontWeight;
+  final String fontFamily;
+  final List<String> fontFamilyFallback;
+  final CellMetrics metrics;
+  final double devicePixelRatio;
+
+  TerminalRenderCacheKey({
+    required this.fontSize,
+    required this.fontWeight,
+    required this.fontFamily,
+    required List<String> fontFamilyFallback,
+    required this.metrics,
+    required this.devicePixelRatio,
+  }) : fontFamilyFallback = List.unmodifiable(fontFamilyFallback);
+
+  factory TerminalRenderCacheKey.fromTheme({
+    required TerminalTheme theme,
+    required CellMetrics metrics,
+    required double devicePixelRatio,
+  }) {
+    return TerminalRenderCacheKey(
+      fontSize: theme.fontSize,
+      fontWeight: theme.fontWeight,
+      fontFamily: theme.fontFamily,
+      fontFamilyFallback: theme.fontFamilyFallback,
+      metrics: metrics,
+      devicePixelRatio: devicePixelRatio,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    fontSize,
+    fontWeight,
+    fontFamily,
+    Object.hashAll(fontFamilyFallback),
+    metrics,
+    devicePixelRatio,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is TerminalRenderCacheKey &&
+      other.fontSize == fontSize &&
+      other.fontWeight == fontWeight &&
+      other.fontFamily == fontFamily &&
+      _listEquals(other.fontFamilyFallback, fontFamilyFallback) &&
+      other.metrics == metrics &&
+      other.devicePixelRatio == devicePixelRatio;
+
+  static bool _listEquals(List<String> a, List<String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+
+class _GlyphAtlasEntry {
+  final GlyphAtlas atlas;
+  var references = 0;
+
+  _GlyphAtlasEntry(this.atlas);
+}

--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -3,7 +3,6 @@ import 'package:flutter/widgets.dart';
 import 'package:libghostty/libghostty.dart';
 
 import '../foundation.dart';
-import 'atlas/glyph_atlas.dart';
 import 'atlas/sprite_buffer.dart';
 import 'kitty_image_cache.dart';
 import 'paint_state.dart';
@@ -15,6 +14,7 @@ import 'painters/kitty_graphics_painter.dart';
 import 'painters/terminal_text_painter.dart';
 import 'painters/underline_painter.dart';
 import 'sprite_builder.dart';
+import 'terminal_render_cache.dart';
 
 /// Pre-fetched cell data at the cursor position.
 ///
@@ -98,6 +98,9 @@ class TerminalRenderer extends LeafRenderObjectWidget {
   /// backend (PTY, SSH) of the new dimensions.
   final OnResize? onResize;
 
+  /// Internal render cache used to share compatible atlas state.
+  final TerminalRenderCache renderCache;
+
   const TerminalRenderer({
     super.key,
     required this.terminal,
@@ -105,6 +108,7 @@ class TerminalRenderer extends LeafRenderObjectWidget {
     required this.metrics,
     required this.offset,
     required this.renderObserver,
+    required this.renderCache,
     this.blinkVisible = true,
     this.onResize,
   });
@@ -116,6 +120,7 @@ class TerminalRenderer extends LeafRenderObjectWidget {
       offset: offset,
       metrics: metrics,
       terminal: terminal,
+      renderCache: renderCache,
       onResize: onResize,
       blinkVisible: blinkVisible,
       renderObserver: renderObserver,
@@ -153,6 +158,7 @@ class TerminalRenderer extends LeafRenderObjectWidget {
     renderObject
       ..terminal = terminal
       ..theme = theme
+      ..renderCache = renderCache
       ..offset = offset
       ..metrics = metrics
       ..onResize = onResize
@@ -186,6 +192,8 @@ class TerminalRenderBox extends RenderBox {
   ViewportOffset _offset;
   TerminalRenderObserver _renderObserver;
   OnResize? _onResize;
+  TerminalRenderCache _renderCache;
+  late TerminalGlyphAtlasHandle _atlasHandle;
   var _performingLayout = false;
   var _needsContentSync = false;
   var _stickToBottom = true;
@@ -193,16 +201,15 @@ class TerminalRenderBox extends RenderBox {
   var _lastCursor = const Cursor();
   CursorCell? _lastCursorCell;
 
-  late final GlyphAtlas _atlas;
   late final SpriteBuffer _sprites;
-  late final SpriteBuilder _spriteBuilder;
+  late SpriteBuilder _spriteBuilder;
   final _renderState = RenderState();
 
-  late final EmojiPainter _emojiPainter;
-  late final CursorPainter _cursorPainter;
+  late EmojiPainter _emojiPainter;
+  late CursorPainter _cursorPainter;
+  late TerminalTextPainter _textPainter;
+  late UnderlinePainter _underlinePainter;
   late final TerminalPaintState _paintState;
-  late final TerminalTextPainter _textPainter;
-  late final UnderlinePainter _underlinePainter;
   late final BackgroundPainter _backgroundPainter;
   late final DecorationPainter _decorationPainter;
   late final KittyImageCache _kittyImageCache;
@@ -217,31 +224,29 @@ class TerminalRenderBox extends RenderBox {
     required CellMetrics metrics,
     required ViewportOffset offset,
     required TerminalRenderObserver renderObserver,
+    required TerminalRenderCache renderCache,
     bool blinkVisible = true,
     OnResize? onResize,
   }) : _terminal = terminal,
        _offset = offset,
        _onResize = onResize,
-       _renderObserver = renderObserver {
+       _renderObserver = renderObserver,
+       _renderCache = renderCache {
     _paintState = TerminalPaintState(theme, metrics)
       ..blinkVisible = blinkVisible
       ..selection = renderObserver.selection
       ..cursorFocused = renderObserver.hasFocus;
-    _atlas = GlyphAtlas(
-      fontSize: theme.fontSize,
-      fontWeight: theme.fontWeight,
-      fontFamily: theme.fontFamily,
-      fontFamilyFallback: theme.fontFamilyFallback,
+    _atlasHandle = _renderCache.acquireGlyphAtlas(
+      .fromTheme(
+        theme: theme,
+        metrics: metrics,
+        devicePixelRatio: _currentDevicePixelRatio,
+      ),
     );
-
     _sprites = SpriteBuffer();
-    _spriteBuilder = SpriteBuilder(_atlas, _sprites, _paintState);
-    _backgroundPainter = BackgroundPainter(_paintState, _sprites);
-    _textPainter = TerminalTextPainter(_atlas, _sprites.wide, _sprites.regular);
-    _cursorPainter = CursorPainter(_paintState, _atlas);
-    _emojiPainter = EmojiPainter(_atlas, _sprites);
-    _underlinePainter = UnderlinePainter(_atlas, _sprites);
+    _bindAtlasDependents();
     _decorationPainter = DecorationPainter(_sprites);
+    _backgroundPainter = BackgroundPainter(_paintState, _sprites);
     _kittyImageCache = KittyImageCache(onImageReady: markNeedsPaint);
     _kittyBelowBgPainter = KittyGraphicsPainter(
       state: _paintState,
@@ -280,7 +285,6 @@ class TerminalRenderBox extends RenderBox {
   set metrics(CellMetrics value) {
     if (_paintState.metrics == value) return;
     _paintState.metrics = value;
-    _atlas.clear();
     markNeedsLayout();
   }
 
@@ -300,6 +304,17 @@ class TerminalRenderBox extends RenderBox {
     _renderObserver = value;
     if (attached) _renderObserver.addListener(_onRenderObserverChanged);
     _onRenderObserverChanged();
+  }
+
+  set renderCache(TerminalRenderCache value) {
+    if (identical(value, _renderCache)) return;
+
+    _renderCache = value;
+    final atlasChanged = _acquireAtlasForCurrentConfig(force: true);
+    if (atlasChanged) {
+      _spriteBuilder.dirtyRows.markAll();
+      _markTerminalDirty();
+    }
   }
 
   set terminal(Terminal value) {
@@ -322,12 +337,12 @@ class TerminalRenderBox extends RenderBox {
   /// the grid, and pre-seeds glyphs.
   set theme(TerminalTheme value) {
     if (_paintState.theme == value) return;
-    final fontChanged = _atlas.updateFont(
-      fontSize: value.fontSize,
-      fontWeight: value.fontWeight,
-      fontFamily: value.fontFamily,
-      fontFamilyFallback: value.fontFamilyFallback,
-    );
+    final oldTheme = _paintState.theme;
+    final fontChanged =
+        oldTheme.fontSize != value.fontSize ||
+        oldTheme.fontWeight != value.fontWeight ||
+        oldTheme.fontFamily != value.fontFamily ||
+        !_listEquals(oldTheme.fontFamilyFallback, value.fontFamilyFallback);
     _paintState.updateTheme(value);
     _applyThemeColors();
     _needsContentSync = true;
@@ -387,13 +402,13 @@ class TerminalRenderBox extends RenderBox {
 
   @override
   void dispose() {
-    _atlas.dispose();
     _kittyImageCache.dispose();
     _paintState.rows = 0;
     _paintState.cols = 0;
     _spriteBuilder.dispose();
     _sprites.dispose();
     _renderState.dispose();
+    _atlasHandle.release();
     super.dispose();
   }
 
@@ -439,12 +454,8 @@ class TerminalRenderBox extends RenderBox {
       ),
     );
 
-    final dpr =
-        WidgetsBinding.instance.platformDispatcher.views.first.devicePixelRatio;
-    final atlasReconfigured = _atlas.configure(
-      dpr: dpr,
-      metrics: _paintState.metrics,
-    );
+    final dpr = _currentDevicePixelRatio;
+    final atlasReconfigured = _acquireAtlasForCurrentConfig(dpr: dpr);
 
     final gridChanged =
         newCols != _paintState.cols || newRows != _paintState.rows;
@@ -493,6 +504,55 @@ class TerminalRenderBox extends RenderBox {
     _terminal.palette = [
       for (var i = 0; i < 256; i++) _paintState.theme.palette[i].toRgbColor(),
     ];
+  }
+
+  bool _acquireAtlasForCurrentConfig({double? dpr, bool force = false}) {
+    final key = TerminalRenderCacheKey.fromTheme(
+      theme: _paintState.theme,
+      metrics: _paintState.metrics,
+      devicePixelRatio: dpr ?? _currentDevicePixelRatio,
+    );
+    if (!force && key == _atlasHandle.key) return false;
+
+    final previousHandle = _atlasHandle;
+    final previousBuilder = _spriteBuilder;
+
+    _atlasHandle = _renderCache.acquireGlyphAtlas(key);
+    _bindAtlasDependents();
+    if (_paintState.rows > 0 && _paintState.cols > 0) {
+      _spriteBuilder.configure(_paintState.rows, _paintState.cols);
+    }
+
+    previousBuilder.dispose();
+    previousHandle.release();
+    return true;
+  }
+
+  void _bindAtlasDependents() {
+    final atlas = _atlasHandle.atlas;
+    _spriteBuilder = SpriteBuilder(atlas, _sprites, _paintState);
+    _textPainter = TerminalTextPainter(atlas, _sprites.wide, _sprites.regular);
+    _cursorPainter = CursorPainter(_paintState, atlas);
+    _emojiPainter = EmojiPainter(atlas, _sprites);
+    _underlinePainter = UnderlinePainter(atlas, _sprites);
+  }
+
+  double get _currentDevicePixelRatio {
+    return WidgetsBinding
+        .instance
+        .platformDispatcher
+        .views
+        .first
+        .devicePixelRatio;
+  }
+
+  static bool _listEquals(List<String> a, List<String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   void _markTerminalDirty() {
@@ -648,14 +708,14 @@ class TerminalRenderBox extends RenderBox {
     }
     final runes = cell.content.runes;
     if (runes.length == 1) {
-      _paintState.cursorGlyphEntry = _atlas.addCodepoint(
+      _paintState.cursorGlyphEntry = _atlasHandle.atlas.addCodepoint(
         runes.first,
         bold: style.bold,
         italic: style.italic,
         span: cell.wide ? 2 : 1,
       );
     } else {
-      _paintState.cursorGlyphEntry = _atlas.add((
+      _paintState.cursorGlyphEntry = _atlasHandle.atlas.add((
         text: cell.content,
         bold: style.bold,
         italic: style.italic,

--- a/packages/flterm/lib/src/widgets.dart
+++ b/packages/flterm/lib/src/widgets.dart
@@ -3,6 +3,7 @@ export 'widgets/terminal_controller_impl.dart';
 export 'widgets/terminal_gesture_detector.dart';
 export 'widgets/terminal_input_client.dart';
 export 'widgets/terminal_raw_gesture_detector.dart';
+export 'widgets/terminal_scope.dart';
 export 'widgets/terminal_scroll_controller.dart';
 export 'widgets/terminal_shortcut_scope.dart';
 export 'widgets/terminal_view.dart';

--- a/packages/flterm/lib/src/widgets/terminal_scope.dart
+++ b/packages/flterm/lib/src/widgets/terminal_scope.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/widgets.dart';
+
+import '../rendering/terminal_render_cache.dart';
+
+TerminalRenderCache? terminalScopeRenderCacheOf(BuildContext context) {
+  return context
+      .dependOnInheritedWidgetOfExactType<_TerminalScopeInherited>()
+      ?.renderCache;
+}
+
+/// Shares terminal resources across descendant [TerminalView] widgets.
+///
+/// Wrapping multiple terminals in the same scope lets compatible renderers
+/// reuse expensive internal caches. Terminals outside a scope create an
+/// isolated local scope automatically.
+class TerminalScope extends StatefulWidget {
+  final Widget child;
+
+  const TerminalScope({super.key, required this.child});
+
+  @override
+  State<TerminalScope> createState() => _TerminalScopeState();
+}
+
+class _TerminalScopeState extends State<TerminalScope> {
+  final _renderCache = TerminalRenderCache();
+
+  @override
+  Widget build(BuildContext context) {
+    return _TerminalScopeInherited(
+      renderCache: _renderCache,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _renderCache.dispose();
+    super.dispose();
+  }
+}
+
+class _TerminalScopeInherited extends InheritedWidget {
+  final TerminalRenderCache renderCache;
+
+  const _TerminalScopeInherited({
+    required this.renderCache,
+    required super.child,
+  });
+
+  @override
+  bool updateShouldNotify(_TerminalScopeInherited oldWidget) {
+    return !identical(renderCache, oldWidget.renderCache);
+  }
+}

--- a/packages/flterm/lib/src/widgets/terminal_view.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view.dart
@@ -5,8 +5,10 @@ import 'package:flutter/widgets.dart';
 
 import '../foundation.dart';
 import '../rendering.dart';
+import '../rendering/terminal_render_cache.dart';
 import 'terminal_controller.dart';
 import 'terminal_gesture_detector.dart';
+import 'terminal_scope.dart';
 import 'terminal_scroll_controller.dart';
 import 'terminal_shortcut_scope.dart';
 import 'terminal_view_binding.dart';
@@ -144,60 +146,21 @@ class _TerminalViewState extends State<TerminalView> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: .translucent,
-      onTap: _controller.requestFocus,
-      child: ColoredBox(
-        // Backdrop tinted by backgroundOpacity. The repaint boundary
-        // TerminalRenderBox skips its own grid fill below 1.0 and
-        // relies on this as the sole tint source, so default background
-        // cells show through to whatever sits behind the widget without
-        // composing twice across the two layers.
-        color: _theme.background.withValues(alpha: _theme.backgroundOpacity),
-        child: Padding(
-          padding: widget.padding,
-          child: Focus(
-            onKeyEvent: _handleKeyEvent,
-            child: TerminalShortcutScope(
-              onPaste: _handlePaste,
-              controller: _controller,
-              shortcuts: widget.shortcuts,
-              enableSelectAll: widget.gestureSettings.enabledSelections
-                  .contains(SelectionGesture.selectAll),
-              child: MouseRegion(
-                onHover: _handleMouseHover,
-                cursor: _effectiveMouseCursor(),
-                child: Focus(
-                  focusNode: _focusNode,
-                  autofocus: widget.autofocus,
-                  onFocusChange: _handleFocusChange,
-                  child: TerminalGestureDetector(
-                    metrics: _metrics,
-                    binding: _binding,
-                    visibleRows: _visibleRows,
-                    settings: widget.gestureSettings,
-                    scrollController: _scrollController,
-                    child: Scrollable(
-                      controller: _scrollController,
-                      physics: widget.scrollPhysics,
-                      viewportBuilder: (_, offset) => TerminalRenderer(
-                        theme: _theme,
-                        offset: offset,
-                        metrics: _metrics,
-                        renderObserver: _controller,
-                        terminal: _binding.terminal,
-                        blinkVisible: _blinkVisible,
-                        onResize: _handleResize,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
+    final cache = terminalScopeRenderCacheOf(context);
+    if (cache != null) return _build(context, cache);
+
+    return TerminalScope(
+      child: Builder(
+        builder: (context) =>
+            _build(context, terminalScopeRenderCacheOf(context)!),
       ),
     );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
   }
 
   @override
@@ -303,10 +266,62 @@ class _TerminalViewState extends State<TerminalView> {
     _controller.addListener(_onControllerChanged);
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+  Widget _build(BuildContext context, TerminalRenderCache cache) {
+    return GestureDetector(
+      behavior: .translucent,
+      onTap: _controller.requestFocus,
+      child: ColoredBox(
+        // Backdrop tinted by backgroundOpacity. The repaint boundary
+        // TerminalRenderBox skips its own grid fill below 1.0 and
+        // relies on this as the sole tint source, so default background
+        // cells show through to whatever sits behind the widget without
+        // composing twice across the two layers.
+        color: _theme.background.withValues(alpha: _theme.backgroundOpacity),
+        child: Padding(
+          padding: widget.padding,
+          child: Focus(
+            onKeyEvent: _handleKeyEvent,
+            child: TerminalShortcutScope(
+              onPaste: _handlePaste,
+              controller: _controller,
+              shortcuts: widget.shortcuts,
+              enableSelectAll: widget.gestureSettings.enabledSelections
+                  .contains(SelectionGesture.selectAll),
+              child: MouseRegion(
+                onHover: _handleMouseHover,
+                cursor: _effectiveMouseCursor(),
+                child: Focus(
+                  focusNode: _focusNode,
+                  autofocus: widget.autofocus,
+                  onFocusChange: _handleFocusChange,
+                  child: TerminalGestureDetector(
+                    metrics: _metrics,
+                    binding: _binding,
+                    visibleRows: _visibleRows,
+                    settings: widget.gestureSettings,
+                    scrollController: _scrollController,
+                    child: Scrollable(
+                      controller: _scrollController,
+                      physics: widget.scrollPhysics,
+                      viewportBuilder: (_, offset) => TerminalRenderer(
+                        theme: _theme,
+                        offset: offset,
+                        metrics: _metrics,
+                        renderObserver: _controller,
+                        terminal: _binding.terminal,
+                        renderCache: cache,
+                        blinkVisible: _blinkVisible,
+                        onResize: _handleResize,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   MouseCursor _effectiveMouseCursor() {

--- a/packages/flterm/test/rendering/cursor_layer_test.dart
+++ b/packages/flterm/test/rendering/cursor_layer_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -317,12 +318,19 @@ Future<void> _pumpRenderer(
             metrics: metrics,
             terminal: terminal,
             offset: ViewportOffset.zero(),
+            renderCache: _renderCache(),
             renderObserver: _TestRenderObserver(),
           ),
         ),
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
 }
 
 class _TestRenderObserver implements TerminalRenderObserver {

--- a/packages/flterm/test/rendering/emoji_golden_test.dart
+++ b/packages/flterm/test/rendering/emoji_golden_test.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -421,6 +422,7 @@ Future<void> _pumpRenderer(
             theme: resolvedTheme,
             metrics: metrics,
             offset: ViewportOffset.zero(),
+            renderCache: _renderCache(),
             renderObserver: _TestRenderObserver(
               selection: selection,
               hasFocus: focused,
@@ -430,6 +432,12 @@ Future<void> _pumpRenderer(
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
 }
 
 class _TestRenderObserver implements TerminalRenderObserver {

--- a/packages/flterm/test/rendering/sprites_golden_test.dart
+++ b/packages/flterm/test/rendering/sprites_golden_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
 import 'package:flterm/src/rendering/sprite/sprite_face.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -313,11 +314,18 @@ Widget _wrap(
           theme: theme,
           metrics: metrics,
           offset: ViewportOffset.zero(),
+          renderCache: _renderCache(),
           renderObserver: const _TestRenderObserver(),
         ),
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
 }
 
 class _TestRenderObserver implements TerminalRenderObserver {

--- a/packages/flterm/test/rendering/terminal_render_cache_test.dart
+++ b/packages/flterm/test/rendering/terminal_render_cache_test.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TerminalRenderCache', () {
+    test('shares glyph atlas for matching keys', () {
+      final cache = TerminalRenderCache();
+      addTearDown(cache.dispose);
+
+      final first = cache.acquireGlyphAtlas(_key());
+      final second = cache.acquireGlyphAtlas(_key());
+      addTearDown(second.release);
+      addTearDown(first.release);
+
+      expect(second.atlas, same(first.atlas));
+    });
+
+    test('keeps atlas alive until the last handle is released', () {
+      final cache = TerminalRenderCache();
+      addTearDown(cache.dispose);
+
+      final first = cache.acquireGlyphAtlas(_key());
+      final second = cache.acquireGlyphAtlas(_key());
+      final atlas = first.atlas;
+
+      first.release();
+      expect(atlas.image, isNotNull);
+
+      second.release();
+      expect(atlas.image, isNull);
+    });
+
+    test('does not share glyph atlas across font-affecting keys', () {
+      final cache = TerminalRenderCache();
+      addTearDown(cache.dispose);
+
+      final first = cache.acquireGlyphAtlas(_key());
+      final second = cache.acquireGlyphAtlas(_key(fontSize: 16));
+      addTearDown(second.release);
+      addTearDown(first.release);
+
+      expect(second.atlas, isNot(same(first.atlas)));
+    });
+  });
+}
+
+TerminalRenderCacheKey _key({double fontSize = 14}) {
+  return TerminalRenderCacheKey(
+    fontSize: fontSize,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'monospace',
+    fontFamilyFallback: const [],
+    metrics: const CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12),
+    devicePixelRatio: 1.0,
+  );
+}

--- a/packages/flterm/test/rendering/terminal_renderer_golden_test.dart
+++ b/packages/flterm/test/rendering/terminal_renderer_golden_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -874,6 +875,7 @@ Widget _wrap(
               ),
           metrics: metrics,
           offset: ViewportOffset.zero(),
+          renderCache: _renderCache(),
           renderObserver: _TestRenderObserver(
             selection: selection,
             hasFocus: focused,
@@ -884,6 +886,12 @@ Widget _wrap(
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
 }
 
 class _TestRenderObserver implements TerminalRenderObserver {

--- a/packages/flterm/test/rendering/terminal_renderer_test.dart
+++ b/packages/flterm/test/rendering/terminal_renderer_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -75,15 +76,36 @@ void main() {
     });
 
     testWidgets('theme change triggers layout', (tester) async {
-      await tester.pumpWidget(_wrap(terminal));
+      final renderCache = _TrackingRenderCache();
+      addTearDown(renderCache.dispose);
+      await tester.pumpWidget(_wrap(terminal, renderCache: renderCache));
       final box = tester.renderObject<TerminalRenderBox>(
         find.byType(TerminalRenderer),
       );
       expect(box.theme, TerminalTheme.dark());
+      final acquisitionsBefore = renderCache.acquiredKeys.length;
 
       final light = TerminalTheme.light();
-      await tester.pumpWidget(_wrap(terminal, theme: light));
+      await tester.pumpWidget(
+        _wrap(terminal, theme: light, renderCache: renderCache),
+      );
       expect(box.theme, light);
+      expect(renderCache.acquiredKeys, hasLength(acquisitionsBefore));
+    });
+
+    testWidgets('font theme change reacquires atlas', (tester) async {
+      final renderCache = _TrackingRenderCache();
+      addTearDown(renderCache.dispose);
+      await tester.pumpWidget(_wrap(terminal, renderCache: renderCache));
+      final keyBefore = renderCache.acquiredKeys.last;
+
+      final larger = TerminalTheme.dark().copyWith(fontSize: 18);
+      await tester.pumpWidget(
+        _wrap(terminal, theme: larger, renderCache: renderCache),
+      );
+      await tester.pump();
+
+      expect(renderCache.acquiredKeys.last, isNot(keyBefore));
     });
 
     testWidgets('selection change does not trigger layout', (tester) async {
@@ -157,7 +179,9 @@ Widget _wrap(
   bool focused = true,
   bool blinkVisible = true,
   OnResize? onResize,
+  TerminalRenderCache? renderCache,
 }) {
+  renderCache ??= _renderCache();
   final width = maxWidth ?? _cols * metrics.cellWidth;
   final height = maxHeight ?? _rows * metrics.cellHeight;
   return Directionality(
@@ -171,6 +195,7 @@ Widget _wrap(
           theme: theme ?? TerminalTheme.dark(),
           metrics: metrics,
           offset: ViewportOffset.zero(),
+          renderCache: renderCache,
           renderObserver: _TestRenderObserver(
             selection: selection,
             hasFocus: focused,
@@ -181,6 +206,22 @@ Widget _wrap(
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
+}
+
+class _TrackingRenderCache extends TerminalRenderCache {
+  final acquiredKeys = <TerminalRenderCacheKey>[];
+
+  @override
+  TerminalGlyphAtlasHandle acquireGlyphAtlas(TerminalRenderCacheKey key) {
+    acquiredKeys.add(key);
+    return super.acquireGlyphAtlas(key);
+  }
 }
 
 class _TestRenderObserver implements TerminalRenderObserver {

--- a/packages/flterm/test/rendering/transparent_background_golden_test.dart
+++ b/packages/flterm/test/rendering/transparent_background_golden_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -130,6 +131,7 @@ Future<void> _pumpScene(
                   theme: theme,
                   metrics: _metrics,
                   offset: ViewportOffset.zero(),
+                  renderCache: _renderCache(),
                   renderObserver: const _Observer(),
                 ),
               ),
@@ -139,6 +141,12 @@ Future<void> _pumpScene(
       ),
     ),
   );
+}
+
+TerminalRenderCache _renderCache() {
+  final cache = TerminalRenderCache();
+  addTearDown(cache.dispose);
+  return cache;
 }
 
 class _Observer implements TerminalRenderObserver {

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering.dart';
 import 'package:flterm/src/widgets.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/gestures.dart';
@@ -20,6 +21,40 @@ void main() {
     testWidgets('renders with controller', (tester) async {
       await tester.pumpWidget(_wrapInApp(controller: controller));
       expect(find.byType(TerminalView), findsOneWidget);
+    });
+
+    testWidgets('creates an isolated render cache without explicit scope', (
+      tester,
+    ) async {
+      final controller2 = TerminalController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(
+        _wrapSplitTerminals(controller: controller, controller2: controller2),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TerminalRenderer), findsNWidgets(2));
+      expect(find.byType(TerminalScope), findsNWidgets(2));
+    });
+
+    testWidgets('uses explicit TerminalScope for descendant terminals', (
+      tester,
+    ) async {
+      final controller2 = TerminalController();
+      addTearDown(controller2.dispose);
+
+      await tester.pumpWidget(
+        _wrapSplitTerminals(
+          controller: controller,
+          controller2: controller2,
+          scoped: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TerminalRenderer), findsNWidgets(2));
+      expect(find.byType(TerminalScope), findsOneWidget);
     });
 
     testWidgets('onResize fires with dimensions from layout', (tester) async {
@@ -737,6 +772,32 @@ Widget _wrapInApp({
           gestureSettings: gestureSettings,
           padding: padding,
         ),
+      ),
+    ),
+  );
+}
+
+Widget _wrapSplitTerminals({
+  required TerminalController controller,
+  required TerminalController controller2,
+  bool scoped = false,
+}) {
+  final terminals = Column(
+    children: [
+      Expanded(
+        child: TerminalView(controller: controller, padding: EdgeInsets.zero),
+      ),
+      Expanded(
+        child: TerminalView(controller: controller2, padding: EdgeInsets.zero),
+      ),
+    ],
+  );
+  return MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        width: 800,
+        height: 480,
+        child: scoped ? TerminalScope(child: terminals) : terminals,
       ),
     ),
   );


### PR DESCRIPTION
Add `TerminalScope` and a scoped terminal render cache so compatible terminal views can share glyph atlas resources while each view still releases its cache handle on disposal or configuration changes.