### PR TITLE
refactor(libghostty): make grid refs value snapshots

### DIFF
--- a/packages/flterm/lib/src/foundation/screen_extension.dart
+++ b/packages/flterm/lib/src/foundation/screen_extension.dart
@@ -35,7 +35,6 @@ extension TerminalScreenExtension on Terminal {
       while (start > 0) {
         final ref = GridRef.at(this, col: 0, row: start - 1);
         final wrap = ref.rowWrap;
-        ref.dispose();
         if (!wrap) break;
         start--;
       }
@@ -43,7 +42,6 @@ extension TerminalScreenExtension on Terminal {
       while (end < rs.rows - 1) {
         final ref = GridRef.at(this, col: 0, row: end);
         final wrap = ref.rowWrap;
-        ref.dispose();
         if (!wrap) break;
         end++;
       }
@@ -52,7 +50,6 @@ extension TerminalScreenExtension on Terminal {
         final ref = GridRef.at(this, col: endCol - 1, row: end);
         final hasContent = ref.graphemes.isNotEmpty;
         final isSpacer = ref.wide == CellWidth.spacerTail;
-        ref.dispose();
         if (hasContent || isSpacer) break;
         endCol--;
       }
@@ -77,7 +74,6 @@ extension TerminalScreenExtension on Terminal {
       final ref = GridRef.at(this, col: col, row: row);
       final w = ref.wide;
       final isW = ref.isWide;
-      ref.dispose();
       if (isW) return inclusive ? col : col + 2;
       if (w == CellWidth.spacerTail) return inclusive ? col - 1 : col + 1;
       return col;

--- a/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
+++ b/packages/flterm/lib/src/rendering/terminal_frame_builder.dart
@@ -400,7 +400,6 @@ final class _CursorFrameBuilder {
       row: effectiveCursor.row,
     );
     final cell = _CursorCellSnapshot(ref.content, ref.style, wide: ref.isWide);
-    ref.dispose();
 
     _cursor = effectiveCursor;
     _lastCell = cell;

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -51,7 +51,6 @@ void main() {
   // Read a single cell via grid reference (for ad-hoc lookups).
   final ref = GridRef.at(terminal, col: 0, row: 0);
   print(ref.content); // the character at (0, 0)
-  ref.dispose();
 
   // Read screen via render state and reusable iterators.
   final renderState = RenderState();

--- a/packages/libghostty/example/grid_traverse.dart
+++ b/packages/libghostty/example/grid_traverse.dart
@@ -9,7 +9,6 @@ void main() {
   for (var col = 0; col < 13; col++) {
     final ref = GridRef.at(terminal, col: col, row: 0);
     print('($col, 0): "${ref.content}"');
-    ref.dispose();
   }
 
   terminal.dispose();

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -316,7 +316,12 @@ abstract interface class GhosttyBindings {
   Style styleDefault();
   bool styleIsDefault(Style style);
 
-  CResult<int> terminalGridRef(int terminal, PointTag pointTag, int x, int y);
+  CResult<RawGridRef> terminalGridRef(
+    int terminal,
+    PointTag pointTag,
+    int x,
+    int y,
+  );
   CResult<int> terminalGridRefTrack(
     int terminal,
     PointTag pointTag,
@@ -325,15 +330,14 @@ abstract interface class GhosttyBindings {
   );
   CResult<({int col, int row})> terminalPointFromGridRef(
     int terminal,
-    int ref,
+    RawGridRef ref,
     PointTag pointTag,
   );
-  void gridRefFree(int ref);
-  CResult<int> gridRefCell(int ref);
-  CResult<int> gridRefRow(int ref);
-  CResult<Style> gridRefStyle(int ref);
-  CResult<List<int>> gridRefGraphemes(int ref);
-  CResult<String> gridRefHyperlinkUri(int ref);
+  CResult<int> gridRefCell(RawGridRef ref);
+  CResult<int> gridRefRow(RawGridRef ref);
+  CResult<Style> gridRefStyle(RawGridRef ref);
+  CResult<List<int>> gridRefGraphemes(RawGridRef ref);
+  CResult<String> gridRefHyperlinkUri(RawGridRef ref);
   void trackedGridRefFree(int ref);
   bool trackedGridRefHasValue(int ref);
   CResult<({int col, int row})> trackedGridRefPoint(int ref, PointTag pointTag);
@@ -344,7 +348,7 @@ abstract interface class GhosttyBindings {
     int x,
     int y,
   );
-  CResult<int> trackedGridRefSnapshot(int ref);
+  CResult<RawGridRef> trackedGridRefSnapshot(int ref);
 
   CResult<int> formatterTerminalNew(
     int terminal,

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -1707,6 +1707,18 @@ class NativeBindings implements GhosttyBindings {
     point.value.coordinate.y = y;
   }
 
+  static RawGridRef _readGridRef(GridRef ref) {
+    return (node: ref.node.address, x: ref.x, y: ref.y);
+  }
+
+  static void _writeGridRef(GridRef target, RawGridRef ref) {
+    target
+      ..size = sizeOf<GridRef>()
+      ..node = Pointer<Void>.fromAddress(ref.node)
+      ..x = ref.x
+      ..y = ref.y;
+  }
+
   static RawColor _cellColorToRaw(CellColor color) => switch (color) {
     DefaultColor() => defaultRawColor,
     PaletteColor(:final index) => (
@@ -1890,18 +1902,23 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
-  CResult<int> terminalGridRef(int terminal, PointTag pointTag, int x, int y) {
+  CResult<RawGridRef> terminalGridRef(
+    int terminal,
+    PointTag pointTag,
+    int x,
+    int y,
+  ) {
     return using((arena) {
       final point = arena<Point>();
       _writePoint(point.ref, pointTag, x, y);
-      final gridRef = calloc<GridRef>();
+      final gridRef = arena<GridRef>();
       gridRef.ref.size = sizeOf<GridRef>();
       final result = ghostty_terminal_grid_ref(
         Pointer.fromAddress(terminal),
         point.ref,
         gridRef,
       );
-      return (result, gridRef.address);
+      return (result, _readGridRef(gridRef.ref));
     });
   }
 
@@ -1926,41 +1943,44 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
-  void gridRefFree(int ref) {
-    calloc.free(Pointer<Void>.fromAddress(ref));
-  }
-
-  @override
-  CResult<int> gridRefCell(int ref) {
-    final result = ghostty_grid_ref_cell(
-      Pointer.fromAddress(ref),
-      _outU64.cast(),
-    );
-    return (result, _outU64.value);
-  }
-
-  @override
-  CResult<int> gridRefRow(int ref) {
-    final result = ghostty_grid_ref_row(
-      Pointer.fromAddress(ref),
-      _outU64.cast(),
-    );
-    return (result, _outU64.value);
-  }
-
-  @override
-  CResult<Style> gridRefStyle(int ref) {
-    _outStyle.ref.size = sizeOf<native.Style>();
-    final result = ghostty_grid_ref_style(Pointer.fromAddress(ref), _outStyle);
-    return (result, _readNativeStyle(_outStyle.ref));
-  }
-
-  @override
-  CResult<List<int>> gridRefGraphemes(int ref) {
+  CResult<int> gridRefCell(RawGridRef ref) {
     return using((arena) {
+      final gridRef = arena<GridRef>();
+      _writeGridRef(gridRef.ref, ref);
+      final result = ghostty_grid_ref_cell(gridRef, _outU64.cast());
+      return (result, _outU64.value);
+    });
+  }
+
+  @override
+  CResult<int> gridRefRow(RawGridRef ref) {
+    return using((arena) {
+      final gridRef = arena<GridRef>();
+      _writeGridRef(gridRef.ref, ref);
+      final result = ghostty_grid_ref_row(gridRef, _outU64.cast());
+      return (result, _outU64.value);
+    });
+  }
+
+  @override
+  CResult<Style> gridRefStyle(RawGridRef ref) {
+    return using((arena) {
+      final gridRef = arena<GridRef>();
+      _writeGridRef(gridRef.ref, ref);
+      _outStyle.ref.size = sizeOf<native.Style>();
+      final result = ghostty_grid_ref_style(gridRef, _outStyle);
+      return (result, _readNativeStyle(_outStyle.ref));
+    });
+  }
+
+  @override
+  CResult<List<int>> gridRefGraphemes(RawGridRef ref) {
+    return using((arena) {
+      final gridRef = arena<GridRef>();
       final outLen = arena<Size>();
+      _writeGridRef(gridRef.ref, ref);
       var result = ghostty_grid_ref_graphemes(
-        Pointer.fromAddress(ref),
+        gridRef,
         _graphemeBuf,
         32,
         outLen,
@@ -1969,12 +1989,7 @@ class NativeBindings implements GhosttyBindings {
 
       if (result == Result.outOfSpace) {
         final bigBuf = arena<Uint32>(len);
-        result = ghostty_grid_ref_graphemes(
-          Pointer.fromAddress(ref),
-          bigBuf,
-          len,
-          outLen,
-        );
+        result = ghostty_grid_ref_graphemes(gridRef, bigBuf, len, outLen);
         len = outLen.value;
         return (result, [for (var i = 0; i < len; i++) bigBuf[i]]);
       }
@@ -1984,11 +1999,12 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
-  CResult<String> gridRefHyperlinkUri(int ref) {
+  CResult<String> gridRefHyperlinkUri(RawGridRef ref) {
     return using((arena) {
-      final gridRef = Pointer<GridRef>.fromAddress(ref);
+      final gridRef = arena<GridRef>();
       final outLen = arena<Size>();
       var buf = arena<Uint8>(256);
+      _writeGridRef(gridRef.ref, ref);
       var result = ghostty_grid_ref_hyperlink_uri(gridRef, buf, 256, outLen);
       var len = outLen.value;
 
@@ -2049,31 +2065,31 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
-  CResult<int> trackedGridRefSnapshot(int ref) {
-    final gridRef = calloc<GridRef>();
-    gridRef.ref.size = sizeOf<GridRef>();
-    final result = ghostty_tracked_grid_ref_snapshot(
-      Pointer.fromAddress(ref),
-      gridRef,
-    );
-    if (result != Result.success) {
-      calloc.free(gridRef);
-      return (result, 0);
-    }
-    return (result, gridRef.address);
+  CResult<RawGridRef> trackedGridRefSnapshot(int ref) {
+    return using((arena) {
+      final gridRef = arena<GridRef>();
+      gridRef.ref.size = sizeOf<GridRef>();
+      final result = ghostty_tracked_grid_ref_snapshot(
+        Pointer.fromAddress(ref),
+        gridRef,
+      );
+      return (result, _readGridRef(gridRef.ref));
+    });
   }
 
   @override
   CResult<({int col, int row})> terminalPointFromGridRef(
     int terminal,
-    int ref,
+    RawGridRef ref,
     PointTag pointTag,
   ) {
     return using((arena) {
+      final gridRef = arena<GridRef>();
       final out = arena<PointCoordinate>();
+      _writeGridRef(gridRef.ref, ref);
       final result = ghostty_terminal_point_from_grid_ref(
         Pointer.fromAddress(terminal),
-        Pointer<GridRef>.fromAddress(ref),
+        gridRef,
         pointTag,
         out,
       );
@@ -2120,8 +2136,8 @@ class NativeBindings implements GhosttyBindings {
       if (selection != null) {
         final sel = arena<Selection>();
         sel.ref.size = sizeOf<Selection>();
-        sel.ref.start = Pointer<GridRef>.fromAddress(selection.start).ref;
-        sel.ref.end = Pointer<GridRef>.fromAddress(selection.end).ref;
+        _writeGridRef(sel.ref.start, selection.start);
+        _writeGridRef(sel.ref.end, selection.end);
         sel.ref.rectangle = selection.rectangle;
         opts.ref.selection = sel;
       } else {

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -32,9 +32,18 @@ typedef ValueGetter<T> = T Function();
 typedef ValueSetter<T> = void Function(T value);
 typedef VoidCallback = void Function();
 
-/// A selection range addressed by `GridRef` handles. `rectangle` indicates
-/// a rectangular (block) selection rather than a linear one.
-typedef RawSelection = ({int start, int end, bool rectangle});
+/// An untracked grid reference value.
+///
+/// The value follows libghostty's untracked grid-reference lifetime rules and
+/// is valid only until the next mutating operation on the terminal that
+/// produced it.
+typedef RawGridRef = ({int node, int x, int y});
+
+/// A selection range addressed by untracked grid-reference values.
+///
+/// `rectangle` indicates a rectangular block selection rather than a linear
+/// text range.
+typedef RawSelection = ({RawGridRef start, RawGridRef end, bool rectangle});
 
 /// Callback invoked for each internal libghostty log message, after the
 /// scope and message byte slices have been decoded to Dart strings.

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -58,6 +58,9 @@ class Layouts {
 
   // GhosttyGridRef
   late final int gridRefSize;
+  late final int gridRefNode;
+  late final int gridRefX;
+  late final int gridRefY;
 
   // GhosttyKittyGraphicsPlacementRenderInfo
   late final int kittyRenderInfoSize;
@@ -212,6 +215,9 @@ class Layouts {
 
     struct = _Struct(types, 'GhosttyGridRef');
     gridRefSize = struct.size;
+    gridRefNode = struct['node'];
+    gridRefX = struct['x'];
+    gridRefY = struct['y'];
 
     // TODO(elias8): migrate to `_Struct(types, ...)` once upstream ghostty
     // registers `GhosttyKittyGraphicsPlacementRenderInfo` in `types.zig`.

--- a/packages/libghostty/lib/src/bindings/wasm/memory.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/memory.dart
@@ -63,5 +63,10 @@ class Mem {
 
   void writeU32(int addr, int val) => view.setUint32(addr, val, .little);
 
+  void writeU64(int addr, int val) {
+    view.setUint32(addr, val & 0xffffffff, .little);
+    view.setUint32(addr + 4, val ~/ 0x100000000, .little);
+  }
+
   void writeU8(int addr, int val) => view.setUint8(addr, val);
 }

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -2364,7 +2364,12 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
-  CResult<int> terminalGridRef(int terminal, PointTag pointTag, int x, int y) {
+  CResult<RawGridRef> terminalGridRef(
+    int terminal,
+    PointTag pointTag,
+    int x,
+    int y,
+  ) {
     final pointPtr = _exports.ghostty_wasm_alloc_u8_array(_layout.pointSize);
     final gridRefPtr = _exports.ghostty_wasm_alloc_u8_array(
       _layout.gridRefSize,
@@ -2376,8 +2381,10 @@ class WasmBindings implements GhosttyBindings {
       pointPtr,
       gridRefPtr,
     );
+    final value = _readGridRef(gridRefPtr);
     _exports.ghostty_wasm_free_u8_array(pointPtr, _layout.pointSize);
-    return (.fromValue(result), gridRefPtr);
+    _freeGridRef(gridRefPtr);
+    return (.fromValue(result), value);
   }
 
   @override
@@ -2402,48 +2409,50 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
-  void gridRefFree(int ref) {
-    _exports.ghostty_wasm_free_u8_array(ref, _layout.gridRefSize);
-  }
-
-  @override
-  CResult<int> gridRefCell(int ref) {
+  CResult<int> gridRefCell(RawGridRef ref) {
     const u64Size = 8;
+    final refPtr = _allocGridRef(ref);
     final outPtr = _exports.ghostty_wasm_alloc_u8_array(u64Size);
-    final result = _exports.ghostty_grid_ref_cell(ref, outPtr);
+    final result = _exports.ghostty_grid_ref_cell(refPtr, outPtr);
     final value = _mem.readU64(outPtr);
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_u8_array(outPtr, u64Size);
     return (.fromValue(result), value);
   }
 
   @override
-  CResult<int> gridRefRow(int ref) {
+  CResult<int> gridRefRow(RawGridRef ref) {
     const u64Size = 8;
+    final refPtr = _allocGridRef(ref);
     final outPtr = _exports.ghostty_wasm_alloc_u8_array(u64Size);
-    final result = _exports.ghostty_grid_ref_row(ref, outPtr);
+    final result = _exports.ghostty_grid_ref_row(refPtr, outPtr);
     final value = _mem.readU64(outPtr);
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_u8_array(outPtr, u64Size);
     return (.fromValue(result), value);
   }
 
   @override
-  CResult<Style> gridRefStyle(int ref) {
+  CResult<Style> gridRefStyle(RawGridRef ref) {
+    final refPtr = _allocGridRef(ref);
     final stylePtr = _exports.ghostty_wasm_alloc_u8_array(_layout.styleSize);
     _mem.writeU32(stylePtr, _layout.styleSize);
-    final result = _exports.ghostty_grid_ref_style(ref, stylePtr);
+    final result = _exports.ghostty_grid_ref_style(refPtr, stylePtr);
     final value = _readStyle(stylePtr);
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_u8_array(stylePtr, _layout.styleSize);
     return (.fromValue(result), value);
   }
 
   @override
-  CResult<List<int>> gridRefGraphemes(int ref) {
+  CResult<List<int>> gridRefGraphemes(RawGridRef ref) {
     const bufCount = 32;
     const bufSize = bufCount * 4;
+    final refPtr = _allocGridRef(ref);
     final outLen = _exports.ghostty_wasm_alloc_usize();
     var buf = _exports.ghostty_wasm_alloc_u8_array(bufSize);
     var result = Result.fromValue(
-      _exports.ghostty_grid_ref_graphemes(ref, buf, bufCount, outLen),
+      _exports.ghostty_grid_ref_graphemes(refPtr, buf, bufCount, outLen),
     );
     var len = _mem.readU32(outLen);
 
@@ -2452,10 +2461,11 @@ class WasmBindings implements GhosttyBindings {
       final bigSize = len * 4;
       buf = _exports.ghostty_wasm_alloc_u8_array(bigSize);
       result = Result.fromValue(
-        _exports.ghostty_grid_ref_graphemes(ref, buf, len, outLen),
+        _exports.ghostty_grid_ref_graphemes(refPtr, buf, len, outLen),
       );
       len = _mem.readU32(outLen);
       final value = [for (var i = 0; i < len; i++) _mem.readU32(buf + i * 4)];
+      _freeGridRef(refPtr);
       _exports.ghostty_wasm_free_usize(outLen);
       _exports.ghostty_wasm_free_u8_array(buf, bigSize);
       return (result, value);
@@ -2465,18 +2475,20 @@ class WasmBindings implements GhosttyBindings {
       true => const <int>[],
       false => [for (var i = 0; i < len; i++) _mem.readU32(buf + i * 4)],
     };
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_usize(outLen);
     _exports.ghostty_wasm_free_u8_array(buf, bufSize);
     return (result, value);
   }
 
   @override
-  CResult<String> gridRefHyperlinkUri(int ref) {
+  CResult<String> gridRefHyperlinkUri(RawGridRef ref) {
     const initSize = 256;
+    final refPtr = _allocGridRef(ref);
     final outLen = _exports.ghostty_wasm_alloc_usize();
     var buf = _exports.ghostty_wasm_alloc_u8_array(initSize);
     var result = Result.fromValue(
-      _exports.ghostty_grid_ref_hyperlink_uri(ref, buf, initSize, outLen),
+      _exports.ghostty_grid_ref_hyperlink_uri(refPtr, buf, initSize, outLen),
     );
     var len = _mem.readU32(outLen);
 
@@ -2484,16 +2496,18 @@ class WasmBindings implements GhosttyBindings {
       _exports.ghostty_wasm_free_u8_array(buf, initSize);
       buf = _exports.ghostty_wasm_alloc_u8_array(len);
       result = Result.fromValue(
-        _exports.ghostty_grid_ref_hyperlink_uri(ref, buf, len, outLen),
+        _exports.ghostty_grid_ref_hyperlink_uri(refPtr, buf, len, outLen),
       );
       len = _mem.readU32(outLen);
       final value = len == 0 ? '' : utf8.decode(_mem.readBytes(buf, len));
+      _freeGridRef(refPtr);
       _exports.ghostty_wasm_free_usize(outLen);
       _exports.ghostty_wasm_free_u8_array(buf, len);
       return (result, value);
     }
 
     final value = len == 0 ? '' : utf8.decode(_mem.readBytes(buf, len));
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_usize(outLen);
     _exports.ghostty_wasm_free_u8_array(buf, initSize);
     return (result, value);
@@ -2545,7 +2559,7 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
-  CResult<int> trackedGridRefSnapshot(int ref) {
+  CResult<RawGridRef> trackedGridRefSnapshot(int ref) {
     final gridRefPtr = _exports.ghostty_wasm_alloc_u8_array(
       _layout.gridRefSize,
     );
@@ -2553,31 +2567,31 @@ class WasmBindings implements GhosttyBindings {
     final result = Result.fromValue(
       _exports.ghostty_tracked_grid_ref_snapshot(ref, gridRefPtr),
     );
-    if (result != .success) {
-      _exports.ghostty_wasm_free_u8_array(gridRefPtr, _layout.gridRefSize);
-      return (result, 0);
-    }
-    return (result, gridRefPtr);
+    final value = _readGridRef(gridRefPtr);
+    _freeGridRef(gridRefPtr);
+    return (result, value);
   }
 
   @override
   CResult<({int col, int row})> terminalPointFromGridRef(
     int terminal,
-    int ref,
+    RawGridRef ref,
     PointTag pointTag,
   ) {
     final size = _layout.pointCoordinateSize;
+    final refPtr = _allocGridRef(ref);
     final outPtr = _exports.ghostty_wasm_alloc_u8_array(size);
     final result = Result.fromValue(
       _exports.ghostty_terminal_point_from_grid_ref(
         terminal,
-        ref,
+        refPtr,
         pointTag.value,
         outPtr,
       ),
     );
     final col = _mem.readU16(outPtr + _layout.pointCoordinateX);
     final row = _mem.readU32(outPtr + _layout.pointCoordinateY);
+    _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_u8_array(outPtr, size);
     return (result, (col: col, row: row));
   }
@@ -2660,12 +2674,8 @@ class WasmBindings implements GhosttyBindings {
     if (selection != null) {
       selPtr = _exports.ghostty_wasm_alloc_u8_array(_layout.selectionSize);
       _mem.writeU32(selPtr, _layout.selectionSize);
-      final startSrc = selection.start;
-      final endSrc = selection.end;
-      final startDst = selPtr + _layout.selectionStart;
-      final endDst = selPtr + _layout.selectionEnd;
-      _mem.writeBytes(startDst, _mem.readBytes(startSrc, _layout.gridRefSize));
-      _mem.writeBytes(endDst, _mem.readBytes(endSrc, _layout.gridRefSize));
+      _writeGridRef(selPtr + _layout.selectionStart, selection.start);
+      _writeGridRef(selPtr + _layout.selectionEnd, selection.end);
       _mem.writeU8(
         selPtr + _layout.selectionRectangle,
         selection.rectangle ? 1 : 0,
@@ -3052,6 +3062,31 @@ class WasmBindings implements GhosttyBindings {
     _mem.writeU32(pointPtr, pointTag.value);
     _mem.writeU16(pointPtr + _layout.pointX, x);
     _mem.writeU32(pointPtr + _layout.pointY, y);
+  }
+
+  int _allocGridRef(RawGridRef ref) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(_layout.gridRefSize);
+    _writeGridRef(ptr, ref);
+    return ptr;
+  }
+
+  void _freeGridRef(int ptr) {
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.gridRefSize);
+  }
+
+  RawGridRef _readGridRef(int ptr) {
+    return (
+      node: _mem.readPtr(ptr + _layout.gridRefNode),
+      x: _mem.readU16(ptr + _layout.gridRefX),
+      y: _mem.readU16(ptr + _layout.gridRefY),
+    );
+  }
+
+  void _writeGridRef(int ptr, RawGridRef ref) {
+    _mem.writeU32(ptr, _layout.gridRefSize);
+    _mem.writeU32(ptr + _layout.gridRefNode, ref.node);
+    _mem.writeU16(ptr + _layout.gridRefX, ref.x);
+    _mem.writeU16(ptr + _layout.gridRefY, ref.y);
   }
 
   SgrAttribute _readSgrAttribute(int attrPtr) {

--- a/packages/libghostty/lib/src/impl/terminal/formatter.dart
+++ b/packages/libghostty/lib/src/impl/terminal/formatter.dart
@@ -78,36 +78,32 @@ final class Formatter {
       );
     }
 
-    final start = GridRef._(
+    final start = GridRef.at(
       terminal,
       col: selection.startCol,
       row: selection.startRow,
       pointTag: selection.pointTag,
     );
-    final end = GridRef._(
+    final end = GridRef.at(
       terminal,
       col: selection.endCol,
       row: selection.endRow,
       pointTag: selection.pointTag,
     );
-    try {
-      return check(
-        bindings.formatterTerminalNew(
-          terminal._handle,
-          format,
-          unwrap: unwrap,
-          trim: trim,
-          extra: extra,
-          selection: (
-            start: start._handle,
-            end: end._handle,
-            rectangle: selection.rectangle,
-          ),
+
+    return check(
+      bindings.formatterTerminalNew(
+        terminal._handle,
+        format,
+        unwrap: unwrap,
+        trim: trim,
+        extra: extra,
+        selection: (
+          start: start._value,
+          end: end._value,
+          rectangle: selection.rectangle,
         ),
-      );
-    } finally {
-      start.dispose();
-      end.dispose();
-    }
+      ),
+    );
   }
 }

--- a/packages/libghostty/lib/src/impl/terminal/grid_ref.dart
+++ b/packages/libghostty/lib/src/impl/terminal/grid_ref.dart
@@ -2,10 +2,9 @@ part of 'terminal.dart';
 
 /// A resolved reference to a specific cell position in the terminal grid.
 ///
-/// Created via [GridRef.at]. Read cell data immediately and call [dispose]
-/// when done. A grid reference is only valid until the next operation on
-/// the terminal instance (including seemingly unrelated operations), so
-/// cache any needed information right after creation.
+/// Created via [GridRef.at]. A grid reference is only valid until the next
+/// operation on the terminal instance, including seemingly unrelated
+/// operations, so cache any needed information right after creation.
 ///
 /// Not intended for render loops. Use [RenderState] with [RowIterator] and
 /// [CellIterator] for performance-critical rendering.
@@ -14,13 +13,10 @@ part of 'terminal.dart';
 /// final ref = GridRef.at(terminal, col: 0, row: 0);
 /// print(ref.content);
 /// print(ref.style);
-/// ref.dispose();
 /// ```
 @immutable
 final class GridRef {
-  static final _finalizer = Finalizer<int>(bindings.gridRefFree);
-
-  final int _handle;
+  final RawGridRef _value;
   final Terminal _terminal;
 
   /// Resolves the grid cell at ([col], [row]) in the coordinate space
@@ -44,17 +40,15 @@ final class GridRef {
     required int col,
     required int row,
     PointTag pointTag = .active,
-  }) : this._fromHandle(
+  }) : this._fromValue(
          terminal,
          check(bindings.terminalGridRef(terminal._handle, pointTag, col, row)),
        );
 
-  GridRef._fromHandle(this._terminal, this._handle) {
-    _finalizer.attach(this, _handle, detach: this);
-  }
+  const GridRef._fromValue(this._terminal, this._value);
 
   /// The raw cell handle at this position.
-  int get cell => check(bindings.gridRefCell(_handle));
+  int get cell => check(bindings.gridRefCell(_value));
 
   /// The cell's full grapheme cluster as a string, or empty if the cell
   /// has no text.
@@ -66,12 +60,15 @@ final class GridRef {
   /// The cell's grapheme cluster as a list of Unicode codepoints. The
   /// primary codepoint is first, followed by any combining codepoints.
   /// Empty if the cell has no text.
-  List<int> get graphemes => check(bindings.gridRefGraphemes(_handle));
+  List<int> get graphemes => check(bindings.gridRefGraphemes(_value));
+
+  @override
+  int get hashCode => Object.hash(GridRef, _terminal, _value);
 
   /// The hyperlink URI at this position, or null if the cell has no
   /// hyperlink.
   String? get hyperlinkUri {
-    final (code, uri) = bindings.gridRefHyperlinkUri(_handle);
+    final (code, uri) = bindings.gridRefHyperlinkUri(_value);
     if (code == Result.noValue) return null;
     checkCode(code);
     return uri.isEmpty ? null : uri;
@@ -81,26 +78,23 @@ final class GridRef {
   bool get isWide => wide == CellWidth.wide;
 
   /// The raw row handle at this position.
-  int get row => check(bindings.gridRefRow(_handle));
+  int get row => check(bindings.gridRefRow(_value));
 
   /// Whether this row is soft-wrapped to the next row.
   bool get rowWrap => check(bindings.rowGetWrap(row));
 
   /// The [Style] of the cell at this position.
-  Style get style => check(bindings.gridRefStyle(_handle));
+  Style get style => check(bindings.gridRefStyle(_value));
 
   /// The cell's width: [CellWidth.narrow], [CellWidth.wide], or
   /// [CellWidth.spacerTail].
   CellWidth get wide => check(bindings.cellGetWide(cell));
 
-  /// Releases the native grid reference handle.
-  ///
-  /// Must be called to free resources; the reference must not be used
-  /// afterward.
-  void dispose() {
-    _finalizer.detach(this);
-    bindings.gridRefFree(_handle);
-  }
+  @override
+  bool operator ==(Object other) =>
+      other is GridRef &&
+      identical(other._terminal, _terminal) &&
+      other._value == _value;
 
   /// Converts this grid reference to coordinates in the given coordinate
   /// space. Returns null if the reference falls outside the requested
@@ -109,11 +103,14 @@ final class GridRef {
   ({int col, int row})? pointIn(PointTag pointTag) {
     final (code, point) = bindings.terminalPointFromGridRef(
       _terminal._handle,
-      _handle,
+      _value,
       pointTag,
     );
     if (code == Result.noValue) return null;
     checkCode(code);
     return point;
   }
+
+  @override
+  String toString() => 'GridRef(${_value.x},${_value.y})';
 }

--- a/packages/libghostty/lib/src/impl/terminal/tracked_grid_ref.dart
+++ b/packages/libghostty/lib/src/impl/terminal/tracked_grid_ref.dart
@@ -17,7 +17,6 @@ part of 'terminal.dart';
 /// final tracked = TrackedGridRef.at(terminal, col: 0, row: 0);
 /// final ref = tracked.snapshot();
 /// print(ref?.content);
-/// ref?.dispose();
 /// tracked.dispose();
 /// ```
 final class TrackedGridRef {
@@ -92,13 +91,12 @@ final class TrackedGridRef {
 
   /// Creates a short-lived [GridRef] snapshot for reading cell data.
   ///
-  /// The returned [GridRef] follows normal grid-reference lifetime rules and
-  /// must be disposed by the caller. Returns null if this tracked reference no
-  /// longer has a meaningful value.
+  /// The returned [GridRef] follows normal grid-reference lifetime rules.
+  /// Returns null if this tracked reference no longer has a meaningful value.
   GridRef? snapshot() {
-    final (code, handle) = bindings.trackedGridRefSnapshot(_handle);
+    final (code, ref) = bindings.trackedGridRefSnapshot(_handle);
     if (code == .noValue) return null;
     checkCode(code);
-    return GridRef._fromHandle(_terminal, handle);
+    return GridRef._fromValue(_terminal, ref);
   }
 }

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -478,7 +478,6 @@ void main() {
     group('handles', () {
       test('return selected cell and row', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
 
         final (_, cell) = bindings.gridRefCell(ref);
         expect(bindings.cellGetCodepoint(cell).$2, 'H'.codeUnitAt(0));
@@ -497,7 +496,6 @@ void main() {
           Uint8List.fromList('\x1b[1mBold'.codeUnits),
         );
         final (_, ref) = bindings.terminalGridRef(t, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, style) = bindings.gridRefStyle(ref);
         expect(style.bold, isTrue);
       });
@@ -506,7 +504,6 @@ void main() {
     group('gridRefGraphemes', () {
       test('returns codepoints', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, graphemes) = bindings.gridRefGraphemes(ref);
         expect(graphemes, contains('H'.codeUnitAt(0)));
       });
@@ -523,7 +520,6 @@ void main() {
         addTearDown(() => bindings.trackedGridRefFree(tracked));
 
         final (_, ref) = bindings.trackedGridRefSnapshot(tracked);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, graphemes) = bindings.gridRefGraphemes(ref);
 
         expect(graphemes, contains('e'.codeUnitAt(0)));
@@ -706,7 +702,6 @@ void main() {
     group('gridRefHyperlinkUri', () {
       test('returns empty string for cell without hyperlink', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (code, uri) = bindings.gridRefHyperlinkUri(ref);
         expect(code, Result.success);
         expect(uri, isEmpty);
@@ -728,7 +723,6 @@ void main() {
     group('terminalPointFromGridRef', () {
       test('roundtrips active coordinates', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 3, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (code, point) = bindings.terminalPointFromGridRef(
           terminal,
           ref,
@@ -818,8 +812,6 @@ void main() {
         );
         final (_, startRef) = bindings.terminalGridRef(t, .active, 0, 0);
         final (_, endRef) = bindings.terminalGridRef(t, .active, 2, 0);
-        addTearDown(() => bindings.gridRefFree(endRef));
-        addTearDown(() => bindings.gridRefFree(startRef));
         final (_, formatter) = bindings.formatterTerminalNew(
           t,
           .plain,

--- a/packages/libghostty/test/impl/terminal/grid_ref_test.dart
+++ b/packages/libghostty/test/impl/terminal/grid_ref_test.dart
@@ -23,7 +23,6 @@ void main() {
     group('at', () {
       test('returns content for a resolved cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.content;
 
@@ -32,7 +31,6 @@ void main() {
 
       test('returns empty content for an empty cell', () {
         final ref = GridRef.at(terminal, col: 79, row: 23);
-        addTearDown(ref.dispose);
 
         final result = ref.content;
 
@@ -50,7 +48,6 @@ void main() {
     group('cell', () {
       test('returns a cell handle', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.cell;
 
@@ -61,7 +58,6 @@ void main() {
     group('row', () {
       test('returns a row handle', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.row;
 
@@ -73,7 +69,6 @@ void main() {
       test('returns the cell style', () {
         terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.style;
 
@@ -83,7 +78,6 @@ void main() {
       test('reflects bold text', () {
         terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.style.bold;
 
@@ -94,7 +88,6 @@ void main() {
     group('graphemes', () {
       test('returns the cell codepoints', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.graphemes;
 
@@ -105,7 +98,6 @@ void main() {
     group('hyperlinkUri', () {
       test('returns null when the cell has no hyperlink', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.hyperlinkUri;
 
@@ -116,7 +108,6 @@ void main() {
     group('wide', () {
       test('returns narrow for a single width cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.wide;
 
@@ -126,7 +117,6 @@ void main() {
       test('returns wide for a leading wide cell', () {
         terminal.write(Uint8List.fromList([0xE6, 0x97, 0xA5]));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.wide;
 
@@ -137,7 +127,6 @@ void main() {
     group('isWide', () {
       test('returns false for a single width cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.isWide;
 
@@ -147,7 +136,6 @@ void main() {
       test('returns true for a leading wide cell', () {
         terminal.write(Uint8List.fromList([0xE6, 0x97, 0xA5]));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.isWide;
 
@@ -161,7 +149,6 @@ void main() {
         addTearDown(wrapped.dispose);
         wrapped.write(Uint8List.fromList('ABCDEF'.codeUnits));
         final ref = GridRef.at(wrapped, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.rowWrap;
 
@@ -172,7 +159,6 @@ void main() {
     group('pointIn', () {
       test('returns coordinates in the requested coordinate space', () {
         final ref = GridRef.at(terminal, col: 2, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.pointIn(.active);
 

--- a/packages/libghostty/test/impl/terminal/tracked_grid_ref_test.dart
+++ b/packages/libghostty/test/impl/terminal/tracked_grid_ref_test.dart
@@ -99,7 +99,6 @@ void main() {
         addTearDown(tracked.dispose);
 
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
         expect(result, isA<GridRef>());
       });
@@ -109,9 +108,8 @@ void main() {
         addTearDown(tracked.dispose);
 
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
-        expect(result.content, 'e');
+        expect(result!.content, 'e');
       });
 
       test('returns null after reset', () {
@@ -135,9 +133,8 @@ void main() {
 
         scrolled.write(Uint8List.fromList('\r\ndelta'.codeUnits));
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
-        expect(result.content, 'a');
+        expect(result!.content, 'a');
       });
     });
   });

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -486,7 +486,6 @@ void main() {
     group('handles', () {
       test('return selected cell and row', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
 
         final (_, cell) = bindings.gridRefCell(ref);
         expect(bindings.cellGetCodepoint(cell).$2, 'H'.codeUnitAt(0));
@@ -505,7 +504,6 @@ void main() {
           Uint8List.fromList('\x1b[1mBold'.codeUnits),
         );
         final (_, ref) = bindings.terminalGridRef(t, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, style) = bindings.gridRefStyle(ref);
         expect(style.bold, isTrue);
       });
@@ -514,7 +512,6 @@ void main() {
     group('gridRefGraphemes', () {
       test('returns codepoints', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, graphemes) = bindings.gridRefGraphemes(ref);
         expect(graphemes, contains('H'.codeUnitAt(0)));
       });
@@ -531,7 +528,6 @@ void main() {
         addTearDown(() => bindings.trackedGridRefFree(tracked));
 
         final (_, ref) = bindings.trackedGridRefSnapshot(tracked);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (_, graphemes) = bindings.gridRefGraphemes(ref);
 
         expect(graphemes, contains('e'.codeUnitAt(0)));
@@ -714,7 +710,6 @@ void main() {
     group('gridRefHyperlinkUri', () {
       test('returns empty string for cell without hyperlink', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 0, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (code, uri) = bindings.gridRefHyperlinkUri(ref);
         expect(code, Result.success);
         expect(uri, isEmpty);
@@ -736,7 +731,6 @@ void main() {
     group('terminalPointFromGridRef', () {
       test('roundtrips active coordinates', () {
         final (_, ref) = bindings.terminalGridRef(terminal, .active, 3, 0);
-        addTearDown(() => bindings.gridRefFree(ref));
         final (code, point) = bindings.terminalPointFromGridRef(
           terminal,
           ref,
@@ -826,8 +820,6 @@ void main() {
         );
         final (_, startRef) = bindings.terminalGridRef(t, .active, 0, 0);
         final (_, endRef) = bindings.terminalGridRef(t, .active, 2, 0);
-        addTearDown(() => bindings.gridRefFree(endRef));
-        addTearDown(() => bindings.gridRefFree(startRef));
         final (_, formatter) = bindings.formatterTerminalNew(
           t,
           .plain,

--- a/packages/libghostty/test/wasm/impl/terminal/grid_ref_test.dart
+++ b/packages/libghostty/test/wasm/impl/terminal/grid_ref_test.dart
@@ -27,7 +27,6 @@ void main() {
     group('at', () {
       test('returns content for a resolved cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.content;
 
@@ -36,7 +35,6 @@ void main() {
 
       test('returns empty content for an empty cell', () {
         final ref = GridRef.at(terminal, col: 79, row: 23);
-        addTearDown(ref.dispose);
 
         final result = ref.content;
 
@@ -54,7 +52,6 @@ void main() {
     group('cell', () {
       test('returns a cell handle', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.cell;
 
@@ -65,7 +62,6 @@ void main() {
     group('row', () {
       test('returns a row handle', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.row;
 
@@ -77,7 +73,6 @@ void main() {
       test('returns the cell style', () {
         terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.style;
 
@@ -87,7 +82,6 @@ void main() {
       test('reflects bold text', () {
         terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.style.bold;
 
@@ -98,7 +92,6 @@ void main() {
     group('graphemes', () {
       test('returns the cell codepoints', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.graphemes;
 
@@ -109,7 +102,6 @@ void main() {
     group('hyperlinkUri', () {
       test('returns null when the cell has no hyperlink', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.hyperlinkUri;
 
@@ -120,7 +112,6 @@ void main() {
     group('wide', () {
       test('returns narrow for a single width cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.wide;
 
@@ -130,7 +121,6 @@ void main() {
       test('returns wide for a leading wide cell', () {
         terminal.write(Uint8List.fromList([0xE6, 0x97, 0xA5]));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.wide;
 
@@ -141,7 +131,6 @@ void main() {
     group('isWide', () {
       test('returns false for a single width cell', () {
         final ref = GridRef.at(terminal, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.isWide;
 
@@ -151,7 +140,6 @@ void main() {
       test('returns true for a leading wide cell', () {
         terminal.write(Uint8List.fromList([0xE6, 0x97, 0xA5]));
         final ref = GridRef.at(terminal, col: 5, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.isWide;
 
@@ -165,7 +153,6 @@ void main() {
         addTearDown(wrapped.dispose);
         wrapped.write(Uint8List.fromList('ABCDEF'.codeUnits));
         final ref = GridRef.at(wrapped, col: 0, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.rowWrap;
 
@@ -176,7 +163,6 @@ void main() {
     group('pointIn', () {
       test('returns coordinates in the requested coordinate space', () {
         final ref = GridRef.at(terminal, col: 2, row: 0);
-        addTearDown(ref.dispose);
 
         final result = ref.pointIn(.active);
 

--- a/packages/libghostty/test/wasm/impl/terminal/tracked_grid_ref_test.dart
+++ b/packages/libghostty/test/wasm/impl/terminal/tracked_grid_ref_test.dart
@@ -103,7 +103,6 @@ void main() {
         addTearDown(tracked.dispose);
 
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
         expect(result, isA<GridRef>());
       });
@@ -113,9 +112,8 @@ void main() {
         addTearDown(tracked.dispose);
 
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
-        expect(result.content, 'e');
+        expect(result!.content, 'e');
       });
 
       test('returns null after reset', () {
@@ -139,9 +137,8 @@ void main() {
 
         scrolled.write(Uint8List.fromList('\r\ndelta'.codeUnits));
         final result = tracked.snapshot();
-        addTearDown(result!.dispose);
 
-        expect(result.content, 'a');
+        expect(result!.content, 'a');
       });
     });
   });


### PR DESCRIPTION
Make libghostty grid references value snapshots instead of disposable native handles, while keeping tracked grid references as the explicit long-lived handle type and updating native, WASM, formatter, and flterm call sites to use the new ownership model.