### PR TITLE
chore(flterm): prepare v0.0.3 release

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.0.3
+
+### Breaking
+
+- **Flutter SDK floor**: requires Dart 3.12 and Flutter 3.44.
+
+### Added
+
+- **IME composition**: composing text appears at the terminal cursor
+  and works with platform text input.
+- **Sprite glyph rendering**: box drawing, block elements, Braille,
+  Powerline, geometric shapes, and legacy computing glyphs render
+  with built-in glyphs.
+- **Shared render caches**: `TerminalScope` lets multiple terminal
+  views share compatible rendering resources.
+- **APC buffer limits**: `TerminalConfig.apcBufferLimit` controls how
+  much APC payload data the terminal accepts.
+
+### Changed
+
+- **Rendering pipeline**: terminal frames share rendering caches and do
+  less repeated work between frames.
+
+### Fixed
+
+- **Keyboard input**: shifted printable keys and IME editing produce
+  the expected terminal text.
+- **Rendering accuracy**: erased backgrounds, cursor shape, cell
+  metrics, and sprite glyphs render more consistently.
+
 ## 0.0.2
 
 ### Breaking

--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -12,7 +12,7 @@ libghostty-vt engine.
 
 | Android | iOS | Linux | macOS | Web | Windows |
 |:-------:|:---:|:-----:|:-----:|:---:|:-------:|
-|    ✅    |  ✅  |   ✅   |   ✅   |  ✅  |    ✅    |
+|    ✓    |  ✓  |   ✓   |   ✓   |  ✓  |    ✓    |
 
 ## Overview
 
@@ -35,7 +35,7 @@ libghostty-vt engine.
 
 ```yaml
 dependencies:
-  flterm: ^0.0.2
+  flterm: ^0.0.3
 ```
 
 On web, initialize the wasm module once before mounting any terminal:

--- a/packages/flterm/pubspec.yaml
+++ b/packages/flterm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flterm
 description: Flutter terminal widget on top of Ghostty's libghostty-vt engine.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/elias8/libghostty
 repository: https://github.com/elias8/libghostty/tree/main/packages/flterm
 issue_tracker: https://github.com/elias8/libghostty/issues
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   image: ^4.8.0
-  libghostty: ^0.0.8
+  libghostty: ^0.0.9
   meta: ^1.18.0
 
 dev_dependencies:


### PR DESCRIPTION
- Requires Dart 3.12 and Flutter 3.44.
- Adds IME composition support with composing text shown at the terminal cursor.
- Adds built-in sprite rendering for box drawing, block elements, Braille, Powerline, geometric shapes, and legacy computing glyphs.
- Adds `TerminalScope` for sharing compatible rendering resources across terminal views.
- Adds `TerminalConfig.apcBufferLimit` for controlling accepted APC payload size.
- Improves shifted printable key input, IME editing, cursor shape, cell metrics, erased backgrounds, and sprite glyph rendering.