### PR TITLE
Reorder font family fallback list

### DIFF
--- a/packages/flterm/lib/src/foundation/terminal_theme.dart
+++ b/packages/flterm/lib/src/foundation/terminal_theme.dart
@@ -27,16 +27,16 @@ const _darkAnsiColors = [
 ];
 
 const _defaultFontFamilyFallback = [
-  'Apple Color Emoji',
-  'Noto Color Emoji',
-  'Noto Emoji',
-  'Segoe UI Emoji',
   'JetBrains Mono',
   'Menlo',
   'Consolas',
   'Ubuntu Mono',
   'DejaVu Sans Mono',
   'Courier New',
+  'Apple Color Emoji',
+  'Noto Color Emoji',
+  'Noto Emoji',
+  'Segoe UI Emoji',
 ];
 
 const _lightAnsiColors = [
@@ -299,8 +299,9 @@ final class TerminalTheme {
 
   /// Fallback font families tried when a glyph is missing from [fontFamily].
   ///
-  /// Defaults to platform emoji fonts (Apple Color Emoji, Segoe UI Emoji,
-  /// Noto Color Emoji) followed by a cross-platform monospace chain.
+  /// Defaults to common monospace fonts followed by platform emoji fonts. Emoji
+  /// fonts are kept last so text-like glyphs, including digits and symbols,
+  /// stay grid-aligned when a monospace fallback can render them.
   final List<String> fontFamilyFallback;
 
   /// Font size in logical pixels.


### PR DESCRIPTION
Reorder _defaultFontFamilyFallback to place standard monospace font families before emoji fonts. This ensures digits and letters resolve to monospaced text fallbacks first, while emoji fonts still act as leaf-level fallbacks for characters (like icons/emojis) that are truly missing from the monospace fonts.