### PR TITLE
chore(libghostty): prepare v0.0.9 release

### DIFF
--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.0.9
+
+### Added
+
+- **Back-arrow key mode**: `TerminalMode.backArrowKeyMode()` and
+  `KeyEncoder.setBackArrowKeyMode()` expose DEC mode 67, letting legacy
+  Backspace encoding switch between DEL and BS.
+- **APC buffer limits**: `Terminal.setApcBufferLimit()` and
+  `Terminal.setKittyApcBufferLimit()` configure general and Kitty-specific
+  APC payload limits.
+
+### Fixed
+
+- **Resize callbacks**: `ghostty_terminal_resize` is no longer bound as a
+  leaf FFI call, preventing callback crashes when resize emits in-band size
+  reports through `onWritePty`.
+
 ## 0.0.8
 
 ### Breaking

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.8
+  libghostty: ^0.0.9
 ```
 
 On web, initialize the WASM module once before using any bindings:

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
Prepare the libghostty 0.0.9 release by bumping package metadata, refreshing the README install snippet, and adding changelog coverage for back-arrow key mode, APC buffer limits, the Ghostty pin update, and the resize callback FFI fix.