### PR TITLE
fix(libghostty): prevent resize FFI callback crash

### DIFF
--- a/packages/libghostty/lib/src/ffi/libghostty.g.dart
+++ b/packages/libghostty/lib/src/ffi/libghostty.g.dart
@@ -3239,7 +3239,7 @@ external void ghostty_terminal_reset(Terminal terminal);
 /// @ingroup terminal
 @ffi.Native<
   ffi.Int Function(Terminal, ffi.Uint16, ffi.Uint16, ffi.Uint32, ffi.Uint32)
->(symbol: 'ghostty_terminal_resize', isLeaf: true)
+>(symbol: 'ghostty_terminal_resize')
 external int _ghostty_terminal_resize(
   Terminal terminal,
   int cols,

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -285,6 +285,16 @@ void main() {
         expect(renderState.rows, 40);
       });
 
+      test('emits in-band size report when mode 2048 is enabled', () {
+        Uint8List? received;
+        terminal.onWritePty = (data) => received = data;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        terminal.resize(cols: 100, rows: 40, cellWidthPx: 9, cellHeightPx: 18);
+
+        expect(String.fromCharCodes(received!), '\x1B[48;40;100;720;900t');
+      });
+
       test('clamps cursor', () {
         terminal.write(Uint8List.fromList('\x1b[24;80H'.codeUnits));
         terminal.resize(cols: 40, rows: 10);

--- a/packages/libghostty/tool/ffigen.dart
+++ b/packages/libghostty/tool/ffigen.dart
@@ -109,7 +109,11 @@ Headers _headers({List<String> compilerOpts = const []}) => Headers(
   compilerOptions: [..._compilerOpts, ...compilerOpts],
 );
 
-const _nonLeafFunctions = {'ghostty_terminal_vt_write', 'ghostty_terminal_set'};
+const _nonLeafFunctions = {
+  'ghostty_terminal_resize',
+  'ghostty_terminal_vt_write',
+  'ghostty_terminal_set',
+};
 
 FfiGenerator _createGenerator({
   Map<String, Map<String, String>>? enumMemberRenames,


### PR DESCRIPTION
Mark `ghostty_terminal_resize` as a non-leaf FFI call because resize can synchronously emit an in-band size report through the PTY callback. Add regression coverage for mode 2048 size reports to prevent Dart's native callback from leaf call crash when terminal apps such as nvim resize.