### PR TITLE
fix(flterm): encode shifted printable keys as text

### DIFF
--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -278,12 +278,18 @@ class TerminalControllerImpl extends TerminalController
     final unshiftedCodepoint = unshiftedCodepointForKey(key);
     final mods = _currentMods();
     final character = _encoderCharacter(event.character);
+    final consumedMods = _consumedModsFor(
+      character,
+      unshiftedCodepoint: unshiftedCodepoint,
+      mods: mods,
+    );
 
     _keyEvent
       ..key = key
       ..mods = mods
       ..action = action
       ..utf8 = character
+      ..consumedMods = consumedMods
       ..unshiftedCodepoint = unshiftedCodepoint
       ..composing = _hasActiveComposition;
 
@@ -567,6 +573,7 @@ class TerminalControllerImpl extends TerminalController
       ..key = key
       ..mods = effectiveMods
       ..action = .press
+      ..consumedMods = const .none()
       ..unshiftedCodepoint = codepoint
       ..utf8 = codepoint > 0 ? String.fromCharCode(codepoint) : null
       ..composing = false;
@@ -674,6 +681,23 @@ class TerminalControllerImpl extends TerminalController
     return mods;
   }
 
+  Mods _consumedModsFor(
+    String? character, {
+    required int unshiftedCodepoint,
+    required Mods mods,
+  }) {
+    if (!mods.hasShift || character == null || unshiftedCodepoint == 0) {
+      return const .none();
+    }
+
+    final codepoints = character.runes.iterator;
+    if (!codepoints.moveNext()) return const .none();
+    final codepoint = codepoints.current;
+    if (codepoints.moveNext()) return const .none();
+    if (codepoint == unshiftedCodepoint) return const .none();
+    return const .shift();
+  }
+
   bool _emitKeyPress(
     vt.Key key, {
     Mods mods = const .none(),
@@ -684,6 +708,7 @@ class TerminalControllerImpl extends TerminalController
       ..key = key
       ..mods = mods
       ..action = .press
+      ..consumedMods = const .none()
       ..unshiftedCodepoint = codepoint
       ..utf8 = codepoint > 0 ? String.fromCharCode(codepoint) : null
       ..composing = false;

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -686,6 +686,8 @@ class TerminalControllerImpl extends TerminalController
     required int unshiftedCodepoint,
     required Mods mods,
   }) {
+    // Flutter does not expose consumed modifiers, so this fallback only
+    // accounts for Shift producing a different single-codepoint character.
     if (!mods.hasShift || character == null || unshiftedCodepoint == 0) {
       return const .none();
     }

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -435,6 +435,30 @@ void main() {
       });
     });
 
+    testWidgets('shifted printable key emits text in keyboard protocol mode', (
+      tester,
+    ) async {
+      writeUtf8(controller, '\x1b[=1u');
+      final output = <Uint8List>[];
+      controller.onOutput = output.add;
+
+      await tester.pumpWidget(
+        wrapInApp(controller: controller, autofocus: true, showKeyboard: false),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.sendKeyEvent(
+        LogicalKeyboardKey.semicolon,
+        physicalKey: PhysicalKeyboardKey.semicolon,
+        character: ':',
+      );
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+
+      expect(decodeOutput(output), ':');
+    });
+
     testWidgets('composition updates preedit without output', (tester) async {
       final output = <Uint8List>[];
       controller.onOutput = output.add;


### PR DESCRIPTION
Encode shifted printable input as text when keyboard protocol mode is active by passing consumed Shift to the key encoder. This fixes cases like `Shift+;` producing `:` instead of a modified-key escape sequence, while keeping broader layout and IME keyboard parity out of scope.