### PR TITLE
fix(ptyx): gate unix-only code

### DIFF
--- a/packages/ptyx/native/src/abi.rs
+++ b/packages/ptyx/native/src/abi.rs
@@ -70,11 +70,13 @@ pub(crate) const PTYX_MESSAGE_CLOSED: i64 = 2;
 
 pub(crate) const PTYX_EVENT_EXIT: i64 = 1;
 pub(crate) const PTYX_EVENT_ERROR: i64 = 2;
+#[cfg(unix)]
 pub(crate) const PTYX_EVENT_TERM_MODE: i64 = 3;
 
 pub(crate) const PTYX_ERROR_SOURCE_OUTPUT: i64 = 1;
 pub(crate) const PTYX_ERROR_SOURCE_WRITE: i64 = 2;
 pub(crate) const PTYX_ERROR_SOURCE_WAIT: i64 = 3;
+#[cfg(unix)]
 pub(crate) const PTYX_ERROR_SOURCE_MODE: i64 = 4;
 
 pub(crate) const PTYX_SESSION_OUTPUT_EXTERNAL_TYPED_DATA: u32 = 1 << 0;

--- a/packages/ptyx/native/src/message.rs
+++ b/packages/ptyx/native/src/message.rs
@@ -9,13 +9,15 @@ use std::os::raw::{c_char, c_void};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+#[cfg(unix)]
+use crate::abi::{PTYX_ERROR_SOURCE_MODE, PTYX_EVENT_TERM_MODE};
 use crate::abi::{
-    PTYX_ERROR_SOURCE_MODE, PTYX_ERROR_SOURCE_OUTPUT, PTYX_ERROR_SOURCE_WAIT,
-    PTYX_ERROR_SOURCE_WRITE, PTYX_EVENT_ERROR, PTYX_EVENT_EXIT, PTYX_EVENT_TERM_MODE,
-    PTYX_MESSAGE_CLOSED, PTYX_MESSAGE_OUTPUT,
+    PTYX_ERROR_SOURCE_OUTPUT, PTYX_ERROR_SOURCE_WAIT, PTYX_ERROR_SOURCE_WRITE, PTYX_EVENT_ERROR,
+    PTYX_EVENT_EXIT, PTYX_MESSAGE_CLOSED, PTYX_MESSAGE_OUTPUT,
 };
 use crate::dart_api::{post_array, DartValue};
 use crate::error::PtyxError;
+#[cfg(unix)]
 use crate::term_mode::TermMode;
 
 #[derive(Clone, Copy)]
@@ -23,6 +25,7 @@ pub(crate) enum ErrorSource {
     Output,
     Write,
     Wait,
+    #[cfg(unix)]
     Mode,
 }
 
@@ -113,6 +116,7 @@ fn error_source_value(source: ErrorSource) -> i64 {
         ErrorSource::Output => PTYX_ERROR_SOURCE_OUTPUT,
         ErrorSource::Write => PTYX_ERROR_SOURCE_WRITE,
         ErrorSource::Wait => PTYX_ERROR_SOURCE_WAIT,
+        #[cfg(unix)]
         ErrorSource::Mode => PTYX_ERROR_SOURCE_MODE,
     }
 }
@@ -133,6 +137,7 @@ fn post_error_message(port: i64, source: i64, status: i64, message: *const c_cha
     )
 }
 
