### PR TITLE
refactor(flterm): split atlas responsibilities

### DIFF
--- a/packages/flterm/lib/src/rendering/atlas/glyph_atlas.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_atlas.dart
@@ -1,13 +1,14 @@
-import 'dart:ui' show FontWeight, Image;
+import 'dart:ui' show Image;
 
 import 'package:libghostty/libghostty.dart';
 
-import '../../foundation.dart';
 import 'glyph_atlas_cache.dart';
+import 'glyph_atlas_config.dart';
 import 'glyph_entry.dart';
 import 'glyph_rasterizer.dart';
 
 export 'glyph_atlas_cache.dart' show TextGlyphKey;
+export 'glyph_atlas_config.dart';
 export 'glyph_entry.dart';
 
 /// Glyph cache backed by a [GlyphRasterizer] atlas texture.
@@ -18,59 +19,27 @@ export 'glyph_entry.dart';
 /// bold/italic combination, the entire built-in sprite registry, and every
 /// underline decoration style.
 ///
-/// Lifecycle: construct, [configure] with DPR and cell dimensions,
-/// [addText]/[addEmoji]/[addCodepoint] per frame, [ensureImage] to
-/// composite pending glyphs, [updateFont] on theme change, [dispose] when
-/// detached.
+/// Lifecycle: construct with a [GlyphAtlasConfig],
+/// [addText]/[addEmoji]/[addCodepoint] per frame, [ensureImage] to composite
+/// pending glyphs, [dispose] when detached.
 class GlyphAtlas {
   final _rasterizer = GlyphRasterizer();
   late final _cache = GlyphAtlasCache(_rasterizer);
 
-  double _fontSize;
-  String _fontFamily;
-  FontWeight _fontWeight;
-  List<String> _fontFamilyFallback;
-  var _dpr = 1.0;
-  var _metrics = const CellMetrics(cellWidth: 0, cellHeight: 0, baseline: 0);
+  final GlyphAtlasConfig _config;
 
-  GlyphAtlas({
-    required double fontSize,
-    required String fontFamily,
-    required List<String> fontFamilyFallback,
-    FontWeight fontWeight = FontWeight.normal,
-  }) : _fontSize = fontSize,
-       _fontFamily = fontFamily,
-       _fontWeight = fontWeight,
-       _fontFamilyFallback = fontFamilyFallback;
+  GlyphAtlas(this._config) {
+    _rasterizer.configure(_config);
+    if (_config.metrics.cellWidth > 0 && _config.metrics.cellHeight > 0) {
+      _preseed();
+    }
+  }
 
   int get cacheSize => _cache.size;
 
-  double get devicePixelRatio => _dpr;
+  double get devicePixelRatio => _config.devicePixelRatio;
 
   Image? get image => _rasterizer.image;
-
-  /// Whether [codepoint] has a built-in sprite glyph.
-  ///
-  /// Sprite codepoints render from geometry regardless of how libghostty
-  /// classifies the cell (wide, emoji, etc.). Callers route through
-  /// [addCodepoint] to retrieve the entry; this predicate lets callers
-  /// pick the right output channel before calling.
-  bool hasSprite(int codepoint) => _cache.hasSprite(codepoint);
-
-  /// Returns or creates a text glyph for [key].
-  GlyphEntry addText(TextGlyphKey key, {int span = 1}) =>
-      _cache.addText(key, span: span);
-
-  /// Returns or creates an emoji glyph for [key].
-  ///
-  /// Shares the same cache slot as [addText] for matching
-  /// `(text, bold, italic, span)`: classification of a given grapheme is
-  /// consistent within a frame, so the first writer wins and later
-  /// callers reuse the same atlas region. This is what lets the cursor
-  /// reuse the cell's atlas slot instead of rasterizing a duplicate that
-  /// wouldn't be composited yet.
-  GlyphEntry addEmoji(TextGlyphKey key, {int span = 1}) =>
-      _cache.addEmoji(key, span: span);
 
   /// Dispatches to [addEmoji] when [emoji] is true, otherwise [addText].
   ///
@@ -96,22 +65,20 @@ class GlyphAtlas {
   /// Returns or creates a decoration sprite for the given underline [style].
   GlyphEntry addDecoration(UnderlineStyle style) => _cache.addDecoration(style);
 
-  void clear() {
-    _cache.clear();
-    _rasterizer.clear();
-  }
-
-  /// Sets DPR and cell dimensions. Returns true if changed.
+  /// Returns or creates an emoji glyph for [key].
   ///
-  /// Clears all cached glyphs and pre-seeds the ASCII and box-drawing
-  /// ranges when any parameter differs from the current configuration.
-  bool configure({required double dpr, required CellMetrics metrics}) {
-    if (dpr == _dpr && metrics == _metrics) return false;
-    _dpr = dpr;
-    _metrics = metrics;
-    _reconfigure();
-    return true;
-  }
+  /// Shares the same cache slot as [addText] for matching
+  /// `(text, bold, italic, span)`: classification of a given grapheme is
+  /// consistent within a frame, so the first writer wins and later
+  /// callers reuse the same atlas region. This is what lets the cursor
+  /// reuse the cell's atlas slot instead of rasterizing a duplicate that
+  /// wouldn't be composited yet.
+  GlyphEntry addEmoji(TextGlyphKey key, {int span = 1}) =>
+      _cache.addEmoji(key, span: span);
+
+  /// Returns or creates a text glyph for [key].
+  GlyphEntry addText(TextGlyphKey key, {int span = 1}) =>
+      _cache.addText(key, span: span);
 
   void dispose() {
     _cache.clear();
@@ -121,28 +88,13 @@ class GlyphAtlas {
   /// Composites pending glyphs into the atlas texture.
   void ensureImage() => _rasterizer.ensureImage();
 
-  /// Updates the font and clears the atlas if changed.
+  /// Whether [codepoint] has a built-in sprite glyph.
   ///
-  /// Returns true if the font was actually different and the atlas was cleared.
-  bool updateFont({
-    required double fontSize,
-    required String fontFamily,
-    required FontWeight fontWeight,
-    required List<String> fontFamilyFallback,
-  }) {
-    if (fontSize == _fontSize &&
-        fontWeight == _fontWeight &&
-        fontFamily == _fontFamily &&
-        _listEquals(_fontFamilyFallback, fontFamilyFallback)) {
-      return false;
-    }
-    _fontSize = fontSize;
-    _fontFamily = fontFamily;
-    _fontWeight = fontWeight;
-    _fontFamilyFallback = fontFamilyFallback;
-    _reconfigure();
-    return true;
-  }
+  /// Sprite codepoints render from geometry regardless of how libghostty
+  /// classifies the cell (wide, emoji, etc.). Callers route through
+  /// [addCodepoint] to retrieve the entry; this predicate lets callers
+  /// pick the right output channel before calling.
+  bool hasSprite(int codepoint) => _cache.hasSprite(codepoint);
 
   /// Pre-seeds the atlas with glyphs that will almost certainly be needed.
   ///
@@ -175,29 +127,5 @@ class GlyphAtlas {
     }
 
     ensureImage();
-  }
-
-  /// Applies current font/metrics to the rasterizer, clears all caches,
-  /// and pre-seeds if valid dimensions are available.
-  void _reconfigure() {
-    _rasterizer.configure(
-      fontSize: _fontSize,
-      fontWeight: _fontWeight,
-      fontFamily: _fontFamily,
-      fontFamilyFallback: _fontFamilyFallback,
-      metrics: _metrics,
-      dpr: _dpr,
-    );
-    clear();
-    if (_metrics.cellWidth > 0 && _metrics.cellHeight > 0) _preseed();
-  }
-
-  static bool _listEquals(List<String> a, List<String> b) {
-    if (identical(a, b)) return true;
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
   }
 }

--- a/packages/flterm/lib/src/rendering/atlas/glyph_atlas.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_atlas.dart
@@ -3,24 +3,12 @@ import 'dart:ui' show FontWeight, Image;
 import 'package:libghostty/libghostty.dart';
 
 import '../../foundation.dart';
-import '../sprite/sprite_face.dart';
+import 'glyph_atlas_cache.dart';
 import 'glyph_entry.dart';
 import 'glyph_rasterizer.dart';
 
+export 'glyph_atlas_cache.dart' show TextGlyphKey;
 export 'glyph_entry.dart';
-
-/// Lookup key for a cached glyph. Two glyphs with the same text, bold,
-/// and italic state share the same atlas entry.
-typedef TextGlyphKey = ({String text, bool bold, bool italic});
-
-typedef _GlyphCacheKey = ({String text, bool bold, bool italic, int span});
-typedef _CodepointGlyphKey = ({
-  int codepoint,
-  bool bold,
-  bool italic,
-  int span,
-});
-typedef _SpriteKey = ({int codepoint, int span});
 
 /// Glyph cache backed by a [GlyphRasterizer] atlas texture.
 ///
@@ -35,12 +23,8 @@ typedef _SpriteKey = ({int codepoint, int span});
 /// composite pending glyphs, [updateFont] on theme change, [dispose] when
 /// detached.
 class GlyphAtlas {
-  final Map<_GlyphCacheKey, GlyphEntry> _glyphs = {};
-  final Map<UnderlineStyle, GlyphEntry> _decorations = {};
-  final Map<_SpriteKey, GlyphEntry> _spriteCodepoints = {};
-  final Map<_CodepointGlyphKey, GlyphEntry> _codepoints = {};
   final _rasterizer = GlyphRasterizer();
-  final _spriteFace = SpriteFace();
+  late final _cache = GlyphAtlasCache(_rasterizer);
 
   double _fontSize;
   String _fontFamily;
@@ -59,7 +43,7 @@ class GlyphAtlas {
        _fontWeight = fontWeight,
        _fontFamilyFallback = fontFamilyFallback;
 
-  int get cacheSize => _glyphs.length + _spriteCodepoints.length;
+  int get cacheSize => _cache.size;
 
   double get devicePixelRatio => _dpr;
 
@@ -71,23 +55,11 @@ class GlyphAtlas {
   /// classifies the cell (wide, emoji, etc.). Callers route through
   /// [addCodepoint] to retrieve the entry; this predicate lets callers
   /// pick the right output channel before calling.
-  bool hasSprite(int codepoint) => _spriteFace.hasCodepoint(codepoint);
+  bool hasSprite(int codepoint) => _cache.hasSprite(codepoint);
 
   /// Returns or creates a text glyph for [key].
-  GlyphEntry addText(TextGlyphKey key, {int span = 1}) {
-    final cacheKey = (
-      text: key.text,
-      bold: key.bold,
-      italic: key.italic,
-      span: span,
-    );
-    return _glyphs[cacheKey] ??= _rasterizer.rasterizeText(
-      key.text,
-      bold: key.bold,
-      italic: key.italic,
-      span: span,
-    );
-  }
+  GlyphEntry addText(TextGlyphKey key, {int span = 1}) =>
+      _cache.addText(key, span: span);
 
   /// Returns or creates an emoji glyph for [key].
   ///
@@ -97,28 +69,15 @@ class GlyphAtlas {
   /// callers reuse the same atlas region. This is what lets the cursor
   /// reuse the cell's atlas slot instead of rasterizing a duplicate that
   /// wouldn't be composited yet.
-  GlyphEntry addEmoji(TextGlyphKey key, {int span = 1}) {
-    final cacheKey = (
-      text: key.text,
-      bold: key.bold,
-      italic: key.italic,
-      span: span,
-    );
-    return _glyphs[cacheKey] ??= _rasterizer.rasterizeEmoji(
-      key.text,
-      bold: key.bold,
-      italic: key.italic,
-      span: span,
-    );
-  }
+  GlyphEntry addEmoji(TextGlyphKey key, {int span = 1}) =>
+      _cache.addEmoji(key, span: span);
 
   /// Dispatches to [addEmoji] when [emoji] is true, otherwise [addText].
   ///
   /// Convenience for call sites that classify text vs. emoji at runtime
   /// (e.g. wide-cell dispatch) and want to defer the branch to the atlas.
-  GlyphEntry add(TextGlyphKey key, {int span = 1, bool emoji = false}) {
-    return emoji ? addEmoji(key, span: span) : addText(key, span: span);
-  }
+  GlyphEntry add(TextGlyphKey key, {int span = 1, bool emoji = false}) =>
+      _cache.add(key, span: span, emoji: emoji);
 
   /// Returns or creates a glyph for a single [codepoint].
   ///
@@ -132,44 +91,13 @@ class GlyphAtlas {
     required bool bold,
     required bool italic,
     int span = 1,
-  }) {
-    final glyph = _spriteFace.glyphFor(codepoint);
-    if (glyph != null) {
-      final spriteKey = (codepoint: codepoint, span: span);
-      return _spriteCodepoints[spriteKey] ??= _rasterizer.rasterizeSprite(
-        glyph,
-        span: span,
-      );
-    }
-
-    final codepointKey = (
-      codepoint: codepoint,
-      bold: bold,
-      italic: italic,
-      span: span,
-    );
-    final existing = _codepoints[codepointKey];
-    if (existing != null) return existing;
-
-    final entry = addText((
-      text: String.fromCharCode(codepoint),
-      bold: bold,
-      italic: italic,
-    ), span: span);
-    _codepoints[codepointKey] = entry;
-    return entry;
-  }
+  }) => _cache.addCodepoint(codepoint, bold: bold, italic: italic, span: span);
 
   /// Returns or creates a decoration sprite for the given underline [style].
-  GlyphEntry addDecoration(UnderlineStyle style) {
-    return _decorations[style] ??= _rasterizer.rasterizeDecoration(style);
-  }
+  GlyphEntry addDecoration(UnderlineStyle style) => _cache.addDecoration(style);
 
   void clear() {
-    _glyphs.clear();
-    _codepoints.clear();
-    _spriteCodepoints.clear();
-    _decorations.clear();
+    _cache.clear();
     _rasterizer.clear();
   }
 
@@ -186,10 +114,7 @@ class GlyphAtlas {
   }
 
   void dispose() {
-    _glyphs.clear();
-    _codepoints.clear();
-    _spriteCodepoints.clear();
-    _decorations.clear();
+    _cache.clear();
     _rasterizer.dispose();
   }
 
@@ -241,7 +166,7 @@ class GlyphAtlas {
       }
     }
 
-    for (final cp in _spriteFace.supportedCodepoints) {
+    for (final cp in _cache.supportedSpriteCodepoints) {
       addCodepoint(cp, bold: false, italic: false);
     }
 

--- a/packages/flterm/lib/src/rendering/atlas/glyph_atlas_cache.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_atlas_cache.dart
@@ -1,0 +1,134 @@
+import 'package:libghostty/libghostty.dart' show UnderlineStyle;
+
+import '../sprite/sprite_face.dart';
+import 'glyph_entry.dart';
+import 'glyph_rasterizer.dart';
+
+/// Lookup key for a cached glyph. Two glyphs with the same text, bold,
+/// and italic state share the same atlas entry.
+typedef TextGlyphKey = ({String text, bool bold, bool italic});
+
+typedef _CodepointGlyphKey = ({
+  int codepoint,
+  bool bold,
+  bool italic,
+  int span,
+});
+typedef _GlyphCacheKey = ({String text, bool bold, bool italic, int span});
+typedef _SpriteKey = ({int codepoint, int span});
+
+/// Caches glyph atlas entries and delegates rasterization on cache miss.
+class GlyphAtlasCache {
+  final Map<_GlyphCacheKey, GlyphEntry> _glyphs = {};
+  final Map<UnderlineStyle, GlyphEntry> _decorations = {};
+  final Map<_SpriteKey, GlyphEntry> _spriteCodepoints = {};
+  final Map<_CodepointGlyphKey, GlyphEntry> _codepoints = {};
+  final GlyphRasterizer _rasterizer;
+  final SpriteFace _spriteFace;
+
+  GlyphAtlasCache(this._rasterizer, {SpriteFace? spriteFace})
+    : _spriteFace = spriteFace ?? SpriteFace();
+
+  int get size => _glyphs.length + _spriteCodepoints.length;
+
+  Iterable<int> get supportedSpriteCodepoints =>
+      _spriteFace.supportedCodepoints;
+
+  /// Dispatches to [addEmoji] when [emoji] is true, otherwise [addText].
+  GlyphEntry add(TextGlyphKey key, {int span = 1, bool emoji = false}) {
+    return emoji ? addEmoji(key, span: span) : addText(key, span: span);
+  }
+
+  /// Returns or creates a glyph for a single [codepoint].
+  ///
+  /// Built-in sprite codepoints bypass font rasterization entirely and
+  /// render from geometry. For non-sprite codepoints, [_codepoints] acts
+  /// as a write-through memo over [addText]: a fast path that avoids
+  /// allocating `String.fromCharCode` on cache hit, with the actual entry
+  /// living in `_glyphs` so it stays shared with text-keyed callers.
+  GlyphEntry addCodepoint(
+    int codepoint, {
+    required bool bold,
+    required bool italic,
+    int span = 1,
+  }) {
+    final glyph = _spriteFace.glyphFor(codepoint);
+    if (glyph != null) {
+      final spriteKey = (codepoint: codepoint, span: span);
+      return _spriteCodepoints[spriteKey] ??= _rasterizer.rasterizeSprite(
+        glyph,
+        span: span,
+      );
+    }
+
+    final codepointKey = (
+      codepoint: codepoint,
+      bold: bold,
+      italic: italic,
+      span: span,
+    );
+    final existing = _codepoints[codepointKey];
+    if (existing != null) return existing;
+
+    final entry = addText((
+      text: String.fromCharCode(codepoint),
+      bold: bold,
+      italic: italic,
+    ), span: span);
+    _codepoints[codepointKey] = entry;
+    return entry;
+  }
+
+  /// Returns or creates a decoration sprite for the given underline [style].
+  GlyphEntry addDecoration(UnderlineStyle style) {
+    return _decorations[style] ??= _rasterizer.rasterizeDecoration(style);
+  }
+
+  /// Returns or creates an emoji glyph for [key].
+  ///
+  /// Shares the same cache slot as [addText] for matching
+  /// `(text, bold, italic, span)`: classification of a given grapheme is
+  /// consistent within a frame, so the first writer wins and later
+  /// callers reuse the same atlas region. This is what lets the cursor
+  /// reuse the cell's atlas slot instead of rasterizing a duplicate that
+  /// wouldn't be composited yet.
+  GlyphEntry addEmoji(TextGlyphKey key, {int span = 1}) {
+    final cacheKey = (
+      text: key.text,
+      bold: key.bold,
+      italic: key.italic,
+      span: span,
+    );
+    return _glyphs[cacheKey] ??= _rasterizer.rasterizeEmoji(
+      key.text,
+      bold: key.bold,
+      italic: key.italic,
+      span: span,
+    );
+  }
+
+  /// Returns or creates a text glyph for [key].
+  GlyphEntry addText(TextGlyphKey key, {int span = 1}) {
+    final cacheKey = (
+      text: key.text,
+      bold: key.bold,
+      italic: key.italic,
+      span: span,
+    );
+    return _glyphs[cacheKey] ??= _rasterizer.rasterizeText(
+      key.text,
+      bold: key.bold,
+      italic: key.italic,
+      span: span,
+    );
+  }
+
+  void clear() {
+    _glyphs.clear();
+    _codepoints.clear();
+    _spriteCodepoints.clear();
+    _decorations.clear();
+  }
+
+  bool hasSprite(int codepoint) => _spriteFace.hasCodepoint(codepoint);
+}

--- a/packages/flterm/lib/src/rendering/atlas/glyph_atlas_config.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_atlas_config.dart
@@ -1,0 +1,86 @@
+import 'dart:ui' show FontWeight;
+
+import 'package:meta/meta.dart';
+
+import '../../foundation.dart';
+
+@immutable
+class GlyphAtlasConfig {
+  final double fontSize;
+  final String fontFamily;
+  final FontWeight fontWeight;
+  final List<String> fontFamilyFallback;
+  final CellMetrics metrics;
+  final double devicePixelRatio;
+
+  GlyphAtlasConfig({
+    required this.fontSize,
+    required this.fontFamily,
+    required this.fontWeight,
+    required List<String> fontFamilyFallback,
+    required this.metrics,
+    required this.devicePixelRatio,
+  }) : fontFamilyFallback = .unmodifiable(fontFamilyFallback);
+
+  factory GlyphAtlasConfig.fromTheme({
+    required TerminalTheme theme,
+    required CellMetrics metrics,
+    required double devicePixelRatio,
+  }) {
+    return GlyphAtlasConfig(
+      fontSize: theme.fontSize,
+      fontWeight: theme.fontWeight,
+      fontFamily: theme.fontFamily,
+      fontFamilyFallback: theme.fontFamilyFallback,
+      metrics: metrics,
+      devicePixelRatio: devicePixelRatio,
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    fontSize,
+    fontWeight,
+    fontFamily,
+    Object.hashAll(fontFamilyFallback),
+    metrics,
+    devicePixelRatio,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is GlyphAtlasConfig &&
+      other.fontSize == fontSize &&
+      other.fontWeight == fontWeight &&
+      other.fontFamily == fontFamily &&
+      _listEquals(other.fontFamilyFallback, fontFamilyFallback) &&
+      other.metrics == metrics &&
+      other.devicePixelRatio == devicePixelRatio;
+
+  GlyphAtlasConfig copyWith({
+    double? fontSize,
+    FontWeight? fontWeight,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    CellMetrics? metrics,
+    double? devicePixelRatio,
+  }) {
+    return GlyphAtlasConfig(
+      fontSize: fontSize ?? this.fontSize,
+      fontWeight: fontWeight ?? this.fontWeight,
+      fontFamily: fontFamily ?? this.fontFamily,
+      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+      metrics: metrics ?? this.metrics,
+      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
+    );
+  }
+
+  static bool _listEquals(List<String> a, List<String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/packages/flterm/lib/src/rendering/atlas/glyph_atlas_texture.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_atlas_texture.dart
@@ -1,0 +1,171 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'glyph_entry.dart';
+
+/// Thrown when a glyph or sprite cannot fit inside the configured atlas limit.
+class GlyphAtlasFullException implements Exception {
+  final double requestedWidth;
+  final double requestedHeight;
+  final int atlasWidth;
+  final int atlasHeight;
+  final int maxSize;
+
+  const GlyphAtlasFullException({
+    required this.requestedWidth,
+    required this.requestedHeight,
+    required this.atlasWidth,
+    required this.atlasHeight,
+    required this.maxSize,
+  });
+
+  @override
+  String toString() =>
+      'GlyphAtlasFullException: requested '
+      '${requestedWidth.toStringAsFixed(1)}x'
+      '${requestedHeight.toStringAsFixed(1)} in ${atlasWidth}x$atlasHeight '
+      'atlas with max size $maxSize';
+}
+
+/// Owns glyph atlas storage, slot allocation, and image replacement.
+class GlyphAtlasTexture {
+  static const defaultInitialSize = 1024;
+  static const defaultMaxSize = 4096;
+
+  // Gap between atlas cells prevents sub-pixel bleed between sprites.
+  static const padding = 1.0;
+
+  final _compositePaint = Paint();
+  final int _initialSize;
+  final int _maxSize;
+
+  late int _width;
+  late int _height;
+  var _packX = 0.0;
+  var _packY = 0.0;
+  var _rowHeight = 0.0;
+
+  Image? image;
+
+  GlyphAtlasTexture({
+    int initialSize = defaultInitialSize,
+    int maxSize = defaultMaxSize,
+  }) : assert(initialSize > 0, 'initialSize must be positive'),
+       assert(maxSize >= initialSize, 'maxSize must be >= initialSize'),
+       _initialSize = initialSize,
+       _maxSize = maxSize {
+    _width = initialSize;
+    _height = initialSize;
+  }
+
+  GlyphEntry allocate({
+    required double width,
+    required double height,
+    required double bearingY,
+    double bearingX = 0.0,
+    bool isEmoji = false,
+  }) {
+    _pack(width, height);
+
+    final entry = GlyphEntry(
+      srcLeft: _packX,
+      srcTop: _packY,
+      srcRight: _packX + width,
+      srcBottom: _packY + height,
+      bearingY: bearingY,
+      bearingX: bearingX,
+      isEmoji: isEmoji,
+    );
+
+    _packX += width + padding;
+    _rowHeight = max(_rowHeight, height);
+    return entry;
+  }
+
+  void clear() {
+    image?.dispose();
+    image = null;
+    _packX = 0;
+    _packY = 0;
+    _rowHeight = 0;
+    _width = _initialSize;
+    _height = _initialSize;
+  }
+
+  void dispose() {
+    image?.dispose();
+    image = null;
+  }
+
+  void replaceImage(void Function(Canvas canvas) paintPending) {
+    final recorder = PictureRecorder();
+    final canvas = Canvas(recorder);
+    if (image != null) canvas.drawImage(image!, Offset.zero, _compositePaint);
+
+    paintPending(canvas);
+
+    final picture = recorder.endRecording();
+    image?.dispose();
+    image = picture.toImageSync(_width, _height);
+    picture.dispose();
+  }
+
+  /// Doubles one atlas dimension so the texture stays roughly square as it
+  /// grows toward [_maxSize]. Returns false when both dimensions are maxed.
+  bool _grow() {
+    if ((_width <= _height && _width < _maxSize) ||
+        (_height >= _maxSize && _width < _maxSize)) {
+      _width = min(_width * 2, _maxSize);
+      return true;
+    } else if (_height < _maxSize) {
+      _height = min(_height * 2, _maxSize);
+      return true;
+    }
+    return false;
+  }
+
+  /// Row-based bin packing: fills left-to-right within the current row,
+  /// wraps to the next row when the glyph won't fit, and grows the
+  /// atlas if vertical space is exhausted.
+  void _pack(double width, double height) {
+    if (width + padding > _maxSize || height + padding > _maxSize) {
+      throw GlyphAtlasFullException(
+        requestedWidth: width,
+        requestedHeight: height,
+        atlasWidth: _width,
+        atlasHeight: _height,
+        maxSize: _maxSize,
+      );
+    }
+
+    while (width + padding > _width || height + padding > _height) {
+      if (!_grow()) {
+        throw GlyphAtlasFullException(
+          requestedWidth: width,
+          requestedHeight: height,
+          atlasWidth: _width,
+          atlasHeight: _height,
+          maxSize: _maxSize,
+        );
+      }
+    }
+
+    if (_packX + width + padding > _width) {
+      _packX = 0;
+      _packY += _rowHeight + padding;
+      _rowHeight = 0;
+    }
+
+    while (_packY + height + padding > _height) {
+      if (!_grow()) {
+        throw GlyphAtlasFullException(
+          requestedWidth: width,
+          requestedHeight: height,
+          atlasWidth: _width,
+          atlasHeight: _height,
+          maxSize: _maxSize,
+        );
+      }
+    }
+  }
+}

--- a/packages/flterm/lib/src/rendering/atlas/glyph_rasterizer.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_rasterizer.dart
@@ -3,8 +3,8 @@ import 'dart:ui';
 
 import 'package:libghostty/libghostty.dart' show UnderlineStyle;
 
-import '../../foundation.dart';
 import '../sprite/sprite_face.dart';
+import 'glyph_atlas_config.dart';
 import 'glyph_atlas_texture.dart';
 import 'glyph_entry.dart';
 
@@ -64,25 +64,20 @@ class GlyphRasterizer {
     _dirty = false;
   }
 
-  void configure({
-    required double fontSize,
-    required String fontFamily,
-    required FontWeight fontWeight,
-    required List<String> fontFamilyFallback,
-    required CellMetrics metrics,
-    required double dpr,
-  }) {
-    _fontFamily = fontFamily;
-    _fontWeight = fontWeight;
-    _fontFamilyFallback = fontFamilyFallback;
-    _pxCellWidth = metrics.cellWidth * dpr;
-    _pxCellHeight = metrics.cellHeight * dpr;
-    _pxBaseline = metrics.baseline * dpr;
-    _pxFontSize = fontSize * dpr;
-    _pxUnderlinePosition = metrics.underlinePosition * dpr;
+  void configure(GlyphAtlasConfig config) {
+    _fontFamily = config.fontFamily;
+    _fontWeight = config.fontWeight;
+    _fontFamilyFallback = config.fontFamilyFallback;
+    _pxCellWidth = config.metrics.cellWidth * config.devicePixelRatio;
+    _pxCellHeight = config.metrics.cellHeight * config.devicePixelRatio;
+    _pxBaseline = config.metrics.baseline * config.devicePixelRatio;
+    _pxFontSize = config.fontSize * config.devicePixelRatio;
+    _pxUnderlinePosition =
+        config.metrics.underlinePosition * config.devicePixelRatio;
     _pxUnderlineThickness = max(
       1.0,
-      (metrics.underlineThickness * dpr).ceilToDouble(),
+      (config.metrics.underlineThickness * config.devicePixelRatio)
+          .ceilToDouble(),
     );
     _pxDecorationPadding = (_pxCellHeight / 4).ceilToDouble();
     _pxItalicOverhang = max(1.0, (_pxFontSize * 0.15).ceilToDouble());

--- a/packages/flterm/lib/src/rendering/atlas/glyph_rasterizer.dart
+++ b/packages/flterm/lib/src/rendering/atlas/glyph_rasterizer.dart
@@ -5,7 +5,10 @@ import 'package:libghostty/libghostty.dart' show UnderlineStyle;
 
 import '../../foundation.dart';
 import '../sprite/sprite_face.dart';
+import 'glyph_atlas_texture.dart';
 import 'glyph_entry.dart';
+
+export 'glyph_atlas_texture.dart' show GlyphAtlasFullException;
 
 /// Rasterizes glyphs into a packed atlas texture.
 ///
@@ -18,26 +21,11 @@ import 'glyph_entry.dart';
 /// color tinting via [BlendMode.modulate]. Emoji are rasterized in full
 /// color and composited with scaling to fit within the cell bounds.
 class GlyphRasterizer {
-  static const _defaultInitialSize = 1024;
-  static const _defaultMaxSize = 4096;
-
-  // Gap between atlas cells prevents sub-pixel bleed between sprites.
-  static const _padding = 1.0;
-
   final List<(Paragraph, GlyphEntry)> _pending = [];
   final List<(SpriteGlyph, GlyphEntry)> _pendingSprites = [];
   final List<(UnderlineStyle, GlyphEntry)> _pendingDecorations = [];
-  final _compositePaint = Paint();
   final _spriteContext = SpriteContext();
-
-  final int _initialSize;
-  final int _maxSize;
-
-  late int _width;
-  late int _height;
-  var _packX = 0.0;
-  var _packY = 0.0;
-  var _rowHeight = 0.0;
+  final GlyphAtlasTexture _texture;
   var _dirty = false;
 
   var _fontFamily = '';
@@ -61,31 +49,19 @@ class GlyphRasterizer {
   // in the atlas source rect and not clipped by drawRawAtlas.
   var _pxItalicOverhang = 0.0;
 
-  Image? image;
+  Image? get image => _texture.image;
 
   GlyphRasterizer({
-    int initialSize = _defaultInitialSize,
-    int maxSize = _defaultMaxSize,
-  }) : assert(initialSize > 0, 'initialSize must be positive'),
-       assert(maxSize >= initialSize, 'maxSize must be >= initialSize'),
-       _initialSize = initialSize,
-       _maxSize = maxSize {
-    _width = initialSize;
-    _height = initialSize;
-  }
+    int initialSize = GlyphAtlasTexture.defaultInitialSize,
+    int maxSize = GlyphAtlasTexture.defaultMaxSize,
+  }) : _texture = GlyphAtlasTexture(initialSize: initialSize, maxSize: maxSize);
 
   void clear() {
     _disposePending();
     _pendingSprites.clear();
     _pendingDecorations.clear();
-    image?.dispose();
-    image = null;
+    _texture.clear();
     _dirty = false;
-    _packX = 0;
-    _packY = 0;
-    _rowHeight = 0;
-    _width = _initialSize;
-    _height = _initialSize;
   }
 
   void configure({
@@ -116,8 +92,7 @@ class GlyphRasterizer {
     _disposePending();
     _pendingSprites.clear();
     _pendingDecorations.clear();
-    image?.dispose();
-    image = null;
+    _texture.dispose();
   }
 
   /// Composites pending glyphs and decorations into the atlas image.
@@ -130,67 +105,63 @@ class GlyphRasterizer {
     }
     _dirty = false;
 
-    final recorder = PictureRecorder();
-    final canvas = Canvas(recorder);
-    if (image != null) canvas.drawImage(image!, Offset.zero, _compositePaint);
-
-    for (final (paragraph, entry) in _pending) {
-      canvas.save();
-      canvas.clipRect(
-        Rect.fromLTRB(
-          entry.srcLeft,
-          entry.srcTop,
-          entry.srcRight,
-          entry.srcBottom,
-        ),
-      );
-      if (entry.isEmoji) {
-        _compositeEmoji(canvas, paragraph, entry);
-      } else {
-        canvas.drawParagraph(
-          paragraph,
-          Offset(entry.srcLeft + entry.bearingX, entry.srcTop + entry.bearingY),
+    _texture.replaceImage((canvas) {
+      for (final (paragraph, entry) in _pending) {
+        canvas.save();
+        canvas.clipRect(
+          Rect.fromLTRB(
+            entry.srcLeft,
+            entry.srcTop,
+            entry.srcRight,
+            entry.srcBottom,
+          ),
         );
+        if (entry.isEmoji) {
+          _compositeEmoji(canvas, paragraph, entry);
+        } else {
+          canvas.drawParagraph(
+            paragraph,
+            Offset(
+              entry.srcLeft + entry.bearingX,
+              entry.srcTop + entry.bearingY,
+            ),
+          );
+        }
+        canvas.restore();
+        paragraph.dispose();
       }
-      canvas.restore();
-      paragraph.dispose();
-    }
-    _pending.clear();
 
-    for (final (glyph, entry) in _pendingSprites) {
-      final rect = Rect.fromLTRB(
-        entry.srcLeft,
-        entry.srcTop,
-        entry.srcRight,
-        entry.srcBottom,
-      );
-      canvas.save();
-      canvas.clipRect(rect);
-      _spriteContext.reset();
-      glyph.paint(canvas, rect, _spriteContext);
-      canvas.restore();
-    }
-    _pendingSprites.clear();
-
-    for (final (style, entry) in _pendingDecorations) {
-      canvas.save();
-      canvas.clipRect(
-        Rect.fromLTRB(
+      for (final (glyph, entry) in _pendingSprites) {
+        final rect = Rect.fromLTRB(
           entry.srcLeft,
           entry.srcTop,
           entry.srcRight,
           entry.srcBottom,
-        ),
-      );
-      _compositeDecoration(canvas, style, entry);
-      canvas.restore();
-    }
-    _pendingDecorations.clear();
+        );
+        canvas.save();
+        canvas.clipRect(rect);
+        _spriteContext.reset();
+        glyph.paint(canvas, rect, _spriteContext);
+        canvas.restore();
+      }
 
-    final picture = recorder.endRecording();
-    image?.dispose();
-    image = picture.toImageSync(_width, _height);
-    picture.dispose();
+      for (final (style, entry) in _pendingDecorations) {
+        canvas.save();
+        canvas.clipRect(
+          Rect.fromLTRB(
+            entry.srcLeft,
+            entry.srcTop,
+            entry.srcRight,
+            entry.srcBottom,
+          ),
+        );
+        _compositeDecoration(canvas, style, entry);
+        canvas.restore();
+      }
+    });
+    _pending.clear();
+    _pendingSprites.clear();
+    _pendingDecorations.clear();
   }
 
   /// Builds a paragraph for [text], packs it into the atlas, and returns
@@ -236,19 +207,13 @@ class GlyphRasterizer {
   GlyphEntry rasterizeSprite(SpriteGlyph glyph, {int span = 1}) {
     final pxWidth = (_pxCellWidth * span).ceil().toDouble();
     final pxHeight = _pxCellHeight.ceil().toDouble();
-    _pack(pxWidth, pxHeight);
-
-    final entry = GlyphEntry(
-      srcLeft: _packX,
-      srcTop: _packY,
-      srcRight: _packX + pxWidth,
-      srcBottom: _packY + pxHeight,
+    final entry = _texture.allocate(
+      width: pxWidth,
+      height: pxHeight,
       bearingY: 0,
     );
 
     _pendingSprites.add((glyph, entry));
-    _packX += pxWidth + _padding;
-    _rowHeight = max(_rowHeight, pxHeight);
     _dirty = true;
     return entry;
   }
@@ -267,8 +232,6 @@ class GlyphRasterizer {
     // overlaps into the adjacent cell's space without shifting the glyph.
     final overhang = (italic && !emoji) ? _pxItalicOverhang : 0.0;
     final pxWidth = pxCellWidth + overhang;
-
-    _pack(pxWidth, pxHeight);
 
     // Emoji: fit within the smaller of cell height and cell width, then
     // shrink 5% to prevent clipping at cell edges. Text: use font size.
@@ -331,19 +294,21 @@ class GlyphRasterizer {
         ? max(0.0, (pxCellWidth - paragraph.maxIntrinsicWidth) / 2)
         : 0.0;
 
-    final entry = GlyphEntry(
-      srcLeft: _packX,
-      srcTop: _packY,
-      srcRight: _packX + pxWidth,
-      srcBottom: _packY + pxHeight,
-      bearingY: bearingY,
-      bearingX: bearingX,
-      isEmoji: emoji,
-    );
+    late final GlyphEntry entry;
+    try {
+      entry = _texture.allocate(
+        width: pxWidth,
+        height: pxHeight,
+        bearingY: bearingY,
+        bearingX: bearingX,
+        isEmoji: emoji,
+      );
+    } catch (_) {
+      paragraph.dispose();
+      rethrow;
+    }
 
     _pending.add((paragraph, entry));
-    _packX += pxWidth + _padding;
-    _rowHeight = max(_rowHeight, pxHeight);
     _dirty = true;
     return entry;
   }
@@ -359,19 +324,13 @@ class GlyphRasterizer {
     final pxWidth = _pxCellWidth.ceil().toDouble();
     // Sprite is taller than cell to accommodate decorations extending below.
     final pxHeight = (_pxCellHeight + _pxDecorationPadding).ceil().toDouble();
-    _pack(pxWidth, pxHeight);
-
-    final entry = GlyphEntry(
-      srcLeft: _packX,
-      srcTop: _packY,
-      srcRight: _packX + pxWidth,
-      srcBottom: _packY + pxHeight,
+    final entry = _texture.allocate(
+      width: pxWidth,
+      height: pxHeight,
       bearingY: 0,
     );
 
     _pendingDecorations.add((style, entry));
-    _packX += pxWidth + _padding;
-    _rowHeight = max(_rowHeight, pxHeight);
     _dirty = true;
     return entry;
   }
@@ -565,87 +524,4 @@ class GlyphRasterizer {
     }
     _pending.clear();
   }
-
-  /// Doubles one atlas dimension so the texture stays roughly square as it
-  /// grows toward [_maxSize]. Returns false when both dimensions are maxed.
-  bool _grow() {
-    if ((_width <= _height && _width < _maxSize) ||
-        (_height >= _maxSize && _width < _maxSize)) {
-      _width = min(_width * 2, _maxSize);
-      return true;
-    } else if (_height < _maxSize) {
-      _height = min(_height * 2, _maxSize);
-      return true;
-    }
-    return false;
-  }
-
-  /// Row-based bin packing: fills left-to-right within the current row,
-  /// wraps to the next row when the glyph won't fit, and grows the
-  /// atlas if vertical space is exhausted.
-  void _pack(double width, double height) {
-    if (width + _padding > _maxSize || height + _padding > _maxSize) {
-      throw GlyphAtlasFullException(
-        requestedWidth: width,
-        requestedHeight: height,
-        atlasWidth: _width,
-        atlasHeight: _height,
-        maxSize: _maxSize,
-      );
-    }
-
-    while (width + _padding > _width || height + _padding > _height) {
-      if (!_grow()) {
-        throw GlyphAtlasFullException(
-          requestedWidth: width,
-          requestedHeight: height,
-          atlasWidth: _width,
-          atlasHeight: _height,
-          maxSize: _maxSize,
-        );
-      }
-    }
-
-    if (_packX + width + _padding > _width) {
-      _packX = 0;
-      _packY += _rowHeight + _padding;
-      _rowHeight = 0;
-    }
-
-    while (_packY + height + _padding > _height) {
-      if (!_grow()) {
-        throw GlyphAtlasFullException(
-          requestedWidth: width,
-          requestedHeight: height,
-          atlasWidth: _width,
-          atlasHeight: _height,
-          maxSize: _maxSize,
-        );
-      }
-    }
-  }
-}
-
-/// Thrown when a glyph or sprite cannot fit inside the configured atlas limit.
-class GlyphAtlasFullException implements Exception {
-  final double requestedWidth;
-  final double requestedHeight;
-  final int atlasWidth;
-  final int atlasHeight;
-  final int maxSize;
-
-  const GlyphAtlasFullException({
-    required this.requestedWidth,
-    required this.requestedHeight,
-    required this.atlasWidth,
-    required this.atlasHeight,
-    required this.maxSize,
-  });
-
-  @override
-  String toString() =>
-      'GlyphAtlasFullException: requested '
-      '${requestedWidth.toStringAsFixed(1)}x'
-      '${requestedHeight.toStringAsFixed(1)} in ${atlasWidth}x$atlasHeight '
-      'atlas with max size $maxSize';
 }

--- a/packages/flterm/lib/src/rendering/terminal_render_cache.dart
+++ b/packages/flterm/lib/src/rendering/terminal_render_cache.dart
@@ -1,45 +1,38 @@
-import 'dart:ui' show FontWeight;
-
-import 'package:meta/meta.dart';
-
-import '../foundation.dart';
 import 'atlas/glyph_atlas.dart';
 
 class TerminalGlyphAtlasHandle {
   final TerminalRenderCache _owner;
-  final TerminalRenderCacheKey key;
+  final GlyphAtlasConfig config;
   final _GlyphAtlasEntry _entry;
   var _released = false;
 
-  TerminalGlyphAtlasHandle._(this._owner, this.key, this._entry);
+  TerminalGlyphAtlasHandle._(this._owner, this.config, this._entry);
 
   GlyphAtlas get atlas => _entry.atlas;
 
   void release() {
     if (_released) return;
     _released = true;
-    _owner._releaseGlyphAtlas(key, _entry);
+    _owner._releaseGlyphAtlas(config, _entry);
   }
 }
 
 /// Owns render resources that can be shared by compatible terminal views.
 ///
+/// Render boxes derive a [GlyphAtlasConfig] from their current
+/// theme/metrics/DPR and use it directly as the sharing key.
+///
 /// This type is internal; public sharing is exposed through `TerminalScope`.
 class TerminalRenderCache {
-  final _glyphAtlases = <TerminalRenderCacheKey, _GlyphAtlasEntry>{};
+  final _glyphAtlases = <GlyphAtlasConfig, _GlyphAtlasEntry>{};
 
-  TerminalGlyphAtlasHandle acquireGlyphAtlas(TerminalRenderCacheKey key) {
-    final entry = _glyphAtlases.putIfAbsent(key, () {
-      final atlas = GlyphAtlas(
-        fontSize: key.fontSize,
-        fontWeight: key.fontWeight,
-        fontFamily: key.fontFamily,
-        fontFamilyFallback: key.fontFamilyFallback,
-      )..configure(dpr: key.devicePixelRatio, metrics: key.metrics);
-      return _GlyphAtlasEntry(atlas);
-    });
+  TerminalGlyphAtlasHandle acquireGlyphAtlas(GlyphAtlasConfig config) {
+    final entry = _glyphAtlases.putIfAbsent(
+      config,
+      () => _GlyphAtlasEntry(GlyphAtlas(config)),
+    );
     entry.references++;
-    return TerminalGlyphAtlasHandle._(this, key, entry);
+    return TerminalGlyphAtlasHandle._(this, config, entry);
   }
 
   void dispose() {
@@ -50,81 +43,18 @@ class TerminalRenderCache {
   }
 
   void _releaseGlyphAtlas(
-    TerminalRenderCacheKey key,
+    GlyphAtlasConfig config,
     _GlyphAtlasEntry releasedEntry,
   ) {
-    final entry = _glyphAtlases[key];
+    final entry = _glyphAtlases[config];
     if (entry == null) return;
     if (!identical(entry, releasedEntry)) return;
 
     entry.references--;
     if (entry.references > 0) return;
 
-    _glyphAtlases.remove(key);
+    _glyphAtlases.remove(config);
     entry.atlas.dispose();
-  }
-}
-
-@immutable
-class TerminalRenderCacheKey {
-  final double fontSize;
-  final FontWeight fontWeight;
-  final String fontFamily;
-  final List<String> fontFamilyFallback;
-  final CellMetrics metrics;
-  final double devicePixelRatio;
-
-  TerminalRenderCacheKey({
-    required this.fontSize,
-    required this.fontWeight,
-    required this.fontFamily,
-    required List<String> fontFamilyFallback,
-    required this.metrics,
-    required this.devicePixelRatio,
-  }) : fontFamilyFallback = List.unmodifiable(fontFamilyFallback);
-
-  factory TerminalRenderCacheKey.fromTheme({
-    required TerminalTheme theme,
-    required CellMetrics metrics,
-    required double devicePixelRatio,
-  }) {
-    return TerminalRenderCacheKey(
-      fontSize: theme.fontSize,
-      fontWeight: theme.fontWeight,
-      fontFamily: theme.fontFamily,
-      fontFamilyFallback: theme.fontFamilyFallback,
-      metrics: metrics,
-      devicePixelRatio: devicePixelRatio,
-    );
-  }
-
-  @override
-  int get hashCode => Object.hash(
-    fontSize,
-    fontWeight,
-    fontFamily,
-    Object.hashAll(fontFamilyFallback),
-    metrics,
-    devicePixelRatio,
-  );
-
-  @override
-  bool operator ==(Object other) =>
-      other is TerminalRenderCacheKey &&
-      other.fontSize == fontSize &&
-      other.fontWeight == fontWeight &&
-      other.fontFamily == fontFamily &&
-      _listEquals(other.fontFamilyFallback, fontFamilyFallback) &&
-      other.metrics == metrics &&
-      other.devicePixelRatio == devicePixelRatio;
-
-  static bool _listEquals(List<String> a, List<String> b) {
-    if (identical(a, b)) return true;
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i] != b[i]) return false;
-    }
-    return true;
   }
 }
 

--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:libghostty/libghostty.dart';
 
 import '../foundation.dart';
+import 'atlas/glyph_atlas_config.dart';
 import 'atlas/sprite_buffer.dart';
 import 'kitty_image_cache.dart';
 import 'paint_state.dart';
@@ -507,17 +508,17 @@ class TerminalRenderBox extends RenderBox {
   }
 
   bool _acquireAtlasForCurrentConfig({double? dpr, bool force = false}) {
-    final key = TerminalRenderCacheKey.fromTheme(
+    final config = GlyphAtlasConfig.fromTheme(
       theme: _paintState.theme,
       metrics: _paintState.metrics,
       devicePixelRatio: dpr ?? _currentDevicePixelRatio,
     );
-    if (!force && key == _atlasHandle.key) return false;
+    if (!force && config == _atlasHandle.config) return false;
 
     final previousHandle = _atlasHandle;
     final previousBuilder = _spriteBuilder;
 
-    _atlasHandle = _renderCache.acquireGlyphAtlas(key);
+    _atlasHandle = _renderCache.acquireGlyphAtlas(config);
     _bindAtlasDependents();
     if (_paintState.rows > 0 && _paintState.cols > 0) {
       _spriteBuilder.configure(_paintState.rows, _paintState.cols);

--- a/packages/flterm/test/rendering/atlas/glyph_atlas_cache_test.dart
+++ b/packages/flterm/test/rendering/atlas/glyph_atlas_cache_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
 import 'package:flterm/src/rendering/atlas/glyph_atlas_cache.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_config.dart';
 import 'package:flterm/src/rendering/atlas/glyph_rasterizer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,19 +12,7 @@ void main() {
     late GlyphAtlasCache cache;
 
     setUp(() {
-      rasterizer = GlyphRasterizer()
-        ..configure(
-          fontSize: 14,
-          fontFamily: 'monospace',
-          fontWeight: FontWeight.normal,
-          fontFamilyFallback: const [],
-          metrics: const CellMetrics(
-            cellWidth: 8,
-            cellHeight: 16,
-            baseline: 12,
-          ),
-          dpr: 1.0,
-        );
+      rasterizer = GlyphRasterizer()..configure(_config());
       cache = GlyphAtlasCache(rasterizer);
     });
 
@@ -66,4 +55,15 @@ void main() {
       expect(cache.size, 0);
     });
   });
+}
+
+GlyphAtlasConfig _config() {
+  return GlyphAtlasConfig(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'monospace',
+    fontFamilyFallback: const [],
+    metrics: const CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12),
+    devicePixelRatio: 1.0,
+  );
 }

--- a/packages/flterm/test/rendering/atlas/glyph_atlas_cache_test.dart
+++ b/packages/flterm/test/rendering/atlas/glyph_atlas_cache_test.dart
@@ -1,0 +1,69 @@
+import 'dart:ui';
+
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_cache.dart';
+import 'package:flterm/src/rendering/atlas/glyph_rasterizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GlyphAtlasCache', () {
+    late GlyphRasterizer rasterizer;
+    late GlyphAtlasCache cache;
+
+    setUp(() {
+      rasterizer = GlyphRasterizer()
+        ..configure(
+          fontSize: 14,
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.normal,
+          fontFamilyFallback: const [],
+          metrics: const CellMetrics(
+            cellWidth: 8,
+            cellHeight: 16,
+            baseline: 12,
+          ),
+          dpr: 1.0,
+        );
+      cache = GlyphAtlasCache(rasterizer);
+    });
+
+    tearDown(() => rasterizer.dispose());
+
+    test('shares text entries for matching keys', () {
+      const key = (text: 'A', bold: false, italic: false);
+
+      final first = cache.addText(key);
+      final second = cache.addText(key);
+
+      expect(second, same(first));
+      expect(cache.size, 1);
+    });
+
+    test('shares codepoint entries with text entries', () {
+      const key = (text: 'A', bold: false, italic: false);
+
+      final text = cache.addText(key);
+      final codepoint = cache.addCodepoint(0x41, bold: false, italic: false);
+
+      expect(codepoint, same(text));
+      expect(cache.size, 1);
+    });
+
+    test('sprite codepoints are independent from text style', () {
+      final plain = cache.addCodepoint(0x2500, bold: false, italic: false);
+      final styled = cache.addCodepoint(0x2500, bold: true, italic: true);
+
+      expect(styled, same(plain));
+      expect(cache.size, 1);
+    });
+
+    test('clear removes cached entries', () {
+      cache.addText((text: 'A', bold: false, italic: false));
+      expect(cache.size, 1);
+
+      cache.clear();
+
+      expect(cache.size, 0);
+    });
+  });
+}

--- a/packages/flterm/test/rendering/atlas/glyph_atlas_config_test.dart
+++ b/packages/flterm/test/rendering/atlas/glyph_atlas_config_test.dart
@@ -1,0 +1,63 @@
+import 'dart:ui';
+
+import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GlyphAtlasConfig', () {
+    test('equality includes font, metrics, fallback, and DPR', () {
+      final first = _config();
+      final second = _config();
+
+      expect(second, first);
+      expect(second.hashCode, first.hashCode);
+      expect(_config(fontSize: 16), isNot(first));
+      expect(_config(devicePixelRatio: 2), isNot(first));
+      expect(_config(fallback: const ['serif']), isNot(first));
+    });
+
+    test('defensively copies fallback list', () {
+      final fallback = ['serif'];
+      final config = _config(fallback: fallback);
+
+      fallback.add('emoji');
+
+      expect(config.fontFamilyFallback, ['serif']);
+      expect(
+        () => config.fontFamilyFallback.add('emoji'),
+        throwsUnsupportedError,
+      );
+    });
+
+    test(
+      'copyWith preserves existing values and replaces requested fields',
+      () {
+        final original = _config();
+        final changed = original.copyWith(fontSize: 16);
+
+        expect(changed.fontSize, 16);
+        expect(changed.fontWeight, original.fontWeight);
+        expect(changed.fontFamily, original.fontFamily);
+        expect(changed.fontFamilyFallback, original.fontFamilyFallback);
+        expect(changed.metrics, original.metrics);
+        expect(changed.devicePixelRatio, original.devicePixelRatio);
+      },
+    );
+  });
+}
+
+GlyphAtlasConfig _config({
+  double fontSize = 14,
+  double devicePixelRatio = 1,
+  List<String> fallback = const [],
+}) {
+  return GlyphAtlasConfig(
+    fontSize: fontSize,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'monospace',
+    fontFamilyFallback: fallback,
+    metrics: const CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12),
+    devicePixelRatio: devicePixelRatio,
+  );
+}

--- a/packages/flterm/test/rendering/atlas/glyph_atlas_texture_test.dart
+++ b/packages/flterm/test/rendering/atlas/glyph_atlas_texture_test.dart
@@ -1,0 +1,44 @@
+import 'package:flterm/src/rendering/atlas/glyph_atlas_texture.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('GlyphAtlasTexture', () {
+    test('allocates non-overlapping slots and grows within bounds', () {
+      final texture = GlyphAtlasTexture(initialSize: 16, maxSize: 64);
+      addTearDown(texture.dispose);
+
+      final first = texture.allocate(width: 12, height: 8, bearingY: 0);
+      final second = texture.allocate(width: 12, height: 8, bearingY: 0);
+      final large = texture.allocate(width: 40, height: 8, bearingY: 0);
+
+      expect(first.srcRight, lessThanOrEqualTo(16));
+      expect(second.srcTop, greaterThan(first.srcTop));
+      expect(large.srcRight, lessThanOrEqualTo(64));
+      expect(large.srcBottom, lessThanOrEqualTo(64));
+    });
+
+    test('clear resets allocation to the initial origin', () {
+      final texture = GlyphAtlasTexture(initialSize: 16, maxSize: 64);
+      addTearDown(texture.dispose);
+
+      texture.allocate(width: 12, height: 8, bearingY: 0);
+      texture.allocate(width: 12, height: 8, bearingY: 0);
+
+      texture.clear();
+      final afterClear = texture.allocate(width: 12, height: 8, bearingY: 0);
+
+      expect(afterClear.srcLeft, 0);
+      expect(afterClear.srcTop, 0);
+    });
+
+    test('throws when one slot exceeds the maximum texture size', () {
+      final texture = GlyphAtlasTexture(initialSize: 16, maxSize: 32);
+      addTearDown(texture.dispose);
+
+      expect(
+        () => texture.allocate(width: 32, height: 8, bearingY: 0),
+        throwsA(isA<GlyphAtlasFullException>()),
+      );
+    });
+  });
+}

--- a/packages/flterm/test/rendering/atlas/glyph_rasterizer_test.dart
+++ b/packages/flterm/test/rendering/atlas/glyph_rasterizer_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_config.dart';
 import 'package:flterm/src/rendering/atlas/glyph_rasterizer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,16 +11,13 @@ void main() {
       test('grows until a large slot fits within bounds', () {
         final rasterizer = GlyphRasterizer(initialSize: 16, maxSize: 64)
           ..configure(
-            fontSize: 8,
-            fontFamily: 'monospace',
-            fontWeight: FontWeight.normal,
-            fontFamilyFallback: const [],
-            metrics: const CellMetrics(
-              cellWidth: 40,
-              cellHeight: 8,
-              baseline: 6,
+            _config(
+              metrics: const CellMetrics(
+                cellWidth: 40,
+                cellHeight: 8,
+                baseline: 6,
+              ),
             ),
-            dpr: 1.0,
           );
         addTearDown(rasterizer.dispose);
 
@@ -33,16 +31,13 @@ void main() {
       test('throws when a single slot exceeds the max atlas size', () {
         final rasterizer = GlyphRasterizer(initialSize: 16, maxSize: 32)
           ..configure(
-            fontSize: 8,
-            fontFamily: 'monospace',
-            fontWeight: FontWeight.normal,
-            fontFamilyFallback: const [],
-            metrics: const CellMetrics(
-              cellWidth: 32,
-              cellHeight: 8,
-              baseline: 6,
+            _config(
+              metrics: const CellMetrics(
+                cellWidth: 32,
+                cellHeight: 8,
+                baseline: 6,
+              ),
             ),
-            dpr: 1.0,
           );
         addTearDown(rasterizer.dispose);
 
@@ -55,16 +50,13 @@ void main() {
       test('throws before returning out-of-bounds entries when full', () {
         final rasterizer = GlyphRasterizer(initialSize: 16, maxSize: 32)
           ..configure(
-            fontSize: 8,
-            fontFamily: 'monospace',
-            fontWeight: FontWeight.normal,
-            fontFamilyFallback: const [],
-            metrics: const CellMetrics(
-              cellWidth: 8,
-              cellHeight: 8,
-              baseline: 6,
+            _config(
+              metrics: const CellMetrics(
+                cellWidth: 8,
+                cellHeight: 8,
+                baseline: 6,
+              ),
             ),
-            dpr: 1.0,
           );
         addTearDown(rasterizer.dispose);
 
@@ -91,4 +83,15 @@ void main() {
       });
     });
   });
+}
+
+GlyphAtlasConfig _config({required CellMetrics metrics}) {
+  return GlyphAtlasConfig(
+    fontSize: 8,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'monospace',
+    fontFamilyFallback: const [],
+    metrics: metrics,
+    devicePixelRatio: 1.0,
+  );
 }

--- a/packages/flterm/test/rendering/glyph_atlas_test.dart
+++ b/packages/flterm/test/rendering/glyph_atlas_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flterm/src/foundation/cell_metrics.dart';
 import 'package:flterm/src/rendering/atlas/glyph_atlas.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -7,49 +9,40 @@ void main() {
     late GlyphAtlas atlas;
 
     setUp(() {
-      atlas = GlyphAtlas(
-        fontFamily: 'monospace',
-        fontFamilyFallback: const [],
-        fontSize: 14,
-      );
+      atlas = GlyphAtlas(_config());
     });
 
     tearDown(() => atlas.dispose());
 
-    group('configure', () {
-      test('sets dimensions, pre-seeds glyphs, and creates atlas image', () {
-        atlas.configure(dpr: 2.0, metrics: _metrics);
+    group('construction', () {
+      test('applies config, pre-seeds glyphs, and creates atlas image', () {
+        atlas.dispose();
+        atlas = GlyphAtlas(_config(dpr: 2.0));
 
         expect(atlas.devicePixelRatio, 2.0);
         expect(atlas.cacheSize, greaterThan(0));
         expect(atlas.image, isNotNull);
       });
 
-      test('is no-op when called with same values', () {
-        atlas.configure(dpr: 2.0, metrics: _metrics);
-        final sizeAfterFirst = atlas.cacheSize;
-        final imageAfterFirst = atlas.image;
+      test('defers preseed when cell dimensions are not available', () {
+        atlas.dispose();
+        atlas = GlyphAtlas(
+          _config(
+            metrics: const CellMetrics(
+              cellWidth: 0,
+              cellHeight: 0,
+              baseline: 0,
+            ),
+          ),
+        );
 
-        atlas.configure(dpr: 2.0, metrics: _metrics);
-        expect(atlas.cacheSize, sizeAfterFirst);
-        expect(atlas.image, same(imageAfterFirst));
-      });
-
-      test('clears and re-seeds on DPR change', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-        final sizeBefore = atlas.cacheSize;
-        final imageBefore = atlas.image;
-
-        atlas.configure(dpr: 2.0, metrics: _metrics);
-        expect(atlas.cacheSize, sizeBefore);
-        expect(atlas.image, isNot(same(imageBefore)));
+        expect(atlas.cacheSize, 0);
+        expect(atlas.image, isNull);
       });
     });
 
     group('addCodepoint', () {
       test('creates entry and returns cached on second call', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         final entry1 = atlas.addCodepoint(0x100, bold: false, italic: false);
         final entry2 = atlas.addCodepoint(0x100, bold: false, italic: false);
 
@@ -58,16 +51,12 @@ void main() {
       });
 
       test('different styles produce different entries', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         final plain = atlas.addCodepoint(0x41, bold: false, italic: false);
         final bold = atlas.addCodepoint(0x41, bold: true, italic: false);
         expect(identical(plain, bold), isFalse);
       });
 
       test('sprite codepoints reuse geometry across styles', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         for (final codepoint in _spriteSamples) {
           final plain = atlas.addCodepoint(
             codepoint,
@@ -85,8 +74,6 @@ void main() {
       });
 
       test('span participates in sprite cache key', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         final single = atlas.addCodepoint(0xE0B0, bold: false, italic: false);
         final doubleWidth = atlas.addCodepoint(
           0xE0B0,
@@ -105,7 +92,6 @@ void main() {
 
     group('add', () {
       test('creates entry and returns cached on second call', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
         final sizeBefore = atlas.cacheSize;
 
         const key = (text: '\u{1234}', bold: false, italic: false);
@@ -117,8 +103,6 @@ void main() {
       });
 
       test('wide entry spans 2 cells', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         const key = (text: '\u{4e00}', bold: false, italic: false);
         final entry = atlas.add(key, span: 2);
 
@@ -128,16 +112,12 @@ void main() {
       });
 
       test('emoji entry has isEmoji true', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         const key = (text: '\u{1F600}', bold: false, italic: false);
         final entry = atlas.add(key, emoji: true);
         expect(entry.isEmoji, isTrue);
       });
 
       test('sequential adds produce non-overlapping positions', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         final entries = <GlyphEntry>[];
         for (var code = 0x300; code < 0x310; code++) {
           entries.add(
@@ -164,8 +144,6 @@ void main() {
       });
 
       test('early positions remain stable after many adds', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         final earlyEntries = <GlyphEntry>[];
         for (var code = 0x400; code < 0x410; code++) {
           earlyEntries.add(
@@ -202,16 +180,12 @@ void main() {
 
     group('ensureImage', () {
       test('composites pending glyphs into atlas image', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         atlas.add((text: '\u{1234}', bold: false, italic: false));
         atlas.ensureImage();
         expect(atlas.image, isNotNull);
       });
 
       test('composites pending sprite glyphs into atlas image', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-
         for (final codepoint in _spriteSamples) {
           atlas.addCodepoint(codepoint, bold: false, italic: false);
         }
@@ -220,7 +194,6 @@ void main() {
       });
 
       test('is no-op when no pending glyphs', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
         final imageBefore = atlas.image;
 
         atlas.ensureImage();
@@ -228,23 +201,8 @@ void main() {
       });
     });
 
-    group('clear', () {
-      test('resets caches and image', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
-        atlas.add((text: 'X', bold: false, italic: false));
-        expect(atlas.cacheSize, greaterThan(0));
-        expect(atlas.image, isNotNull);
-
-        atlas.clear();
-
-        expect(atlas.cacheSize, 0);
-        expect(atlas.image, isNull);
-      });
-    });
-
     group('dispose', () {
       test('releases image', () {
-        atlas.configure(dpr: 1.0, metrics: _metrics);
         expect(atlas.image, isNotNull);
 
         atlas.dispose();
@@ -255,6 +213,17 @@ void main() {
 }
 
 const _metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+GlyphAtlasConfig _config({double dpr = 1, CellMetrics metrics = _metrics}) {
+  return GlyphAtlasConfig(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    fontFamily: 'monospace',
+    fontFamilyFallback: const [],
+    metrics: metrics,
+    devicePixelRatio: dpr,
+  );
+}
 
 // One representative codepoint from each sprite family in the registry.
 // dart format off

--- a/packages/flterm/test/rendering/terminal_render_cache_test.dart
+++ b/packages/flterm/test/rendering/terminal_render_cache_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flterm/src/foundation.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_config.dart';
 import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -47,8 +48,8 @@ void main() {
   });
 }
 
-TerminalRenderCacheKey _key({double fontSize = 14}) {
-  return TerminalRenderCacheKey(
+GlyphAtlasConfig _key({double fontSize = 14}) {
+  return GlyphAtlasConfig(
     fontSize: fontSize,
     fontWeight: FontWeight.normal,
     fontFamily: 'monospace',

--- a/packages/flterm/test/rendering/terminal_renderer_test.dart
+++ b/packages/flterm/test/rendering/terminal_renderer_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering.dart';
+import 'package:flterm/src/rendering/atlas/glyph_atlas_config.dart';
 import 'package:flterm/src/rendering/terminal_render_cache.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -215,12 +216,12 @@ TerminalRenderCache _renderCache() {
 }
 
 class _TrackingRenderCache extends TerminalRenderCache {
-  final acquiredKeys = <TerminalRenderCacheKey>[];
+  final acquiredKeys = <GlyphAtlasConfig>[];
 
   @override
-  TerminalGlyphAtlasHandle acquireGlyphAtlas(TerminalRenderCacheKey key) {
-    acquiredKeys.add(key);
-    return super.acquireGlyphAtlas(key);
+  TerminalGlyphAtlasHandle acquireGlyphAtlas(GlyphAtlasConfig config) {
+    acquiredKeys.add(config);
+    return super.acquireGlyphAtlas(config);
   }
 }
 


### PR DESCRIPTION
Split glyph atlas responsibilities into dedicated texture storage, entry cache, and configuration objects so atlas ownership and sharing logic are easier to reason about without changing terminal rendering behavior.