### PR TITLE
feat(flterm): expose terminal control APIs

### DIFF
--- a/packages/flterm/lib/src/foundation/screen_extension.dart
+++ b/packages/flterm/lib/src/foundation/screen_extension.dart
@@ -1,5 +1,5 @@
 import 'package:libghostty/libghostty.dart'
-    show CellWidth, GridRef, RenderState, Terminal;
+    show CellIterator, CellWidth, GridRef, RenderState, RowIterator, Terminal;
 
 final _defaultWordPattern = RegExp(r'\w');
 
@@ -130,74 +130,58 @@ extension TerminalScreenExtension on Terminal {
   }) {
     final isWord = wordPattern ?? _defaultWordPattern;
     final rs = RenderState()..update(this);
+    final rows = RowIterator();
+    final cells = CellIterator();
     try {
       if (row < 0 || row >= rs.rows) return (col, col + 1);
 
       final maxCol = rs.cols;
       if (col < 0 || col >= maxCol) return (col, col + 1);
 
-      int snapped;
-      {
-        final ref = GridRef.at(this, col: col, row: row);
-        snapped = ref.wide == CellWidth.spacerTail && col > 0 ? col - 1 : col;
-        ref.dispose();
+      rows.reset(rs);
+      for (var i = 0; i <= row; i++) {
+        if (!rows.next()) return (col, col + 1);
       }
+      cells.reset(rows);
 
-      String contentAt(int c) {
-        final ref = GridRef.at(this, col: c, row: row);
-        final s = ref.content;
-        ref.dispose();
-        return s;
-      }
+      cells.select(col);
+      final snapped = cells.wide == .spacerTail && col > 0 ? col - 1 : col;
 
-      CellWidth wideAt(int c) {
-        final ref = GridRef.at(this, col: c, row: row);
-        final w = ref.wide;
-        ref.dispose();
-        return w;
-      }
-
-      bool isWideAt(int c) {
-        final ref = GridRef.at(this, col: c, row: row);
-        final w = ref.isWide;
-        ref.dispose();
-        return w;
-      }
-
-      bool matchesWord(String s) => isWord.matchAsPrefix(s) != null;
-
-      final charAtPos = contentAt(snapped);
-      if (charAtPos.isEmpty || !matchesWord(charAtPos)) {
-        final span = isWideAt(snapped) ? 2 : 1;
+      cells.select(snapped);
+      final content = cells.content;
+      if (content.isEmpty || isWord.matchAsPrefix(content) == null) {
+        final span = cells.wide == .wide ? 2 : 1;
         return (snapped, snapped + span);
       }
 
       var start = snapped;
       while (start > 0) {
-        final w = wideAt(start - 1);
-        if (w == CellWidth.spacerTail) {
+        cells.select(start - 1);
+        if (cells.wide == .spacerTail) {
           start--;
           continue;
         }
-        final c = contentAt(start - 1);
-        if (c.isEmpty || !matchesWord(c)) break;
+        final content = cells.content;
+        if (content.isEmpty || isWord.matchAsPrefix(content) == null) break;
         start--;
       }
 
       var end = snapped + 1;
       while (end < maxCol) {
-        final w = wideAt(end);
-        if (w == CellWidth.spacerTail) {
+        cells.select(end);
+        if (cells.wide == .spacerTail) {
           end++;
           continue;
         }
-        final c = contentAt(end);
-        if (c.isEmpty || !matchesWord(c)) break;
+        final content = cells.content;
+        if (content.isEmpty || isWord.matchAsPrefix(content) == null) break;
         end++;
       }
 
       return (start, end);
     } finally {
+      cells.dispose();
+      rows.dispose();
       rs.dispose();
     }
   }

--- a/packages/flterm/lib/src/foundation/terminal_config.dart
+++ b/packages/flterm/lib/src/foundation/terminal_config.dart
@@ -98,6 +98,12 @@ class TerminalConfig {
   /// Defaults to 65 MiB. Set to 0 to reject APC payload data.
   final int apcBufferLimit;
 
+  /// Whether Glyph Protocol APC handling is enabled.
+  ///
+  /// Defaults to false. Enable when the embedder wants libghostty to parse
+  /// Glyph Protocol image payloads in addition to Kitty graphics.
+  final bool glyphProtocol;
+
   /// Initial cursor shape. Terminal programs can override via DECSCUSR.
   final CursorShape cursorStyle;
 
@@ -154,6 +160,7 @@ class TerminalConfig {
     this.rows = 24,
     this.wordPattern,
     this.cursorBlink,
+    this.glyphProtocol = false,
     this.apcBufferLimit = defaultApcBufferLimit,
     this.enquiryResponse = '',
     this.modes = defaultModes,
@@ -179,6 +186,7 @@ class TerminalConfig {
     scrollbackLimit,
     kittyImageStorageLimit,
     apcBufferLimit,
+    glyphProtocol,
     cursorStyle,
     cursorBlink,
     .hashAllUnordered(modes.entries.map((e) => .hash(e.key, e.value))),
@@ -198,6 +206,7 @@ class TerminalConfig {
           scrollbackLimit == other.scrollbackLimit &&
           kittyImageStorageLimit == other.kittyImageStorageLimit &&
           apcBufferLimit == other.apcBufferLimit &&
+          glyphProtocol == other.glyphProtocol &&
           cursorStyle == other.cursorStyle &&
           cursorBlink == other.cursorBlink &&
           _modesEqual(modes, other.modes) &&
@@ -214,6 +223,7 @@ class TerminalConfig {
     int? scrollbackLimit,
     int? kittyImageStorageLimit,
     int? apcBufferLimit,
+    bool? glyphProtocol,
     CursorShape? cursorStyle,
     bool? cursorBlink,
     Map<TerminalMode, bool>? modes,
@@ -230,6 +240,7 @@ class TerminalConfig {
       kittyImageStorageLimit:
           kittyImageStorageLimit ?? this.kittyImageStorageLimit,
       apcBufferLimit: apcBufferLimit ?? this.apcBufferLimit,
+      glyphProtocol: glyphProtocol ?? this.glyphProtocol,
       cursorStyle: cursorStyle ?? this.cursorStyle,
       cursorBlink: cursorBlink ?? this.cursorBlink,
       modes: modes ?? this.modes,

--- a/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -1023,6 +1023,10 @@ final class _StyleResolver {
     required int? backgroundArgb,
   }) {
     final id = cell.styleId;
+    if (!cell.hasStyling && backgroundArgb == null) {
+      return (_defaultFg, _defaultBg, const Style(), false);
+    }
+
     final style = cell.style;
     final contentBackground = style.background is DefaultColor
         ? backgroundArgb

--- a/packages/flterm/lib/src/widgets/terminal_controller.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller.dart
@@ -38,6 +38,9 @@ abstract class TerminalController extends ChangeNotifier
   /// Called when the terminal title changes. Read [title] for the value.
   VoidCallback? onTitleChanged;
 
+  /// Called when the working directory changes. Read [pwd] for the value.
+  VoidCallback? onPwdChanged;
+
   /// Called when the grid dimensions change. Forward to your backend.
   OnResize? onResize;
 

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -87,7 +87,7 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
-  TerminalScreen get activeScreen => _activeScreen;
+  TerminalScreen get activeScreen => terminal.activeScreen;
 
   @override
   set brightness(Brightness value) {
@@ -112,11 +112,13 @@ class TerminalControllerImpl extends TerminalController
   bool get cursorBlinks {
     if (!_cursorBlinking || !hasFocus) return false;
     if (_activeScreen == .alternate) return true;
-    final sc = _scrollController;
-    if (sc == null || !sc.hasClients) return true;
-    final pos = sc.position;
-    if (!pos.hasContentDimensions) return true;
-    return pos.pixels >= pos.maxScrollExtent - 1.0;
+    final scrollController = _scrollController;
+    if (scrollController == null || !scrollController.hasClients) {
+      return terminal.isViewportActive;
+    }
+    final position = scrollController.position;
+    if (!position.hasContentDimensions) return terminal.isViewportActive;
+    return position.pixels >= position.maxScrollExtent - 1.0;
   }
 
   @override

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -35,6 +35,8 @@ class TerminalControllerImpl extends TerminalController
   @override
   final Terminal terminal;
   final _renderState = RenderState();
+  final _rowIterator = RowIterator();
+  final _cellIterator = CellIterator();
   final _keyEncoder = KeyEncoder();
   final _mouseEncoder = MouseEncoder();
   final vt.KeyEvent _keyEvent;
@@ -249,6 +251,8 @@ class TerminalControllerImpl extends TerminalController
     _mouseEvent.dispose();
     _keyEncoder.dispose();
     _mouseEncoder.dispose();
+    _cellIterator.dispose();
+    _rowIterator.dispose();
     _renderState.dispose();
     terminal.dispose();
     super.dispose();
@@ -458,13 +462,13 @@ class TerminalControllerImpl extends TerminalController
 
     var lastScreenRow = -1;
     var lastContentCol = 0;
-    for (var row = 0; row < rows; row++) {
+    _rowIterator.reset(_renderState);
+    while (_rowIterator.next() && _rowIterator.index < rows) {
+      final row = _rowIterator.index;
       var rowLastCol = 0;
-      for (var col = 0; col < cols; col++) {
-        final ref = GridRef.at(terminal, col: col, row: row);
-        final hasContent = ref.graphemes.isNotEmpty;
-        ref.dispose();
-        if (hasContent) rowLastCol = col + 1;
+      _cellIterator.reset(_rowIterator);
+      while (_cellIterator.next() && _cellIterator.col < cols) {
+        if (_cellIterator.hasText) rowLastCol = _cellIterator.col + 1;
       }
       if (rowLastCol > 0) {
         lastScreenRow = row;

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -927,6 +927,7 @@ class TerminalControllerImpl extends TerminalController
     terminal.onWritePty = _emitOutput;
     terminal.onBell = () => onBell?.call();
     terminal.onTitleChanged = () => onTitleChanged?.call();
+    terminal.onPwdChanged = _handlePwdChanged;
     terminal.onColorScheme = () => _brightness == .light ? .light : .dark;
     terminal.onSize = _handleSizeQuery;
     terminal.onDeviceAttributes = () => _config.deviceAttributes;
@@ -934,6 +935,11 @@ class TerminalControllerImpl extends TerminalController
     terminal.onEnquiry = enquiry.isEmpty
         ? null
         : () => .fromList(utf8.encode(enquiry));
+  }
+
+  void _handlePwdChanged() {
+    onPwdChanged?.call();
+    notifyListeners();
   }
 
   /// Filters out control characters and macOS function key private-use

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -75,7 +75,6 @@ class TerminalControllerImpl extends TerminalController
       ),
       super.base() {
     installDefaultKittyPngDecoder();
-    _applyTerminalOptions();
     _textInput
       ..onTextCommitted = _handleTextCommitted
       ..onDelete = _handleDelete
@@ -83,6 +82,7 @@ class TerminalControllerImpl extends TerminalController
       ..onNewline = _handleNewline;
     _wireTerminalCallbacks();
     _applyModes();
+    _applyTerminalOptions();
     terminal.addListener(_onTerminalChanged);
   }
 
@@ -102,8 +102,8 @@ class TerminalControllerImpl extends TerminalController
   set config(TerminalConfig value) {
     if (_config == value) return;
     _config = value;
-    _applyTerminalOptions();
     _applyModes();
+    _applyTerminalOptions();
     _wireTerminalCallbacks();
     notifyListeners();
   }
@@ -654,6 +654,10 @@ class TerminalControllerImpl extends TerminalController
   void _applyTerminalOptions() {
     terminal.kittyImageStorageLimit = _config.kittyImageStorageLimit;
     terminal.setApcBufferLimit(_config.apcBufferLimit);
+    terminal.setGlyphProtocol(enabled: _config.glyphProtocol);
+    terminal.defaultCursorShape = _config.cursorStyle;
+    terminal.defaultCursorBlink = _config.cursorBlink;
+    _cursorBlinking = _effectiveCursorBlinking();
   }
 
   bool _consumeCommittedCompositionEditKey(
@@ -669,16 +673,6 @@ class TerminalControllerImpl extends TerminalController
     if (key != .backspace && key != .delete) return false;
     if (!mods.isEmpty) return false;
     return _textInput.consumeCommittedCompositionEdit();
-  }
-
-  Mods _currentMods() {
-    var mods = _virtualMods;
-    final keyboard = HardwareKeyboard.instance;
-    if (keyboard.isShiftPressed) mods = mods | const .shift();
-    if (keyboard.isControlPressed) mods = mods | const .ctrl();
-    if (keyboard.isAltPressed) mods = mods | const .alt();
-    if (keyboard.isMetaPressed) mods = mods | const .superKey();
-    return mods;
   }
 
   Mods _consumedModsFor(
@@ -698,6 +692,20 @@ class TerminalControllerImpl extends TerminalController
     if (codepoints.moveNext()) return const .none();
     if (codepoint == unshiftedCodepoint) return const .none();
     return const .shift();
+  }
+
+  Mods _currentMods() {
+    var mods = _virtualMods;
+    final keyboard = HardwareKeyboard.instance;
+    if (keyboard.isShiftPressed) mods = mods | const .shift();
+    if (keyboard.isControlPressed) mods = mods | const .ctrl();
+    if (keyboard.isAltPressed) mods = mods | const .alt();
+    if (keyboard.isMetaPressed) mods = mods | const .superKey();
+    return mods;
+  }
+
+  bool _effectiveCursorBlinking() {
+    return _config.cursorBlink ?? terminal.modeGet(const .cursorBlinking());
   }
 
   bool _emitKeyPress(
@@ -849,8 +857,7 @@ class TerminalControllerImpl extends TerminalController
       changed = true;
     }
 
-    final newCursorBlinking =
-        _config.cursorBlink ?? terminal.modeGet(const .cursorBlinking());
+    final newCursorBlinking = _effectiveCursorBlinking();
     if (newCursorBlinking != _cursorBlinking) {
       _cursorBlinking = newCursorBlinking;
       changed = true;

--- a/packages/flterm/test/foundation/terminal_config_test.dart
+++ b/packages/flterm/test/foundation/terminal_config_test.dart
@@ -13,6 +13,7 @@ void main() {
         expect(config.scrollbackLimit, 10000000);
         expect(config.cursorStyle, CursorShape.block);
         expect(config.cursorBlink, isNull);
+        expect(config.glyphProtocol, isFalse);
         expect(config.apcBufferLimit, TerminalConfig.defaultApcBufferLimit);
         expect(config.scrollToBottom, ScrollToBottom.onKeystroke);
         expect(config.selectionClearOnTyping, isTrue);
@@ -64,11 +65,13 @@ void main() {
         final updated = config.copyWith(
           scrollbackLimit: 99999,
           apcBufferLimit: 1024,
+          glyphProtocol: true,
           cursorBlink: false,
         );
 
         expect(updated.scrollbackLimit, 99999);
         expect(updated.apcBufferLimit, 1024);
+        expect(updated.glyphProtocol, isTrue);
         expect(updated.cursorBlink, isFalse);
         expect(updated.cols, config.cols);
       });
@@ -104,6 +107,9 @@ void main() {
         const apcC = TerminalConfig(apcBufferLimit: 1024);
         expect(apcA, equals(apcC));
         expect(apcA, isNot(equals(apcB)));
+
+        const glyphProtocol = TerminalConfig(glyphProtocol: true);
+        expect(a, isNot(equals(glyphProtocol)));
       });
 
       test('ignores map order', () {

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -482,6 +482,39 @@ void main() {
 
         expect(KittyGraphics.of(controller.terminal)!.image(92), isNull);
       });
+
+      test('initial config applies cursor reset defaults', () {
+        final custom = TerminalControllerImpl(
+          config: const TerminalConfig(
+            cursorStyle: CursorShape.underline,
+            cursorBlink: true,
+          ),
+        );
+        final renderState = RenderState();
+        addTearDown(custom.dispose);
+        addTearDown(renderState.dispose);
+
+        writeTerminalUtf8(custom.terminal, '\x1b[0 q');
+        renderState.update(custom.terminal);
+
+        expect(renderState.cursor.shape, CursorShape.underline);
+        expect(renderState.cursor.blinking, isTrue);
+      });
+
+      test('setter applies cursor reset defaults', () {
+        final renderState = RenderState();
+        addTearDown(renderState.dispose);
+
+        controller.config = const TerminalConfig(
+          cursorStyle: CursorShape.bar,
+          cursorBlink: false,
+        );
+        writeTerminalUtf8(controller.terminal, '\x1b[0 q');
+        renderState.update(controller.terminal);
+
+        expect(renderState.cursor.shape, CursorShape.bar);
+        expect(renderState.cursor.blinking, isFalse);
+      });
     });
 
     group('modeGet and modeSet', () {

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -558,6 +558,41 @@ void main() {
       });
     });
 
+    group('pwd', () {
+      test('updates via OSC 7 escape sequence', () {
+        writeTerminalUtf8(controller.terminal, '\x1b]7;file:///tmp\x07');
+
+        expect(controller.pwd, 'file:///tmp');
+      });
+
+      test('notifies listeners on OSC 7 change', () {
+        var notifyCount = 0;
+        controller.addListener(() => notifyCount++);
+
+        writeTerminalUtf8(controller.terminal, '\x1b]7;file:///tmp\x07');
+
+        expect(notifyCount, greaterThan(0));
+      });
+
+      test('fires onPwdChanged callback', () {
+        var fired = false;
+        controller.onPwdChanged = () => fired = true;
+
+        writeTerminalUtf8(controller.terminal, '\x1b]7;file:///tmp\x07');
+
+        expect(fired, isTrue);
+      });
+
+      test('exposes updated value during onPwdChanged callback', () {
+        var pwd = '';
+        controller.onPwdChanged = () => pwd = controller.pwd;
+
+        writeTerminalUtf8(controller.terminal, '\x1b]7;file:///tmp\x07');
+
+        expect(pwd, 'file:///tmp');
+      });
+    });
+
     group('selectWord', () {
       test('selects word at position', () {
         replaceController(const TerminalConfig(cols: 20, rows: 5));

--- a/packages/flterm/test/widgets/terminal_view_binding_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_binding_test.dart
@@ -344,6 +344,63 @@ void main() {
 
         expect(binding.cursorBlinks, isFalse);
       });
+
+      testWidgets('uses libghostty viewport-active state on primary screen', (
+        tester,
+      ) async {
+        controller.dispose();
+        controller = TerminalControllerImpl(
+          config: const TerminalConfig(cols: 20, rows: 2),
+        );
+        binding = controller as TerminalViewBinding;
+        final focusNode = FocusNode();
+        final sc = ScrollController();
+        addTearDown(focusNode.dispose);
+        addTearDown(sc.dispose);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: Focus(focusNode: focusNode, child: const SizedBox()),
+          ),
+        );
+        binding.attach(focusNode, sc);
+        focusNode.requestFocus();
+        await tester.pump();
+
+        writeNumberedLines(controller, 10);
+        controller.terminal.scrollViewport(-1);
+
+        expect(controller.hasFocus, isTrue);
+        expect(controller.scrollbackRows, greaterThan(0));
+        expect(controller.terminal.isViewportActive, isFalse);
+        expect(binding.cursorBlinks, isFalse);
+      });
+
+      testWidgets('respects cursorBlink config before terminal changes', (
+        tester,
+      ) async {
+        controller.dispose();
+        controller = TerminalControllerImpl(
+          config: const TerminalConfig(cursorBlink: false),
+        );
+        binding = controller as TerminalViewBinding;
+        final focusNode = FocusNode();
+        final sc = ScrollController();
+        addTearDown(focusNode.dispose);
+        addTearDown(sc.dispose);
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: Focus(focusNode: focusNode, child: const SizedBox()),
+          ),
+        );
+        binding.attach(focusNode, sc);
+        focusNode.requestFocus();
+        await tester.pump();
+
+        expect(controller.hasFocus, isTrue);
+        expect(binding.cursorBlinks, isFalse);
+      });
     });
 
     group('paste', () {

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -96,6 +96,7 @@ void main() {
     Widget wrapInApp({
       required TerminalController controller,
       TerminalTheme? theme,
+      TerminalScrollController? scrollController,
       bool autofocus = false,
       bool showKeyboard = true,
       MouseAutoHide mouseAutoHide = .onInput,
@@ -112,6 +113,7 @@ void main() {
             child: TerminalView(
               controller: controller,
               theme: theme,
+              scrollController: scrollController,
               autofocus: autofocus,
               showKeyboard: showKeyboard,
               mouseAutoHide: mouseAutoHide,
@@ -165,6 +167,40 @@ void main() {
       for (var i = 0; i < count; i++) {
         writeUtf8(controller, 'line $i\r\n');
       }
+    }
+
+    TerminalRenderer renderer(WidgetTester tester) {
+      return tester.widget<TerminalRenderer>(find.byType(TerminalRenderer));
+    }
+
+    Future<TerminalScrollController> pumpBlinkingScrollableTerminal(
+      WidgetTester tester,
+    ) async {
+      controller.dispose();
+      controller = TerminalController(
+        config: const TerminalConfig(cursorBlink: true),
+      );
+      final scrollController = TerminalScrollController();
+      final theme = TerminalTheme.dark().copyWith(
+        cursor: const CursorTheme(blinkInterval: Duration(milliseconds: 10)),
+      );
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(
+        wrapInApp(
+          controller: controller,
+          theme: theme,
+          scrollController: scrollController,
+          autofocus: true,
+          showKeyboard: false,
+          width: 400,
+          height: 80,
+        ),
+      );
+      await tester.pump();
+      writeNumberedLines(40);
+      await tester.pump();
+      await tester.pump();
+      return scrollController;
     }
 
     testWidgets('renders with controller', (tester) async {
@@ -254,6 +290,47 @@ void main() {
 
       expect(controller.hasFocus, isTrue);
       expect(controller.keyboardState, KeyboardState.showing);
+    });
+
+    testWidgets('scrolling into scrollback keeps the cursor visible', (
+      tester,
+    ) async {
+      final scrollController = await pumpBlinkingScrollableTerminal(tester);
+
+      scrollController.jumpTo(0);
+      await tester.pump();
+
+      expect(
+        (controller as TerminalViewBinding).terminal.isViewportActive,
+        isFalse,
+      );
+      expect(renderer(tester).blinkVisible, isTrue);
+
+      await tester.pump(const Duration(milliseconds: 11));
+      await tester.pump();
+
+      expect(renderer(tester).blinkVisible, isTrue);
+    });
+
+    testWidgets('scrolling to the live viewport restarts cursor blinking', (
+      tester,
+    ) async {
+      final scrollController = await pumpBlinkingScrollableTerminal(tester);
+
+      scrollController.jumpTo(0);
+      await tester.pump();
+      scrollController.jumpTo(scrollController.position.maxScrollExtent);
+      await tester.pump();
+
+      expect(
+        (controller as TerminalViewBinding).terminal.isViewportActive,
+        isTrue,
+      );
+
+      await tester.pump(const Duration(milliseconds: 11));
+      await tester.pump();
+
+      expect(renderer(tester).blinkVisible, isFalse);
     });
 
     testWidgets('text input produces output via onOutput', (tester) async {


### PR DESCRIPTION
Expose flterm controls for Glyph Protocol configuration, cursor reset defaults, and working-directory change callbacks. Use libghostty viewport and cell metadata to keep cursor blinking correct in scrollback, skip unnecessary style lookups, and scan terminal content for word selection and Select All.