+#[cfg(unix)]
 pub(crate) fn post_term_mode(port: i64, mode: TermMode) -> bool {
     let mode = crate::abi::ptyx_term_mode_t::from(mode);
     post_array(

--- a/packages/ptyx/native/src/output.rs
+++ b/packages/ptyx/native/src/output.rs
@@ -13,6 +13,7 @@ use crate::message::{
     post_error, post_output_closed, post_output_copied, post_output_external, ErrorSource,
 };
 
+#[cfg(unix)]
 const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const BACKPRESSURE_WAIT_INTERVAL: Duration = Duration::from_millis(10);
 
@@ -126,6 +127,7 @@ impl OutputBuffer {
         Ok(())
     }
 
+    #[cfg(unix)]
     pub(crate) fn poll_timeout(&self) -> Option<Duration> {
         Some(
             self.first_pending_at

--- a/packages/ptyx/native/src/runtime.rs
+++ b/packages/ptyx/native/src/runtime.rs
@@ -7,7 +7,9 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use crate::config::{RuntimeConfig, SessionOptions};
 use crate::error::{PtyxError, PtyxErrorKind};
@@ -20,6 +22,7 @@ use crate::term_mode::{term_mode_snapshot, TermMode};
 
 use crate::writer::WriteQueue;
 
+#[cfg(unix)]
 const INTERRUPTIBLE_SLEEP_STEP: Duration = Duration::from_millis(10);
 
 pub(crate) struct SessionRuntime {
@@ -282,6 +285,7 @@ fn mode_loop(inner: Arc<SessionInner>, stop: Arc<AtomicBool>, interval: Duration
     }
 }
 
+#[cfg(unix)]
 fn sleep_interruptibly(stop: &AtomicBool, duration: Duration) {
     let deadline = Instant::now() + duration;
     while !stop.load(Ordering::SeqCst) {

--- a/packages/ptyx/native/src/session.rs
+++ b/packages/ptyx/native/src/session.rs
@@ -183,10 +183,15 @@ pub(crate) fn spawn(config: SpawnConfig) -> Result<Box<Session>, PtyxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::config::EnvironmentMode;
+    #[cfg(unix)]
     use std::ffi::OsString;
+    #[cfg(unix)]
     use std::io::Read;
+    #[cfg(unix)]
     use std::thread;
+    #[cfg(unix)]
     use std::time::Duration;
 
     #[cfg(unix)]
@@ -289,6 +294,7 @@ mod tests {
         close(&session);
     }
 
+    #[cfg(unix)]
     fn wait_for_exit(session: &Session) -> i32 {
         crate::process::wait_exit(session.inner.as_ref()).unwrap()
     }

--- a/packages/ptyx/test/src/hook/cargo_target_test.dart
+++ b/packages/ptyx/test/src/hook/cargo_target_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:code_assets/code_assets.dart' show Architecture, OS;
 import 'package:hooks/hooks.dart' show BuildInput;
 import 'package:ptyx/src/hook/cargo_target.dart'
@@ -10,11 +12,14 @@ void main() {
       OS os = .macOS,
       Architecture architecture = .arm64,
     }) {
+      final tmp = Directory.systemTemp.createTempSync('ptyx_hook_test_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
       return BuildInput(<String, Object?>{
         'package_name': 'ptyx',
         'package_root': '.',
-        'out_dir': 'out',
-        'out_dir_shared': 'shared',
+        'out_dir': '${tmp.path}/out',
+        'out_dir_shared': '${tmp.path}/shared',
         'user_defines': <String, Object?>{},
         'config': <String, Object?>{
           'build_code_assets': true,

--- a/packages/ptyx/test/src/hook/library_provider_test.dart
+++ b/packages/ptyx/test/src/hook/library_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:code_assets/code_assets.dart' show Architecture, OS;
 import 'package:hooks/hooks.dart' show BuildInput;
 import 'package:ptyx/src/hook/library_provider.dart'
@@ -18,11 +20,14 @@ void main() {
       Architecture architecture = .arm64,
       Map<String, String> userDefines = const {},
     }) {
+      final tmp = Directory.systemTemp.createTempSync('ptyx_hook_test_');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+
       return BuildInput(<String, Object?>{
         'package_name': 'ptyx',
         'package_root': '.',
-        'out_dir': 'out',
-        'out_dir_shared': 'shared',
+        'out_dir': '${tmp.path}/out',
+        'out_dir_shared': '${tmp.path}/shared',
         'user_defines': <String, Object?>{
           'workspace_pubspec': <String, Object?>{
             'base_path': '.',


### PR DESCRIPTION
Gate ptyx native term-mode and Unix-only runtime helpers behind Unix cfgs, and make hook tests write build outputs into temporary directories so they do not share fixed local paths.