### PR TITLE
fix(flterm): preserve erased cell backgrounds

### DIFF
--- a/packages/flterm/lib/src/rendering/paint_state.dart
+++ b/packages/flterm/lib/src/rendering/paint_state.dart
@@ -63,13 +63,30 @@ class TerminalPaintState {
     _updateThemePalette();
   }
 
-  void updateTerminalColors(TerminalColors colors) {
-    terminalForegroundArgb = colors.foreground.toArgb32;
-    terminalBackgroundArgb = colors.background.toArgb32;
+  /// Updates resolved terminal colors.
+  ///
+  /// Returns true when any color changed so cached paint data containing
+  /// packed ARGB values can be rebuilt.
+  bool updateTerminalColors(TerminalColors colors) {
+    var changed = false;
+    final foreground = colors.foreground.toArgb32;
+    final background = colors.background.toArgb32;
+    if (terminalForegroundArgb != foreground) {
+      terminalForegroundArgb = foreground;
+      changed = true;
+    }
+    if (terminalBackgroundArgb != background) {
+      terminalBackgroundArgb = background;
+      changed = true;
+    }
     final palette = colors.palette;
     for (var i = 0; i < terminalPaletteArgb.length; i++) {
-      terminalPaletteArgb[i] = palette[i].toArgb32;
+      final color = palette[i].toArgb32;
+      if (terminalPaletteArgb[i] == color) continue;
+      terminalPaletteArgb[i] = color;
+      changed = true;
     }
+    return changed;
   }
 
   void _updateThemePalette() {

--- a/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -240,11 +240,15 @@ class TerminalFrameBuilder {
     if (terminalDirty) {
       dirty = _renderState.update(terminal);
       final scrollbar = terminal.scrollbar;
+      final terminalColorsChanged = _state.updateTerminalColors(
+        _renderState.colors,
+      );
 
       _state.viewportOffset = scrollbar.offset;
-      if (dirty == DirtyState.full) {
-        _state.updateTerminalColors(_renderState.colors);
-      }
+      // RenderState updates colors even when its dirty result is clean.
+      // Since sprite buffers cache resolved ARGB values, color changes need
+      // the same full rebuild as other global terminal-state changes.
+      if (terminalColorsChanged) dirty = .full;
 
       _cursorBuilder.sync(
         terminal: terminal,
@@ -875,6 +879,7 @@ final class _RowBuildState {
   var rowBottom = 0.0;
 
   var prevStyleId = -1;
+  int? prevBackgroundArgb;
   var prevSelected = false;
 
   var baseForeground = 0xFFFFFFFF;
@@ -906,6 +911,7 @@ final class _RowBuildState {
     col = 0;
     spriteX = 0.0;
     prevStyleId = -1;
+    prevBackgroundArgb = null;
     prevSelected = false;
     baseForeground = 0xFFFFFFFF;
     baseBackground = frame.defaultBackgroundArgb;
@@ -956,12 +962,18 @@ final class _StyleResolver {
 
   void update(
     CellIterator cell, {
+    required int? backgroundArgb,
     required bool selected,
     required _RowBuildState row,
   }) {
-    if (cell.styleId != row.prevStyleId) {
-      final (fg, bg, style, explicitBg) = _resolveBase(cell);
+    if (cell.styleId != row.prevStyleId ||
+        backgroundArgb != row.prevBackgroundArgb) {
+      final (fg, bg, style, explicitBg) = _resolveBase(
+        cell,
+        backgroundArgb: backgroundArgb,
+      );
       row.prevStyleId = cell.styleId;
+      row.prevBackgroundArgb = backgroundArgb;
       row.baseForeground = fg;
       row.baseBackground = bg;
       row.baseBackgroundExplicit = explicitBg;
@@ -995,9 +1007,28 @@ final class _StyleResolver {
   }
 
   (int foreground, int background, Style style, bool explicitBg) _resolveBase(
-    CellIterator cell,
-  ) {
+    CellIterator cell, {
+    required int? backgroundArgb,
+  }) {
     final id = cell.styleId;
+    final style = cell.style;
+    final contentBackground = style.background is DefaultColor
+        ? backgroundArgb
+        : null;
+    if (contentBackground != null) {
+      final (foreground, background) = _resolveStyleColors(
+        _state,
+        style,
+        defaultForeground: _defaultFg,
+        defaultBackground: _defaultBg,
+      );
+      return (
+        foreground,
+        style.inverse ? background : contentBackground,
+        style,
+        true,
+      );
+    }
 
     if (id < _maxEntries && _gen[id] == _generation) {
       return (
@@ -1008,7 +1039,6 @@ final class _StyleResolver {
       );
     }
 
-    final style = cell.style;
     final (foreground, background) = _resolveStyleColors(
       _state,
       style,
@@ -1253,9 +1283,17 @@ final class _TerminalRowBuilder {
 
     final selected = _frame.isSelected(row.row, row.col);
 
-    if (cell.styleId != row.prevStyleId || selected != row.prevSelected) {
+    final backgroundArgb = cell.hasText ? null : cell.backgroundArgb;
+    if (cell.styleId != row.prevStyleId ||
+        backgroundArgb != row.prevBackgroundArgb ||
+        selected != row.prevSelected) {
       _foreground.flush(row);
-      _styles.update(cell, selected: selected, row: row);
+      _styles.update(
+        cell,
+        backgroundArgb: backgroundArgb,
+        selected: selected,
+        row: row,
+      );
     }
     _syncBackgroundRun(row);
 

--- a/packages/flterm/test/rendering/terminal_frame_builder_test.dart
+++ b/packages/flterm/test/rendering/terminal_frame_builder_test.dart
@@ -196,6 +196,49 @@ void main() {
       expect(sprites.regular.sealedColors.single, 0xFF010203.toSigned(32));
     });
 
+    test('sync updates terminal background after OSC 11', () {
+      terminal.foreground = const RgbColor(255, 255, 255);
+      terminal.background = const RgbColor(0, 0, 0);
+      builder.sync(terminal, terminalDirty: true);
+      writeUtf8(terminal, '\x1b]11;rgb:1e/20/24\x1b\\');
+
+      builder.sync(terminal, terminalDirty: true);
+
+      expect(state.terminalBackgroundArgb, 0xFF1E2024);
+    });
+
+    test('sync rebuilds retained text colors after OSC 10', () {
+      terminal.foreground = const RgbColor(255, 255, 255);
+      terminal.background = const RgbColor(0, 0, 0);
+      writeUtf8(terminal, 'A\r\nB');
+      builder.sync(terminal, terminalDirty: true);
+      writeUtf8(terminal, '\x1b]10;rgb:01/02/03\x1b\\');
+
+      builder.sync(terminal, terminalDirty: true);
+
+      expect(sprites.regular.sealedColors, [
+        0xFF010203.toSigned(32),
+        0xFF010203.toSigned(32),
+      ]);
+    });
+
+    test('sync emits erase backgrounds after resize', () {
+      final frame = createFrame(cols: 8, rows: 2);
+      writeUtf8(frame.terminal, '\x1b[2;2H\x1b[48;2;30;32;36m\x1b[K\x1b[0m');
+      frame.builder.sync(frame.terminal, terminalDirty: true);
+      frame.terminal.resize(cols: 10, rows: 2);
+      frame.state
+        ..cols = 10
+        ..rows = 2;
+      frame.builder
+        ..configure(2, 10)
+        ..markAllRowsDirty();
+
+      frame.builder.sync(frame.terminal, terminalDirty: true);
+
+      expect(frame.sprites.background.count, greaterThan(0));
+    });
+
     test('sync resolves cursor dynamic colors from render state colors', () {
       state.updateTheme(
         TerminalTheme.dark().copyWith(


### PR DESCRIPTION
Preserve erased/background-only cell colors when flterm rebuilds terminal rows. Resolve content backed cell backgrounds during frame building and rebuild cached sprite colors when terminal colors change, with regression coverage for retained colors and erased backgrounds after resize.