### PR TITLE
feat(libghostty): expose selection APIs

### DIFF
--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -519,13 +519,20 @@ class TerminalControllerImpl extends TerminalController
       terminal: terminal,
       format: format,
       unwrap: !block,
-      selection: Selection(
-        startCol: topCol,
-        startRow: topRow,
-        endCol: bottomCol,
-        endRow: bottomRow,
+      selection: Selection.fromRefs(
+        start: GridRef.at(
+          terminal,
+          col: topCol,
+          row: topRow,
+          pointTag: .screen,
+        ),
+        end: GridRef.at(
+          terminal,
+          col: bottomCol,
+          row: bottomRow,
+          pointTag: .screen,
+        ),
         rectangle: block,
-        pointTag: .screen,
       ),
     );
 

--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -52,6 +52,11 @@ export 'src/ffi/libghostty_enums.g.dart'
         OptionAsAlt,
         OscCommandType,
         PointTag,
+        SelectionAdjust,
+        SelectionGestureAutoscroll,
+        SelectionGestureBehavior,
+        SelectionGestureEventOption,
+        SelectionOrder,
         SgrAttributeTag,
         SizeReportStyle,
         SysLogLevel,
@@ -82,6 +87,11 @@ export 'src/impl/terminal/terminal.dart'
         RenderState,
         RowIterator,
         Selection,
+        SelectionGesture,
+        SelectionGestureBehaviors,
+        SelectionGestureEvent,
+        SelectionGestureGeometry,
+        SelectionGestureState,
         Terminal,
         TrackedGridRef;
 export 'src/impl/terminal/terminal_mode.dart' show TerminalMode;

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -350,6 +350,115 @@ abstract interface class GhosttyBindings {
   );
   CResult<RawGridRef> trackedGridRefSnapshot(int ref);
 
+  CResult<RawSelection?> terminalGetSelection(int handle);
+  Result terminalSetSelection(int handle, RawSelection? selection);
+  CResult<RawSelection?> terminalSelectAll(int terminal);
+  CResult<RawSelection?> terminalSelectWord(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? boundaryCodepoints,
+  });
+  CResult<RawSelection?> terminalSelectWordBetween(
+    int terminal,
+    RawGridRef start,
+    RawGridRef end, {
+    List<int>? boundaryCodepoints,
+  });
+  CResult<RawSelection?> terminalSelectLine(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? whitespace,
+    bool semanticPromptBoundary = false,
+  });
+  CResult<RawSelection?> terminalSelectOutput(int terminal, RawGridRef ref);
+  CResult<RawSelection?> terminalSelectionAdjust(
+    int terminal,
+    RawSelection selection,
+    SelectionAdjust adjustment,
+  );
+  CResult<SelectionOrder> terminalSelectionOrder(
+    int terminal,
+    RawSelection selection,
+  );
+  CResult<RawSelection?> terminalSelectionOrdered(
+    int terminal,
+    RawSelection selection,
+    SelectionOrder desired,
+  );
+  CResult<bool> terminalSelectionContains(
+    int terminal,
+    RawSelection selection,
+    PointTag pointTag,
+    int col,
+    int row,
+  );
+  CResult<bool> terminalSelectionEqual(
+    int terminal,
+    RawSelection a,
+    RawSelection b,
+  );
+  CResult<String> terminalSelectionFormat(
+    int terminal,
+    FormatterFormat format, {
+    bool unwrap = false,
+    bool trim = false,
+    RawSelection? selection,
+  });
+
+  CResult<int> selectionGestureNew();
+  void selectionGestureFree(int gesture, int terminal);
+  void selectionGestureReset(int gesture, int terminal);
+  CResult<RawSelection?> selectionGestureEvent(
+    int gesture,
+    int terminal,
+    int event,
+  );
+  CResult<int> selectionGestureEventNew(SelectionGestureEventType type);
+  void selectionGestureEventFree(int event);
+  Result selectionGestureEventClear(
+    int event,
+    SelectionGestureEventOption option,
+  );
+  Result selectionGestureEventSetRef(int event, RawGridRef ref);
+  Result selectionGestureEventSetPosition(int event, double x, double y);
+  Result selectionGestureEventSetRepeatDistance(int event, double value);
+  Result selectionGestureEventSetTimeNs(int event, int value);
+  Result selectionGestureEventSetRepeatIntervalNs(int event, int value);
+  Result selectionGestureEventSetWordBoundaryCodepoints(
+    int event,
+    List<int> codepoints,
+  );
+  Result selectionGestureEventSetBehaviors(
+    int event,
+    SelectionGestureBehavior singleClick,
+    SelectionGestureBehavior doubleClick,
+    SelectionGestureBehavior tripleClick,
+  );
+  Result selectionGestureEventSetRectangle(int event, {required bool value});
+  Result selectionGestureEventSetGeometry(
+    int event, {
+    required int columns,
+    required int cellWidth,
+    required int paddingLeft,
+    required int screenHeight,
+  });
+  Result selectionGestureEventSetViewport(
+    int event, {
+    required int col,
+    required int row,
+  });
+  CResult<int> selectionGestureGetClickCount(int gesture, int terminal);
+  CResult<bool> selectionGestureGetDragged(int gesture, int terminal);
+  CResult<SelectionGestureAutoscroll> selectionGestureGetAutoscroll(
+    int gesture,
+    int terminal,
+  );
+  CResult<SelectionGestureBehavior> selectionGestureGetBehavior(
+    int gesture,
+    int terminal,
+  );
+  CResult<RawGridRef> selectionGestureGetAnchor(int gesture, int terminal);
+
   CResult<int> formatterTerminalNew(
     int terminal,
     FormatterFormat format, {

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -47,6 +47,8 @@ const RawPlacementRenderInfo _emptyRenderInfo = (
   sourceHeight: 0,
 );
 
+const RawGridRef _emptyGridRef = (node: 0, x: 0, y: 0);
+
 class NativeBindings implements GhosttyBindings {
   final _utf8Ptrs = <int, Pointer<Char>>{};
   final _callables = <int, Map<TerminalOption, NativeCallable>>{};
@@ -1719,6 +1721,30 @@ class NativeBindings implements GhosttyBindings {
       ..y = ref.y;
   }
 
+  static RawSelection _readSelection(Selection selection) {
+    return (
+      start: _readGridRef(selection.start),
+      end: _readGridRef(selection.end),
+      rectangle: selection.rectangle,
+    );
+  }
+
+  static void _writeSelection(Selection target, RawSelection selection) {
+    target.size = sizeOf<Selection>();
+    _writeGridRef(target.start, selection.start);
+    _writeGridRef(target.end, selection.end);
+    target.rectangle = selection.rectangle;
+  }
+
+  static Pointer<Uint32> _writeCodepoints(Arena arena, List<int>? codepoints) {
+    if (codepoints == null) return nullptr;
+    final ptr = arena<Uint32>(codepoints.isEmpty ? 1 : codepoints.length);
+    for (var i = 0; i < codepoints.length; i++) {
+      ptr[i] = codepoints[i];
+    }
+    return ptr;
+  }
+
   static RawColor _cellColorToRaw(CellColor color) => switch (color) {
     DefaultColor() => defaultRawColor,
     PaletteColor(:final index) => (
@@ -1943,6 +1969,7 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  @override
   CResult<int> gridRefCell(RawGridRef ref) {
     return using((arena) {
       final gridRef = arena<GridRef>();
@@ -2094,6 +2121,612 @@ class NativeBindings implements GhosttyBindings {
         out,
       );
       return (result, (col: out.ref.x, row: out.ref.y));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalGetSelection(int handle) {
+    return using((arena) {
+      final selection = arena<Selection>();
+      selection.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_get(
+        Pointer.fromAddress(handle),
+        .selection,
+        selection.cast(),
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(selection.ref));
+    });
+  }
+
+  @override
+  Result terminalSetSelection(int handle, RawSelection? selection) {
+    if (selection == null) {
+      return ghostty_terminal_set(
+        Pointer.fromAddress(handle),
+        .selection,
+        nullptr,
+      );
+    }
+    return using((arena) {
+      final sel = arena<Selection>();
+      _writeSelection(sel.ref, selection);
+      return ghostty_terminal_set(
+        Pointer.fromAddress(handle),
+        .selection,
+        sel.cast(),
+      );
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectAll(int terminal) {
+    return using((arena) {
+      final out = arena<Selection>();
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_select_all(
+        Pointer.fromAddress(terminal),
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectWord(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? boundaryCodepoints,
+  }) {
+    return using((arena) {
+      final opts = arena<TerminalSelectWordOptions>();
+      final out = arena<Selection>();
+      final codepoints = _writeCodepoints(arena, boundaryCodepoints);
+      opts.ref
+        ..size = sizeOf<TerminalSelectWordOptions>()
+        ..boundary_codepoints = codepoints
+        ..boundary_codepoints_len = boundaryCodepoints?.length ?? 0;
+      _writeGridRef(opts.ref.ref, ref);
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_select_word(
+        Pointer.fromAddress(terminal),
+        opts,
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectWordBetween(
+    int terminal,
+    RawGridRef start,
+    RawGridRef end, {
+    List<int>? boundaryCodepoints,
+  }) {
+    return using((arena) {
+      final opts = arena<TerminalSelectWordBetweenOptions>();
+      final out = arena<Selection>();
+      final codepoints = _writeCodepoints(arena, boundaryCodepoints);
+      opts.ref
+        ..size = sizeOf<TerminalSelectWordBetweenOptions>()
+        ..boundary_codepoints = codepoints
+        ..boundary_codepoints_len = boundaryCodepoints?.length ?? 0;
+      _writeGridRef(opts.ref.start, start);
+      _writeGridRef(opts.ref.end, end);
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_select_word_between(
+        Pointer.fromAddress(terminal),
+        opts,
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectLine(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? whitespace,
+    bool semanticPromptBoundary = false,
+  }) {
+    return using((arena) {
+      final opts = arena<TerminalSelectLineOptions>();
+      final out = arena<Selection>();
+      final codepoints = _writeCodepoints(arena, whitespace);
+      opts.ref
+        ..size = sizeOf<TerminalSelectLineOptions>()
+        ..whitespace = codepoints
+        ..whitespace_len = whitespace?.length ?? 0
+        ..semantic_prompt_boundary = semanticPromptBoundary;
+      _writeGridRef(opts.ref.ref, ref);
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_select_line(
+        Pointer.fromAddress(terminal),
+        opts,
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectOutput(int terminal, RawGridRef ref) {
+    return using((arena) {
+      final gridRef = arena<GridRef>();
+      final out = arena<Selection>();
+      _writeGridRef(gridRef.ref, ref);
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_select_output(
+        Pointer.fromAddress(terminal),
+        gridRef.ref,
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectionAdjust(
+    int terminal,
+    RawSelection selection,
+    SelectionAdjust adjustment,
+  ) {
+    return using((arena) {
+      final sel = arena<Selection>();
+      _writeSelection(sel.ref, selection);
+      final result = ghostty_terminal_selection_adjust(
+        Pointer.fromAddress(terminal),
+        sel,
+        adjustment,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(sel.ref));
+    });
+  }
+
+  @override
+  CResult<SelectionOrder> terminalSelectionOrder(
+    int terminal,
+    RawSelection selection,
+  ) {
+    return using((arena) {
+      final sel = arena<Selection>();
+      final out = arena<UnsignedInt>();
+      _writeSelection(sel.ref, selection);
+      final result = ghostty_terminal_selection_order(
+        Pointer.fromAddress(terminal),
+        sel,
+        out.cast(),
+      );
+      if (result != .success) return (result, .forward);
+      return (result, SelectionOrder.fromValue(out.value));
+    });
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectionOrdered(
+    int terminal,
+    RawSelection selection,
+    SelectionOrder desired,
+  ) {
+    return using((arena) {
+      final sel = arena<Selection>();
+      final out = arena<Selection>();
+      _writeSelection(sel.ref, selection);
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_terminal_selection_ordered(
+        Pointer.fromAddress(terminal),
+        sel,
+        desired,
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<bool> terminalSelectionContains(
+    int terminal,
+    RawSelection selection,
+    PointTag pointTag,
+    int col,
+    int row,
+  ) {
+    return using((arena) {
+      final sel = arena<Selection>();
+      final point = arena<Point>();
+      _writeSelection(sel.ref, selection);
+      _writePoint(point.ref, pointTag, col, row);
+      final result = ghostty_terminal_selection_contains(
+        Pointer.fromAddress(terminal),
+        sel,
+        point.ref,
+        _outBool,
+      );
+      return (result, _outBool.value);
+    });
+  }
+
+  @override
+  CResult<bool> terminalSelectionEqual(
+    int terminal,
+    RawSelection a,
+    RawSelection b,
+  ) {
+    return using((arena) {
+      final selA = arena<Selection>();
+      final selB = arena<Selection>();
+      _writeSelection(selA.ref, a);
+      _writeSelection(selB.ref, b);
+      final result = ghostty_terminal_selection_equal(
+        Pointer.fromAddress(terminal),
+        selA,
+        selB,
+        _outBool,
+      );
+      return (result, _outBool.value);
+    });
+  }
+
+  @override
+  CResult<String> terminalSelectionFormat(
+    int terminal,
+    FormatterFormat format, {
+    bool unwrap = false,
+    bool trim = false,
+    RawSelection? selection,
+  }) {
+    return using((arena) {
+      final opts = arena<TerminalSelectionFormatOptions>();
+      final outPtr = arena<Pointer<Uint8>>();
+      final outLen = arena<Size>();
+      opts.ref
+        ..size = sizeOf<TerminalSelectionFormatOptions>()
+        ..emitAsInt = format.value
+        ..unwrap = unwrap
+        ..trim = trim;
+      if (selection == null) {
+        opts.ref.selection = nullptr;
+      } else {
+        final sel = arena<Selection>();
+        _writeSelection(sel.ref, selection);
+        opts.ref.selection = sel;
+      }
+      final result = ghostty_terminal_selection_format_alloc(
+        Pointer.fromAddress(terminal),
+        nullptr,
+        opts.ref,
+        outPtr,
+        outLen,
+      );
+      final len = outLen.value;
+      final buf = outPtr.value;
+      if (result != .success || len == 0 || buf == nullptr) {
+        return (result, '');
+      }
+      final encoded = utf8.decode(buf.asTypedList(len));
+      ghostty_free(nullptr, buf, len);
+      return (result, encoded);
+    });
+  }
+
+  @override
+  CResult<int> selectionGestureNew() {
+    return using((arena) {
+      final out = arena<SelectionGesture>();
+      final result = ghostty_selection_gesture_new(nullptr, out);
+      return (result, out.value.address);
+    });
+  }
+
+  @override
+  void selectionGestureFree(int gesture, int terminal) {
+    ghostty_selection_gesture_free(
+      Pointer.fromAddress(gesture),
+      Pointer.fromAddress(terminal),
+    );
+  }
+
+  @override
+  void selectionGestureReset(int gesture, int terminal) {
+    ghostty_selection_gesture_reset(
+      Pointer.fromAddress(gesture),
+      Pointer.fromAddress(terminal),
+    );
+  }
+
+  @override
+  CResult<RawSelection?> selectionGestureEvent(
+    int gesture,
+    int terminal,
+    int event,
+  ) {
+    return using((arena) {
+      final out = arena<Selection>();
+      out.ref.size = sizeOf<Selection>();
+      final result = ghostty_selection_gesture_event(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        Pointer.fromAddress(event),
+        out,
+      );
+      if (result != .success) return (result, null);
+      return (result, _readSelection(out.ref));
+    });
+  }
+
+  @override
+  CResult<int> selectionGestureEventNew(SelectionGestureEventType type) {
+    return using((arena) {
+      final out = arena<SelectionGestureEvent>();
+      final result = ghostty_selection_gesture_event_new(nullptr, out, type);
+      return (result, out.value.address);
+    });
+  }
+
+  @override
+  void selectionGestureEventFree(int event) {
+    ghostty_selection_gesture_event_free(Pointer.fromAddress(event));
+  }
+
+  @override
+  Result selectionGestureEventClear(
+    int event,
+    SelectionGestureEventOption option,
+  ) {
+    return ghostty_selection_gesture_event_set(
+      Pointer.fromAddress(event),
+      option,
+      nullptr,
+    );
+  }
+
+  @override
+  Result selectionGestureEventSetRef(int event, RawGridRef ref) {
+    return using((arena) {
+      final value = arena<GridRef>();
+      _writeGridRef(value.ref, ref);
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .ref,
+        value.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetPosition(int event, double x, double y) {
+    return using((arena) {
+      final value = arena<SurfacePosition>();
+      value.ref
+        ..x = x
+        ..y = y;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .position,
+        value.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetRepeatDistance(int event, double value) {
+    return using((arena) {
+      final ptr = arena<Double>();
+      ptr.value = value;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .repeatDistance,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetTimeNs(int event, int value) {
+    return using((arena) {
+      final ptr = arena<Uint64>();
+      ptr.value = value;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .timeNs,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetRepeatIntervalNs(int event, int value) {
+    return using((arena) {
+      final ptr = arena<Uint64>();
+      ptr.value = value;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .repeatIntervalNs,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetWordBoundaryCodepoints(
+    int event,
+    List<int> codepoints,
+  ) {
+    return using((arena) {
+      final ptr = arena<Codepoints>();
+      ptr.ref
+        ..ptr = _writeCodepoints(arena, codepoints)
+        ..len = codepoints.length;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .wordBoundaryCodepoints,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetBehaviors(
+    int event,
+    SelectionGestureBehavior singleClick,
+    SelectionGestureBehavior doubleClick,
+    SelectionGestureBehavior tripleClick,
+  ) {
+    return using((arena) {
+      final ptr = arena<SelectionGestureBehaviors>();
+      ptr.ref
+        ..single_clickAsInt = singleClick.value
+        ..double_clickAsInt = doubleClick.value
+        ..triple_clickAsInt = tripleClick.value;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .behaviors,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetRectangle(int event, {required bool value}) {
+    return using((arena) {
+      final ptr = arena<Bool>();
+      ptr.value = value;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .rectangle,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetGeometry(
+    int event, {
+    required int columns,
+    required int cellWidth,
+    required int paddingLeft,
+    required int screenHeight,
+  }) {
+    return using((arena) {
+      final ptr = arena<SelectionGestureGeometry>();
+      ptr.ref
+        ..columns = columns
+        ..cell_width = cellWidth
+        ..padding_left = paddingLeft
+        ..screen_height = screenHeight;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .geometry,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  Result selectionGestureEventSetViewport(
+    int event, {
+    required int col,
+    required int row,
+  }) {
+    return using((arena) {
+      final ptr = arena<PointCoordinate>();
+      ptr.ref
+        ..x = col
+        ..y = row;
+      return ghostty_selection_gesture_event_set(
+        Pointer.fromAddress(event),
+        .viewport,
+        ptr.cast(),
+      );
+    });
+  }
+
+  @override
+  CResult<int> selectionGestureGetClickCount(int gesture, int terminal) {
+    return using((arena) {
+      final out = arena<Uint8>();
+      final result = ghostty_selection_gesture_get(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        .clickCount,
+        out.cast(),
+      );
+      return (result, out.value);
+    });
+  }
+
+  @override
+  CResult<bool> selectionGestureGetDragged(int gesture, int terminal) {
+    return using((arena) {
+      final out = arena<Bool>();
+      final result = ghostty_selection_gesture_get(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        .dragged,
+        out.cast(),
+      );
+      return (result, out.value);
+    });
+  }
+
+  @override
+  CResult<SelectionGestureAutoscroll> selectionGestureGetAutoscroll(
+    int gesture,
+    int terminal,
+  ) {
+    return using((arena) {
+      final out = arena<UnsignedInt>();
+      final result = ghostty_selection_gesture_get(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        .autoscroll,
+        out.cast(),
+      );
+      if (result != .success) return (result, .none);
+      return (result, SelectionGestureAutoscroll.fromValue(out.value));
+    });
+  }
+
+  @override
+  CResult<SelectionGestureBehavior> selectionGestureGetBehavior(
+    int gesture,
+    int terminal,
+  ) {
+    return using((arena) {
+      final out = arena<UnsignedInt>();
+      final result = ghostty_selection_gesture_get(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        .behavior,
+        out.cast(),
+      );
+      if (result != .success) return (result, .cell);
+      return (result, SelectionGestureBehavior.fromValue(out.value));
+    });
+  }
+
+  @override
+  CResult<RawGridRef> selectionGestureGetAnchor(int gesture, int terminal) {
+    return using((arena) {
+      final out = arena<GridRef>();
+      out.ref.size = sizeOf<GridRef>();
+      final result = ghostty_selection_gesture_get(
+        Pointer.fromAddress(gesture),
+        Pointer.fromAddress(terminal),
+        .anchor,
+        out.cast(),
+      );
+      if (result != .success) return (result, _emptyGridRef);
+      return (result, _readGridRef(out.ref));
     });
   }
 

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -56,6 +56,33 @@ class Layouts {
   late final int selectionEnd;
   late final int selectionRectangle;
 
+  // GhosttyTerminalSelectWordOptions
+  late final int selectWordSize;
+  late final int selectWordRef;
+  late final int selectWordBoundaryCodepoints;
+  late final int selectWordBoundaryCodepointsLen;
+
+  // GhosttyTerminalSelectWordBetweenOptions
+  late final int selectWordBetweenSize;
+  late final int selectWordBetweenStart;
+  late final int selectWordBetweenEnd;
+  late final int selectWordBetweenBoundaryCodepoints;
+  late final int selectWordBetweenBoundaryCodepointsLen;
+
+  // GhosttyTerminalSelectLineOptions
+  late final int selectLineSize;
+  late final int selectLineRef;
+  late final int selectLineWhitespace;
+  late final int selectLineWhitespaceLen;
+  late final int selectLineSemanticPromptBoundary;
+
+  // GhosttyTerminalSelectionFormatOptions
+  late final int selectionFormatSize;
+  late final int selectionFormatEmit;
+  late final int selectionFormatUnwrap;
+  late final int selectionFormatTrim;
+  late final int selectionFormatSelection;
+
   // GhosttyGridRef
   late final int gridRefSize;
   late final int gridRefNode;
@@ -80,6 +107,29 @@ class Layouts {
   late final int pointCoordinateSize;
   late final int pointCoordinateX;
   late final int pointCoordinateY;
+
+  // GhosttyCodepoints
+  late final int codepointsSize;
+  late final int codepointsPtr;
+  late final int codepointsLen;
+
+  // GhosttySurfacePosition
+  late final int surfacePositionSize;
+  late final int surfacePositionX;
+  late final int surfacePositionY;
+
+  // GhosttySelectionGestureBehaviors
+  late final int gestureBehaviorsSize;
+  late final int gestureBehaviorsSingleClick;
+  late final int gestureBehaviorsDoubleClick;
+  late final int gestureBehaviorsTripleClick;
+
+  // GhosttySelectionGestureGeometry
+  late final int gestureGeometrySize;
+  late final int gestureGeometryColumns;
+  late final int gestureGeometryCellWidth;
+  late final int gestureGeometryPaddingLeft;
+  late final int gestureGeometryScreenHeight;
 
   // GhosttyMouseEncoderSize
   late final int mouseEncoderSizeSize;
@@ -213,6 +263,43 @@ class Layouts {
     selectionEnd = struct['end'];
     selectionRectangle = struct['rectangle'];
 
+    struct = _Struct(types, 'GhosttyTerminalSelectWordOptions');
+    selectWordSize = struct.size;
+    selectWordRef = struct['ref'];
+    selectWordBoundaryCodepoints = struct['boundary_codepoints'];
+    selectWordBoundaryCodepointsLen = struct['boundary_codepoints_len'];
+
+    struct = _Struct(types, 'GhosttyTerminalSelectWordBetweenOptions');
+    selectWordBetweenSize = struct.size;
+    selectWordBetweenStart = struct['start'];
+    selectWordBetweenEnd = struct['end'];
+    selectWordBetweenBoundaryCodepoints = struct['boundary_codepoints'];
+    selectWordBetweenBoundaryCodepointsLen = struct['boundary_codepoints_len'];
+
+    struct = _Struct(types, 'GhosttyTerminalSelectLineOptions');
+    selectLineSize = struct.size;
+    selectLineRef = struct['ref'];
+    selectLineWhitespace = struct['whitespace'];
+    selectLineWhitespaceLen = struct['whitespace_len'];
+    selectLineSemanticPromptBoundary = struct['semantic_prompt_boundary'];
+
+    final selectionFormat = types['GhosttyTerminalSelectionFormatOptions'];
+    if (selectionFormat == null) {
+      // Some WASM artifacts omit this C struct from ghostty_type_json.
+      selectionFormatSize = 16;
+      selectionFormatEmit = 4;
+      selectionFormatUnwrap = 8;
+      selectionFormatTrim = 9;
+      selectionFormatSelection = 12;
+    } else {
+      struct = _Struct(types, 'GhosttyTerminalSelectionFormatOptions');
+      selectionFormatSize = struct.size;
+      selectionFormatEmit = struct['emit'];
+      selectionFormatUnwrap = struct['unwrap'];
+      selectionFormatTrim = struct['trim'];
+      selectionFormatSelection = struct['selection'];
+    }
+
     struct = _Struct(types, 'GhosttyGridRef');
     gridRefSize = struct.size;
     gridRefNode = struct['node'];
@@ -258,6 +345,29 @@ class Layouts {
     pointCoordinateSize = sub.size;
     pointCoordinateX = sub['x'];
     pointCoordinateY = sub['y'];
+
+    struct = _Struct(types, 'GhosttyCodepoints');
+    codepointsSize = struct.size;
+    codepointsPtr = struct['ptr'];
+    codepointsLen = struct['len'];
+
+    struct = _Struct(types, 'GhosttySurfacePosition');
+    surfacePositionSize = struct.size;
+    surfacePositionX = struct['x'];
+    surfacePositionY = struct['y'];
+
+    struct = _Struct(types, 'GhosttySelectionGestureBehaviors');
+    gestureBehaviorsSize = struct.size;
+    gestureBehaviorsSingleClick = struct['single_click'];
+    gestureBehaviorsDoubleClick = struct['double_click'];
+    gestureBehaviorsTripleClick = struct['triple_click'];
+
+    struct = _Struct(types, 'GhosttySelectionGestureGeometry');
+    gestureGeometrySize = struct.size;
+    gestureGeometryColumns = struct['columns'];
+    gestureGeometryCellWidth = struct['cell_width'];
+    gestureGeometryPaddingLeft = struct['padding_left'];
+    gestureGeometryScreenHeight = struct['screen_height'];
 
     struct = _Struct(types, 'GhosttyRenderStateColors');
     colorsSize = struct.size;

--- a/packages/libghostty/lib/src/bindings/wasm/memory.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/memory.dart
@@ -57,6 +57,8 @@ class Mem {
 
   void writeF32(int addr, double val) => view.setFloat32(addr, val, .little);
 
+  void writeF64(int addr, double val) => view.setFloat64(addr, val, .little);
+
   void writeI32(int addr, int val) => view.setInt32(addr, val, .little);
 
   void writeU16(int addr, int val) => view.setUint16(addr, val, .little);

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -81,6 +81,8 @@ const RawPlacementRenderInfo _emptyRenderInfo = (
   sourceHeight: 0,
 );
 
+const RawGridRef _emptyGridRef = (node: 0, x: 0, y: 0);
+
 class WasmBindings implements GhosttyBindings {
   final Mem _mem;
   final web.Table _table;
@@ -2383,7 +2385,7 @@ class WasmBindings implements GhosttyBindings {
     );
     final value = _readGridRef(gridRefPtr);
     _exports.ghostty_wasm_free_u8_array(pointPtr, _layout.pointSize);
-    _freeGridRef(gridRefPtr);
+    _exports.ghostty_wasm_free_u8_array(gridRefPtr, _layout.gridRefSize);
     return (.fromValue(result), value);
   }
 
@@ -2568,7 +2570,7 @@ class WasmBindings implements GhosttyBindings {
       _exports.ghostty_tracked_grid_ref_snapshot(ref, gridRefPtr),
     );
     final value = _readGridRef(gridRefPtr);
-    _freeGridRef(gridRefPtr);
+    _exports.ghostty_wasm_free_u8_array(gridRefPtr, _layout.gridRefSize);
     return (result, value);
   }
 
@@ -2594,6 +2596,667 @@ class WasmBindings implements GhosttyBindings {
     _freeGridRef(refPtr);
     _exports.ghostty_wasm_free_u8_array(outPtr, size);
     return (result, (col: col, row: row));
+  }
+
+  @override
+  CResult<RawSelection?> terminalGetSelection(int handle) {
+    final ptr = _allocSelection();
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_get(handle, TerminalData.selection.value, ptr),
+    );
+    final value = result == .success ? _readSelection(ptr) : null;
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  Result terminalSetSelection(int handle, RawSelection? selection) {
+    if (selection == null) {
+      return .fromValue(
+        _exports.ghostty_terminal_set(
+          handle,
+          TerminalOption.selection.value,
+          0,
+        ),
+      );
+    }
+    final ptr = _allocSelection(selection);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_set(
+        handle,
+        TerminalOption.selection.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.selectionSize);
+    return result;
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectAll(int terminal) {
+    final outPtr = _allocSelection();
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_select_all(terminal, outPtr),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectWord(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? boundaryCodepoints,
+  }) {
+    final optsPtr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.selectWordSize,
+    );
+    final outPtr = _allocSelection();
+    final codepoints = _allocCodepoints(boundaryCodepoints);
+    _zero(optsPtr, _layout.selectWordSize);
+    _mem.writeU32(optsPtr, _layout.selectWordSize);
+    _writeGridRef(optsPtr + _layout.selectWordRef, ref);
+    _mem.writeU32(
+      optsPtr + _layout.selectWordBoundaryCodepoints,
+      codepoints.ptr,
+    );
+    _mem.writeU32(
+      optsPtr + _layout.selectWordBoundaryCodepointsLen,
+      boundaryCodepoints?.length ?? 0,
+    );
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_select_word(terminal, optsPtr, outPtr),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _freeCodepoints(codepoints);
+    _exports.ghostty_wasm_free_u8_array(optsPtr, _layout.selectWordSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectWordBetween(
+    int terminal,
+    RawGridRef start,
+    RawGridRef end, {
+    List<int>? boundaryCodepoints,
+  }) {
+    final optsPtr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.selectWordBetweenSize,
+    );
+    final outPtr = _allocSelection();
+    final codepoints = _allocCodepoints(boundaryCodepoints);
+    _zero(optsPtr, _layout.selectWordBetweenSize);
+    _mem.writeU32(optsPtr, _layout.selectWordBetweenSize);
+    _writeGridRef(optsPtr + _layout.selectWordBetweenStart, start);
+    _writeGridRef(optsPtr + _layout.selectWordBetweenEnd, end);
+    _mem.writeU32(
+      optsPtr + _layout.selectWordBetweenBoundaryCodepoints,
+      codepoints.ptr,
+    );
+    _mem.writeU32(
+      optsPtr + _layout.selectWordBetweenBoundaryCodepointsLen,
+      boundaryCodepoints?.length ?? 0,
+    );
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_select_word_between(terminal, optsPtr, outPtr),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _freeCodepoints(codepoints);
+    _exports.ghostty_wasm_free_u8_array(optsPtr, _layout.selectWordBetweenSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectLine(
+    int terminal,
+    RawGridRef ref, {
+    List<int>? whitespace,
+    bool semanticPromptBoundary = false,
+  }) {
+    final optsPtr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.selectLineSize,
+    );
+    final outPtr = _allocSelection();
+    final codepoints = _allocCodepoints(whitespace);
+    _zero(optsPtr, _layout.selectLineSize);
+    _mem.writeU32(optsPtr, _layout.selectLineSize);
+    _writeGridRef(optsPtr + _layout.selectLineRef, ref);
+    _mem.writeU32(optsPtr + _layout.selectLineWhitespace, codepoints.ptr);
+    _mem.writeU32(
+      optsPtr + _layout.selectLineWhitespaceLen,
+      whitespace?.length ?? 0,
+    );
+    _mem.writeU8(
+      optsPtr + _layout.selectLineSemanticPromptBoundary,
+      semanticPromptBoundary ? 1 : 0,
+    );
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_select_line(terminal, optsPtr, outPtr),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _freeCodepoints(codepoints);
+    _exports.ghostty_wasm_free_u8_array(optsPtr, _layout.selectLineSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectOutput(int terminal, RawGridRef ref) {
+    final refPtr = _allocGridRef(ref);
+    final outPtr = _allocSelection();
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_select_output(terminal, refPtr, outPtr),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _freeGridRef(refPtr);
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectionAdjust(
+    int terminal,
+    RawSelection selection,
+    SelectionAdjust adjustment,
+  ) {
+    final selPtr = _allocSelection(selection);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_adjust(
+        terminal,
+        selPtr,
+        adjustment.value,
+      ),
+    );
+    final value = result == .success ? _readSelection(selPtr) : null;
+    _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<SelectionOrder> terminalSelectionOrder(
+    int terminal,
+    RawSelection selection,
+  ) {
+    const u32Size = 4;
+    final selPtr = _allocSelection(selection);
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(u32Size);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_order(terminal, selPtr, outPtr),
+    );
+    final value = result == .success
+        ? SelectionOrder.fromValue(_mem.readU32(outPtr))
+        : SelectionOrder.forward;
+    _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, u32Size);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawSelection?> terminalSelectionOrdered(
+    int terminal,
+    RawSelection selection,
+    SelectionOrder desired,
+  ) {
+    final selPtr = _allocSelection(selection);
+    final outPtr = _allocSelection();
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_ordered(
+        terminal,
+        selPtr,
+        desired.value,
+        outPtr,
+      ),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<bool> terminalSelectionContains(
+    int terminal,
+    RawSelection selection,
+    PointTag pointTag,
+    int col,
+    int row,
+  ) {
+    final selPtr = _allocSelection(selection);
+    final pointPtr = _exports.ghostty_wasm_alloc_u8_array(_layout.pointSize);
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(1);
+    _writePoint(pointPtr, pointTag, col, row);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_contains(
+        terminal,
+        selPtr,
+        pointPtr,
+        outPtr,
+      ),
+    );
+    final value = _mem.readU8(outPtr) != 0;
+    _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    _exports.ghostty_wasm_free_u8_array(pointPtr, _layout.pointSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, 1);
+    return (result, value);
+  }
+
+  @override
+  CResult<bool> terminalSelectionEqual(
+    int terminal,
+    RawSelection a,
+    RawSelection b,
+  ) {
+    final aPtr = _allocSelection(a);
+    final bPtr = _allocSelection(b);
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(1);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_equal(terminal, aPtr, bPtr, outPtr),
+    );
+    final value = _mem.readU8(outPtr) != 0;
+    _exports.ghostty_wasm_free_u8_array(aPtr, _layout.selectionSize);
+    _exports.ghostty_wasm_free_u8_array(bPtr, _layout.selectionSize);
+    _exports.ghostty_wasm_free_u8_array(outPtr, 1);
+    return (result, value);
+  }
+
+  @override
+  CResult<String> terminalSelectionFormat(
+    int terminal,
+    FormatterFormat format, {
+    bool unwrap = false,
+    bool trim = false,
+    RawSelection? selection,
+  }) {
+    final optsPtr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.selectionFormatSize,
+    );
+    final outPtr = _exports.ghostty_wasm_alloc_opaque();
+    final outLen = _exports.ghostty_wasm_alloc_usize();
+    _zero(optsPtr, _layout.selectionFormatSize);
+    _mem.writeU32(optsPtr, _layout.selectionFormatSize);
+    _mem.writeU32(optsPtr + _layout.selectionFormatEmit, format.value);
+    _mem.writeU8(optsPtr + _layout.selectionFormatUnwrap, unwrap ? 1 : 0);
+    _mem.writeU8(optsPtr + _layout.selectionFormatTrim, trim ? 1 : 0);
+    var selPtr = 0;
+    if (selection != null) {
+      selPtr = _allocSelection(selection);
+    }
+    _mem.writeU32(optsPtr + _layout.selectionFormatSelection, selPtr);
+    final result = Result.fromValue(
+      _exports.ghostty_terminal_selection_format_alloc(
+        terminal,
+        0,
+        optsPtr,
+        outPtr,
+        outLen,
+      ),
+    );
+    final dataPtr = _mem.readPtr(outPtr);
+    final len = _mem.readU32(outLen);
+    final value = result == .success && dataPtr != 0 && len > 0
+        ? utf8.decode(_mem.readBytes(dataPtr, len))
+        : '';
+    if (dataPtr != 0 && len > 0) {
+      _exports.ghostty_free(0, dataPtr, len);
+    }
+    if (selPtr != 0) {
+      _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
+    }
+    _exports.ghostty_wasm_free_u8_array(optsPtr, _layout.selectionFormatSize);
+    _exports.ghostty_wasm_free_opaque(outPtr);
+    _exports.ghostty_wasm_free_usize(outLen);
+    return (result, value);
+  }
+
+  @override
+  CResult<int> selectionGestureNew() {
+    final outPtr = _exports.ghostty_wasm_alloc_opaque();
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_new(0, outPtr),
+    );
+    final handle = _mem.readPtr(outPtr);
+    _exports.ghostty_wasm_free_opaque(outPtr);
+    return (result, handle);
+  }
+
+  @override
+  void selectionGestureFree(int gesture, int terminal) {
+    _exports.ghostty_selection_gesture_free(gesture, terminal);
+  }
+
+  @override
+  void selectionGestureReset(int gesture, int terminal) {
+    _exports.ghostty_selection_gesture_reset(gesture, terminal);
+  }
+
+  @override
+  CResult<RawSelection?> selectionGestureEvent(
+    int gesture,
+    int terminal,
+    int event,
+  ) {
+    final outPtr = _allocSelection();
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event(
+        gesture,
+        terminal,
+        event,
+        outPtr,
+      ),
+    );
+    final value = result == .success ? _readSelection(outPtr) : null;
+    _exports.ghostty_wasm_free_u8_array(outPtr, _layout.selectionSize);
+    return (result, value);
+  }
+
+  @override
+  CResult<int> selectionGestureEventNew(SelectionGestureEventType type) {
+    final outPtr = _exports.ghostty_wasm_alloc_opaque();
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_new(0, outPtr, type.value),
+    );
+    final handle = _mem.readPtr(outPtr);
+    _exports.ghostty_wasm_free_opaque(outPtr);
+    return (result, handle);
+  }
+
+  @override
+  void selectionGestureEventFree(int event) {
+    _exports.ghostty_selection_gesture_event_free(event);
+  }
+
+  @override
+  Result selectionGestureEventClear(
+    int event,
+    SelectionGestureEventOption option,
+  ) {
+    return .fromValue(
+      _exports.ghostty_selection_gesture_event_set(event, option.value, 0),
+    );
+  }
+
+  @override
+  Result selectionGestureEventSetRef(int event, RawGridRef ref) {
+    final ptr = _allocGridRef(ref);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.ref.value,
+        ptr,
+      ),
+    );
+    _freeGridRef(ptr);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetPosition(int event, double x, double y) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.surfacePositionSize,
+    );
+    _mem.writeF64(ptr + _layout.surfacePositionX, x);
+    _mem.writeF64(ptr + _layout.surfacePositionY, y);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.position.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.surfacePositionSize);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetRepeatDistance(int event, double value) {
+    const size = 8;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(size);
+    _mem.writeF64(ptr, value);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.repeatDistance.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, size);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetTimeNs(int event, int value) {
+    const size = 8;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(size);
+    _mem.writeU64(ptr, value);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.timeNs.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, size);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetRepeatIntervalNs(int event, int value) {
+    const size = 8;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(size);
+    _mem.writeU64(ptr, value);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.repeatIntervalNs.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, size);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetWordBoundaryCodepoints(
+    int event,
+    List<int> codepoints,
+  ) {
+    final values = _allocCodepoints(codepoints);
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(_layout.codepointsSize);
+    _zero(ptr, _layout.codepointsSize);
+    _mem.writeU32(ptr + _layout.codepointsPtr, values.ptr);
+    _mem.writeU32(ptr + _layout.codepointsLen, codepoints.length);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.wordBoundaryCodepoints.value,
+        ptr,
+      ),
+    );
+    _freeCodepoints(values);
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.codepointsSize);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetBehaviors(
+    int event,
+    SelectionGestureBehavior singleClick,
+    SelectionGestureBehavior doubleClick,
+    SelectionGestureBehavior tripleClick,
+  ) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.gestureBehaviorsSize,
+    );
+    _mem.writeU32(ptr + _layout.gestureBehaviorsSingleClick, singleClick.value);
+    _mem.writeU32(ptr + _layout.gestureBehaviorsDoubleClick, doubleClick.value);
+    _mem.writeU32(ptr + _layout.gestureBehaviorsTripleClick, tripleClick.value);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.behaviors.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.gestureBehaviorsSize);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetRectangle(int event, {required bool value}) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(1);
+    _mem.writeU8(ptr, value ? 1 : 0);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.rectangle.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, 1);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetGeometry(
+    int event, {
+    required int columns,
+    required int cellWidth,
+    required int paddingLeft,
+    required int screenHeight,
+  }) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.gestureGeometrySize,
+    );
+    _mem.writeU32(ptr + _layout.gestureGeometryColumns, columns);
+    _mem.writeU32(ptr + _layout.gestureGeometryCellWidth, cellWidth);
+    _mem.writeU32(ptr + _layout.gestureGeometryPaddingLeft, paddingLeft);
+    _mem.writeU32(ptr + _layout.gestureGeometryScreenHeight, screenHeight);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.geometry.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.gestureGeometrySize);
+    return result;
+  }
+
+  @override
+  Result selectionGestureEventSetViewport(
+    int event, {
+    required int col,
+    required int row,
+  }) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(
+      _layout.pointCoordinateSize,
+    );
+    _mem.writeU16(ptr + _layout.pointCoordinateX, col);
+    _mem.writeU32(ptr + _layout.pointCoordinateY, row);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_event_set(
+        event,
+        SelectionGestureEventOption.viewport.value,
+        ptr,
+      ),
+    );
+    _exports.ghostty_wasm_free_u8_array(ptr, _layout.pointCoordinateSize);
+    return result;
+  }
+
+  @override
+  CResult<int> selectionGestureGetClickCount(int gesture, int terminal) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(1);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get(
+        gesture,
+        terminal,
+        SelectionGestureData.clickCount.value,
+        ptr,
+      ),
+    );
+    final value = _mem.readU8(ptr);
+    _exports.ghostty_wasm_free_u8_array(ptr, 1);
+    return (result, value);
+  }
+
+  @override
+  CResult<bool> selectionGestureGetDragged(int gesture, int terminal) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(1);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get(
+        gesture,
+        terminal,
+        SelectionGestureData.dragged.value,
+        ptr,
+      ),
+    );
+    final value = _mem.readU8(ptr) != 0;
+    _exports.ghostty_wasm_free_u8_array(ptr, 1);
+    return (result, value);
+  }
+
+  @override
+  CResult<SelectionGestureAutoscroll> selectionGestureGetAutoscroll(
+    int gesture,
+    int terminal,
+  ) {
+    const size = 4;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(size);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get(
+        gesture,
+        terminal,
+        SelectionGestureData.autoscroll.value,
+        ptr,
+      ),
+    );
+    final value = result == .success
+        ? SelectionGestureAutoscroll.fromValue(_mem.readU32(ptr))
+        : SelectionGestureAutoscroll.none;
+    _exports.ghostty_wasm_free_u8_array(ptr, size);
+    return (result, value);
+  }
+
+  @override
+  CResult<SelectionGestureBehavior> selectionGestureGetBehavior(
+    int gesture,
+    int terminal,
+  ) {
+    const size = 4;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(size);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get(
+        gesture,
+        terminal,
+        SelectionGestureData.behavior.value,
+        ptr,
+      ),
+    );
+    final value = result == .success
+        ? SelectionGestureBehavior.fromValue(_mem.readU32(ptr))
+        : SelectionGestureBehavior.cell;
+    _exports.ghostty_wasm_free_u8_array(ptr, size);
+    return (result, value);
+  }
+
+  @override
+  CResult<RawGridRef> selectionGestureGetAnchor(int gesture, int terminal) {
+    final ptr = _allocGridRef(_emptyGridRef);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get(
+        gesture,
+        terminal,
+        SelectionGestureData.anchor.value,
+        ptr,
+      ),
+    );
+    final value = result == .success ? _readGridRef(ptr) : _emptyGridRef;
+    _freeGridRef(ptr);
+    return (result, value);
   }
 
   @override
@@ -2674,8 +3337,10 @@ class WasmBindings implements GhosttyBindings {
     if (selection != null) {
       selPtr = _exports.ghostty_wasm_alloc_u8_array(_layout.selectionSize);
       _mem.writeU32(selPtr, _layout.selectionSize);
-      _writeGridRef(selPtr + _layout.selectionStart, selection.start);
-      _writeGridRef(selPtr + _layout.selectionEnd, selection.end);
+      final startDst = selPtr + _layout.selectionStart;
+      final endDst = selPtr + _layout.selectionEnd;
+      _writeGridRef(startDst, selection.start);
+      _writeGridRef(endDst, selection.end);
       _mem.writeU8(
         selPtr + _layout.selectionRectangle,
         selection.rectangle ? 1 : 0,
@@ -3064,6 +3729,12 @@ class WasmBindings implements GhosttyBindings {
     _mem.writeU32(pointPtr + _layout.pointY, y);
   }
 
+  void _zero(int ptr, int len) {
+    for (var i = 0; i < len; i++) {
+      _mem.writeU8(ptr + i, 0);
+    }
+  }
+
   int _allocGridRef(RawGridRef ref) {
     final ptr = _exports.ghostty_wasm_alloc_u8_array(_layout.gridRefSize);
     _writeGridRef(ptr, ref);
@@ -3087,6 +3758,44 @@ class WasmBindings implements GhosttyBindings {
     _mem.writeU32(ptr + _layout.gridRefNode, ref.node);
     _mem.writeU16(ptr + _layout.gridRefX, ref.x);
     _mem.writeU16(ptr + _layout.gridRefY, ref.y);
+  }
+
+  int _allocSelection([RawSelection? selection]) {
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(_layout.selectionSize);
+    _zero(ptr, _layout.selectionSize);
+    _mem.writeU32(ptr, _layout.selectionSize);
+    if (selection != null) _writeSelection(ptr, selection);
+    return ptr;
+  }
+
+  RawSelection _readSelection(int ptr) {
+    return (
+      start: _readGridRef(ptr + _layout.selectionStart),
+      end: _readGridRef(ptr + _layout.selectionEnd),
+      rectangle: _mem.readU8(ptr + _layout.selectionRectangle) != 0,
+    );
+  }
+
+  void _writeSelection(int ptr, RawSelection selection) {
+    _mem.writeU32(ptr, _layout.selectionSize);
+    _writeGridRef(ptr + _layout.selectionStart, selection.start);
+    _writeGridRef(ptr + _layout.selectionEnd, selection.end);
+    _mem.writeU8(ptr + _layout.selectionRectangle, selection.rectangle ? 1 : 0);
+  }
+
+  ({int ptr, int bytes}) _allocCodepoints(List<int>? codepoints) {
+    if (codepoints == null) return (ptr: 0, bytes: 0);
+    final bytes = (codepoints.isEmpty ? 1 : codepoints.length) * 4;
+    final ptr = _exports.ghostty_wasm_alloc_u8_array(bytes);
+    for (var i = 0; i < codepoints.length; i++) {
+      _mem.writeU32(ptr + i * 4, codepoints[i]);
+    }
+    return (ptr: ptr, bytes: bytes);
+  }
+
+  void _freeCodepoints(({int ptr, int bytes}) codepoints) {
+    if (codepoints.ptr == 0) return;
+    _exports.ghostty_wasm_free_u8_array(codepoints.ptr, codepoints.bytes);
   }
 
   SgrAttribute _readSgrAttribute(int attrPtr) {

--- a/packages/libghostty/lib/src/impl/terminal/formatter.dart
+++ b/packages/libghostty/lib/src/impl/terminal/formatter.dart
@@ -78,18 +78,13 @@ final class Formatter {
       );
     }
 
-    final start = GridRef.at(
-      terminal,
-      col: selection.startCol,
-      row: selection.startRow,
-      pointTag: selection.pointTag,
-    );
-    final end = GridRef.at(
-      terminal,
-      col: selection.endCol,
-      row: selection.endRow,
-      pointTag: selection.pointTag,
-    );
+    if (!identical(selection.start._terminal, terminal)) {
+      throw ArgumentError.value(
+        selection,
+        'selection',
+        'must belong to formatter terminal',
+      );
+    }
 
     return check(
       bindings.formatterTerminalNew(
@@ -98,11 +93,7 @@ final class Formatter {
         unwrap: unwrap,
         trim: trim,
         extra: extra,
-        selection: (
-          start: start._value,
-          end: end._value,
-          rectangle: selection.rectangle,
-        ),
+        selection: selection._raw,
       ),
     );
   }

--- a/packages/libghostty/lib/src/impl/terminal/selection.dart
+++ b/packages/libghostty/lib/src/impl/terminal/selection.dart
@@ -1,83 +1,157 @@
 part of 'terminal.dart';
 
-/// A range of terminal content between two cell positions.
+/// A snapshot selection range defined by two grid references.
 ///
-/// Endpoints are resolved against the terminal's current page state when
-/// a [Formatter] is constructed. Subsequent mutating operations on the
-/// terminal (write, reset, resize) may invalidate those endpoints;
-/// construct a fresh [Formatter] with a new [Selection] after such
-/// operations.
+/// Both endpoints are inclusive and preserve direction. [start] may be after
+/// [end] in terminal order. When [rectangle] is true, the endpoints are
+/// interpreted as opposite corners of a block selection.
 ///
-/// [pointTag] selects the coordinate space the row/column values refer
-/// to. Use [PointTag.active] for the active screen (default),
-/// [PointTag.viewport] for viewport-relative addressing, or
-/// [PointTag.screen] to address the full scrollback plus active screen
-/// by absolute row index.
+/// The endpoint refs are untracked snapshots and follow normal [GridRef]
+/// lifetime rules. A selection does not track terminal mutations. If the
+/// endpoints must survive mutations, keep [TrackedGridRef]s separately and
+/// create a fresh [Selection] from their snapshots immediately before use.
 ///
 /// ```dart
-/// final selection = Selection(
-///   startCol: 0, startRow: 0,
-///   endCol: 10, endRow: 0,
-/// );
-/// final formatter = Formatter(
-///   terminal: terminal,
-///   format: FormatterFormat.plain,
-///   selection: selection,
-/// );
+/// final start = GridRef.at(terminal, col: 0, row: 0);
+/// final end = GridRef.at(terminal, col: 4, row: 0);
+/// terminal.selection = Selection.fromRefs(start: start, end: end);
 /// ```
 @immutable
 final class Selection {
-  /// Zero-based column of the selection start (inclusive).
-  final int startCol;
+  /// Start of the selection range, inclusive.
+  final GridRef start;
 
-  /// Zero-based row of the selection start (inclusive).
-  final int startRow;
+  /// End of the selection range, inclusive.
+  final GridRef end;
 
-  /// Zero-based column of the selection end (inclusive).
-  final int endCol;
-
-  /// Zero-based row of the selection end (inclusive).
-  final int endRow;
-
-  /// Whether the selection covers a rectangular (block) region rather
-  /// than a linear text range.
+  /// Whether endpoints describe a rectangular block selection.
   final bool rectangle;
 
-  /// Coordinate space the row/column values address.
-  final PointTag pointTag;
+  /// Creates a selection from two grid-reference snapshots.
+  ///
+  /// Both refs must come from the same [Terminal]. The refs are values and are
+  /// not consumed by the selection. The created selection follows normal
+  /// [GridRef] lifetime rules and must not be reused after a mutating terminal
+  /// call invalidates its endpoint snapshots.
+  factory Selection.fromRefs({
+    required GridRef start,
+    required GridRef end,
+    bool rectangle = false,
+  }) {
+    if (!identical(start._terminal, end._terminal)) {
+      throw ArgumentError.value(end, 'end', 'must belong to start terminal');
+    }
+    return Selection._(start, end, rectangle);
+  }
 
-  const Selection({
-    required this.startCol,
-    required this.startRow,
-    required this.endCol,
-    required this.endRow,
-    this.rectangle = false,
-    this.pointTag = PointTag.active,
-  });
+  const Selection._(this.start, this.end, this.rectangle);
+
+  Selection._fromRaw(Terminal terminal, RawSelection selection)
+    : this._(
+        GridRef._fromValue(terminal, selection.start),
+        GridRef._fromValue(terminal, selection.end),
+        selection.rectangle,
+      );
 
   @override
-  int get hashCode => Object.hash(
-    Selection,
-    startCol,
-    startRow,
-    endCol,
-    endRow,
-    rectangle,
-    pointTag,
-  );
+  int get hashCode => Object.hash(Selection, start, end, rectangle);
+
+  /// The current endpoint order.
+  SelectionOrder get order {
+    final terminal = start._terminal;
+    return check(bindings.terminalSelectionOrder(terminal._handle, _raw));
+  }
+
+  RawSelection get _raw {
+    return (start: start._value, end: end._value, rectangle: rectangle);
+  }
 
   @override
   bool operator ==(Object other) =>
       other is Selection &&
-      other.startCol == startCol &&
-      other.startRow == startRow &&
-      other.endCol == endCol &&
-      other.endRow == endRow &&
-      other.rectangle == rectangle &&
-      other.pointTag == pointTag;
+      other.start == start &&
+      other.end == end &&
+      other.rectangle == rectangle;
+
+  /// Moves the logical end endpoint by [adjustment].
+  Selection adjust(SelectionAdjust adjustment) {
+    final terminal = start._terminal;
+    return Selection._fromRaw(
+      terminal,
+      check(
+        bindings.terminalSelectionAdjust(terminal._handle, _raw, adjustment),
+      )!,
+    );
+  }
+
+  /// Whether this selection includes the terminal point at [col], [row].
+  bool contains({
+    required int col,
+    required int row,
+    PointTag pointTag = .active,
+  }) {
+    final terminal = start._terminal;
+    return check(
+      bindings.terminalSelectionContains(
+        terminal._handle,
+        _raw,
+        pointTag,
+        col,
+        row,
+      ),
+    );
+  }
+
+  /// Whether this selection is equal to [other] according to libghostty.
+  bool equal(Selection other) {
+    final terminal = start._terminal;
+    _checkSameTerminal(other, terminal);
+    return check(
+      bindings.terminalSelectionEqual(terminal._handle, _raw, other._raw),
+    );
+  }
+
+  /// Formats this selection.
+  String format({
+    FormatterFormat format = .plain,
+    bool unwrap = false,
+    bool trim = false,
+  }) {
+    final terminal = start._terminal;
+    final (code, text) = bindings.terminalSelectionFormat(
+      terminal._handle,
+      format,
+      unwrap: unwrap,
+      trim: trim,
+      selection: _raw,
+    );
+    checkCode(code);
+    return text;
+  }
+
+  /// Returns this selection with endpoints ordered as [desired].
+  Selection ordered(SelectionOrder desired) {
+    final terminal = start._terminal;
+    return Selection._fromRaw(
+      terminal,
+      check(
+        bindings.terminalSelectionOrdered(terminal._handle, _raw, desired),
+      )!,
+    );
+  }
 
   @override
-  String toString() =>
-      'Selection($startCol,$startRow -> $endCol,$endRow'
-      '${rectangle ? ', rectangle' : ''}, $pointTag)';
+  String toString() {
+    return 'Selection($start -> $end${rectangle ? ', rectangle' : ''})';
+  }
+
+  void _checkSameTerminal(Selection other, Terminal terminal) {
+    if (!identical(other.start._terminal, terminal)) {
+      throw ArgumentError.value(
+        other,
+        'other',
+        'must belong to this selection terminal',
+      );
+    }
+  }
 }

--- a/packages/libghostty/lib/src/impl/terminal/selection_gesture.dart
+++ b/packages/libghostty/lib/src/impl/terminal/selection_gesture.dart
@@ -1,0 +1,277 @@
+part of 'terminal.dart';
+
+/// Mutable state machine for terminal text selection gestures.
+///
+/// The gesture converts reusable [SelectionGestureEvent] values into selection
+/// snapshots. Returned selections are not installed automatically. The
+/// creating terminal must outlive this gesture for [state], [apply], and
+/// [reset].
+final class SelectionGesture {
+  static final _finalizer = Finalizer<({int handle, Terminal terminal})>((
+    token,
+  ) {
+    bindings.selectionGestureFree(token.handle, token.terminal._handleOrNull);
+  });
+
+  final int _handle;
+  final Terminal _terminal;
+
+  /// Creates a gesture state machine bound to [terminal].
+  SelectionGesture(Terminal terminal)
+    : _handle = check(bindings.selectionGestureNew()),
+      _terminal = terminal {
+    _finalizer.attach(this, (
+      handle: _handle,
+      terminal: _terminal,
+    ), detach: this);
+  }
+
+  /// Current readable gesture state.
+  SelectionGestureState get state {
+    final terminal = _terminal._handle;
+    final anchorResult = bindings.selectionGestureGetAnchor(_handle, terminal);
+    if (anchorResult.$1 != .success && anchorResult.$1 != .noValue) {
+      checkCode(anchorResult.$1);
+    }
+
+    return SelectionGestureState(
+      clickCount: check(
+        bindings.selectionGestureGetClickCount(_handle, terminal),
+      ),
+      dragged: check(bindings.selectionGestureGetDragged(_handle, terminal)),
+      autoscroll: check(
+        bindings.selectionGestureGetAutoscroll(_handle, terminal),
+      ),
+      behavior: check(bindings.selectionGestureGetBehavior(_handle, terminal)),
+      anchor: anchorResult.$1 == .success
+          ? GridRef._fromValue(_terminal, anchorResult.$2)
+          : null,
+    );
+  }
+
+  /// Applies [event] and returns the produced selection snapshot, if any.
+  Selection? apply(SelectionGestureEvent event) {
+    final (code, raw) = bindings.selectionGestureEvent(
+      _handle,
+      _terminal._handle,
+      event._handle,
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(_terminal, raw!);
+  }
+
+  /// Releases the native gesture handle.
+  ///
+  /// Must be called to free resources; the gesture must not be used afterward.
+  /// It is safe to dispose after the creating terminal has been disposed.
+  void dispose() {
+    _finalizer.detach(this);
+    bindings.selectionGestureFree(_handle, _terminal._handleOrNull);
+  }
+
+  /// Clears active gesture state while keeping this gesture reusable.
+  void reset() => bindings.selectionGestureReset(_handle, _terminal._handle);
+}
+
+/// Selection behavior table for single-, double-, and triple-click gestures.
+@immutable
+final class SelectionGestureBehaviors {
+  /// Standard terminal selection behavior: cell, word, line.
+  static const standard = SelectionGestureBehaviors(
+    singleClick: .cell,
+    doubleClick: .word,
+    tripleClick: .line,
+  );
+
+  /// Behavior for single-click selection gestures.
+  final SelectionGestureBehavior singleClick;
+
+  /// Behavior for double-click selection gestures.
+  final SelectionGestureBehavior doubleClick;
+
+  /// Behavior for triple-click selection gestures.
+  final SelectionGestureBehavior tripleClick;
+
+  /// Creates a behavior table for gesture press events.
+  const SelectionGestureBehaviors({
+    required this.singleClick,
+    required this.doubleClick,
+    required this.tripleClick,
+  });
+}
+
+/// Reusable event data for a selection gesture operation.
+///
+/// The event kind is fixed at construction time. Set options before applying
+/// the event with [SelectionGesture.apply].
+final class SelectionGestureEvent {
+  static final _finalizer = Finalizer<int>(bindings.selectionGestureEventFree);
+
+  final int _handle;
+
+  /// Creates an autoscroll tick event.
+  SelectionGestureEvent.autoscrollTick() : this._(.autoscrollTick);
+
+  /// Creates a deep-press event.
+  SelectionGestureEvent.deepPress() : this._(.deepPress);
+
+  /// Creates a drag event.
+  SelectionGestureEvent.drag() : this._(.drag);
+
+  /// Creates a press event.
+  SelectionGestureEvent.press() : this._(.press);
+
+  /// Creates a release event.
+  SelectionGestureEvent.release() : this._(.release);
+
+  SelectionGestureEvent._(SelectionGestureEventType type)
+    : _handle = check(bindings.selectionGestureEventNew(type)) {
+    _finalizer.attach(this, _handle, detach: this);
+  }
+
+  /// Clears [option].
+  void clear(SelectionGestureEventOption option) {
+    checkCode(bindings.selectionGestureEventClear(_handle, option));
+  }
+
+  /// Releases the event handle.
+  void dispose() {
+    _finalizer.detach(this);
+    bindings.selectionGestureEventFree(_handle);
+  }
+
+  /// Sets the behavior table for press events.
+  void setBehaviors(SelectionGestureBehaviors behaviors) {
+    checkCode(
+      bindings.selectionGestureEventSetBehaviors(
+        _handle,
+        behaviors.singleClick,
+        behaviors.doubleClick,
+        behaviors.tripleClick,
+      ),
+    );
+  }
+
+  /// Sets drag display geometry.
+  void setGeometry(SelectionGestureGeometry geometry) {
+    checkCode(
+      bindings.selectionGestureEventSetGeometry(
+        _handle,
+        columns: geometry.columns,
+        cellWidth: geometry.cellWidth,
+        paddingLeft: geometry.paddingLeft,
+        screenHeight: geometry.screenHeight,
+      ),
+    );
+  }
+
+  /// Sets the surface-space pointer position.
+  void setPosition(double x, double y) {
+    checkCode(bindings.selectionGestureEventSetPosition(_handle, x, y));
+  }
+
+  /// Sets whether drag/autoscroll events produce a rectangular selection.
+  void setRectangle({required bool value}) {
+    checkCode(
+      bindings.selectionGestureEventSetRectangle(_handle, value: value),
+    );
+  }
+
+  /// Sets or clears the grid reference under the pointer.
+  void setRef(GridRef? ref) {
+    if (ref == null) return clear(.ref);
+    checkCode(bindings.selectionGestureEventSetRef(_handle, ref._value));
+  }
+
+  /// Sets the maximum repeat-click distance in pixels.
+  void setRepeatDistance(double value) {
+    checkCode(bindings.selectionGestureEventSetRepeatDistance(_handle, value));
+  }
+
+  /// Sets the maximum interval between repeat clicks in nanoseconds.
+  void setRepeatIntervalNs(int value) {
+    checkCode(
+      bindings.selectionGestureEventSetRepeatIntervalNs(_handle, value),
+    );
+  }
+
+  /// Sets the monotonic event time in nanoseconds.
+  void setTimeNs(int value) {
+    checkCode(bindings.selectionGestureEventSetTimeNs(_handle, value));
+  }
+
+  /// Sets the viewport coordinate for an autoscroll tick.
+  void setViewport({required int col, required int row}) {
+    checkCode(
+      bindings.selectionGestureEventSetViewport(_handle, col: col, row: row),
+    );
+  }
+
+  /// Sets word-boundary codepoints.
+  ///
+  /// Passing an empty list means an explicit empty boundary set. Use
+  /// `clear(SelectionGestureEventOption.wordBoundaryCodepoints)` to restore
+  /// libghostty defaults.
+  void setWordBoundaryCodepoints(List<int> codepoints) {
+    checkCode(
+      bindings.selectionGestureEventSetWordBoundaryCodepoints(
+        _handle,
+        codepoints,
+      ),
+    );
+  }
+}
+
+/// Display geometry used to interpret drag and autoscroll gesture events.
+@immutable
+final class SelectionGestureGeometry {
+  /// Number of rendered terminal columns. Must be non-zero.
+  final int columns;
+
+  /// Width of one terminal cell in surface pixels. Must be non-zero.
+  final int cellWidth;
+
+  /// Left padding before the terminal grid begins in surface pixels.
+  final int paddingLeft;
+
+  /// Height of the rendered terminal surface in surface pixels. Must be
+  /// non-zero.
+  final int screenHeight;
+
+  /// Creates display geometry for drag and autoscroll events.
+  const SelectionGestureGeometry({
+    required this.columns,
+    required this.cellWidth,
+    required this.paddingLeft,
+    required this.screenHeight,
+  });
+}
+
+/// Current readable state for a selection gesture.
+@immutable
+final class SelectionGestureState {
+  /// Current click count. Zero means inactive.
+  final int clickCount;
+
+  /// Whether the current or last left-click gesture dragged.
+  final bool dragged;
+
+  /// Current autoscroll request.
+  final SelectionGestureAutoscroll autoscroll;
+
+  /// Current gesture behavior.
+  final SelectionGestureBehavior behavior;
+
+  /// Current left-click anchor, or null when there is no active anchor.
+  final GridRef? anchor;
+
+  /// Creates a selection gesture state snapshot.
+  const SelectionGestureState({
+    required this.clickCount,
+    required this.dragged,
+    required this.autoscroll,
+    required this.behavior,
+    required this.anchor,
+  });
+}

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -21,6 +21,7 @@ part 'kitty_graphics.dart';
 part 'render_state.dart';
 part 'row_iterator.dart';
 part 'selection.dart';
+part 'selection_gesture.dart';
 part 'tracked_grid_ref.dart';
 
 /// Complete terminal emulator managing screen state, scrollback, cursor,
@@ -84,6 +85,7 @@ final class Terminal with Listenable {
   });
 
   final int _handle;
+  bool _disposed;
 
   /// Creates a terminal with the given grid dimensions and scrollback limit.
   ///
@@ -96,7 +98,8 @@ final class Terminal with Listenable {
   /// final terminal = Terminal(cols: 80, rows: 24, maxScrollback: 5000);
   /// ```
   Terminal({required int cols, required int rows, int maxScrollback = 10_000})
-    : _handle = check(bindings.terminalNew(cols, rows, maxScrollback)) {
+    : _handle = check(bindings.terminalNew(cols, rows, maxScrollback)),
+      _disposed = false {
     _finalizer.attach(this, _handle, detach: this);
   }
 
@@ -287,6 +290,14 @@ final class Terminal with Listenable {
     bindings.terminalSetOnEnquiry(_handle, value);
   }
 
+  /// Registers a callback for working-directory changes via OSC 7/9/1337.
+  ///
+  /// Query the new [pwd] after the callback returns. Fires synchronously
+  /// during [write].
+  set onPwdChanged(VoidCallback? value) {
+    bindings.terminalSetOnPwdChanged(_handle, value);
+  }
+
   /// Registers a callback for XTWINOPS size queries (CSI 14/16/18 t).
   ///
   /// Return a [TerminalSizeInfo] with the current geometry, or null to
@@ -301,14 +312,6 @@ final class Terminal with Listenable {
   /// during [write].
   set onTitleChanged(VoidCallback? value) {
     bindings.terminalSetOnTitleChanged(_handle, value);
-  }
-
-  /// Registers a callback for working-directory changes via OSC 7/9/1337.
-  ///
-  /// Query the new [pwd] after the callback returns. Fires synchronously
-  /// during [write].
-  set onPwdChanged(VoidCallback? value) {
-    bindings.terminalSetOnPwdChanged(_handle, value);
   }
 
   /// Registers a callback for PTY write-back data.
@@ -376,6 +379,27 @@ final class Terminal with Listenable {
   /// traversing the scrollback page list to compute the total size.
   Scrollbar get scrollbar => check(bindings.terminalGetScrollbar(_handle));
 
+  /// Active selection on the terminal screen, or null when none is active.
+  ///
+  /// Getting returns an untracked snapshot. Setting installs a copy as
+  /// terminal-owned tracked state. Set null to clear the active selection.
+  Selection? get selection {
+    final (code, raw) = bindings.terminalGetSelection(_handle);
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
+  /// Sets the active selection on the terminal screen.
+  ///
+  /// Assigning a selection installs a terminal-owned copy of its endpoints.
+  /// Assign null to clear the active selection. Non-null selections must belong
+  /// to this terminal.
+  set selection(Selection? value) {
+    checkCode(bindings.terminalSetSelection(_handle, _checkedSelection(value)));
+    notifyListeners();
+  }
+
   /// Terminal title as set by OSC 0 or OSC 2 sequences.
   ///
   /// The returned value is borrowed from the terminal. Read it immediately
@@ -393,15 +417,41 @@ final class Terminal with Listenable {
   /// Total terminal width in pixels (cols * cell width).
   int get widthPx => check(bindings.terminalGetWidthPx(_handle));
 
+  int get _handleOrNull => _disposed ? 0 : _handle;
+
   /// Releases the native terminal handle and clears registered callbacks.
   ///
   /// Must be called to free resources; the terminal must not be used
   /// afterward.
   void dispose() {
+    if (_disposed) return;
+    _disposed = true;
     clearListeners();
-    bindings.terminalDisposeCallbacks(_handle);
     _finalizer.detach(this);
+    bindings.terminalDisposeCallbacks(_handle);
     bindings.terminalFree(_handle);
+  }
+
+  /// Formats an explicit or active selection.
+  ///
+  /// When [selection] is null, the terminal's active selection is used. Returns
+  /// null if no active selection exists.
+  String? formatSelection({
+    FormatterFormat format = .plain,
+    bool unwrap = false,
+    bool trim = false,
+    Selection? selection,
+  }) {
+    final (code, text) = bindings.terminalSelectionFormat(
+      _handle,
+      format,
+      unwrap: unwrap,
+      trim: trim,
+      selection: _checkedSelection(selection),
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return text;
   }
 
   /// Queries whether the given terminal [mode] is currently enabled.
@@ -457,12 +507,97 @@ final class Terminal with Listenable {
     bindings.terminalScrollViewport(_handle, .delta, delta);
   }
 
+  /// Derives a selection snapshot covering all selectable terminal content.
+  ///
+  /// The returned selection is not installed as the terminal's active
+  /// selection. Assign it to [selection] to make it active.
+  Selection? selectAll() {
+    final (code, raw) = bindings.terminalSelectAll(_handle);
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
+  /// Derives a line selection snapshot under [ref].
+  ///
+  /// The returned selection is not installed as the terminal's active
+  /// selection. Assign it to [selection] to make it active.
+  Selection? selectLine(
+    GridRef ref, {
+    List<int>? whitespace,
+    bool semanticPromptBoundary = false,
+  }) {
+    final (code, raw) = bindings.terminalSelectLine(
+      _handle,
+      _checkedRef(ref),
+      whitespace: whitespace,
+      semanticPromptBoundary: semanticPromptBoundary,
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
+  /// Derives a semantic command-output selection snapshot under [ref].
+  ///
+  /// The returned selection is not installed as the terminal's active
+  /// selection. Assign it to [selection] to make it active.
+  Selection? selectOutput(GridRef ref) {
+    final (code, raw) = bindings.terminalSelectOutput(
+      _handle,
+      _checkedRef(ref),
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
+  /// Derives a word selection snapshot under [ref].
+  ///
+  /// The returned selection is not installed as the terminal's active
+  /// selection. Assign it to [selection] to make it active.
+  Selection? selectWord(GridRef ref, {List<int>? boundaryCodepoints}) {
+    final (code, raw) = bindings.terminalSelectWord(
+      _handle,
+      _checkedRef(ref),
+      boundaryCodepoints: boundaryCodepoints,
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
+  /// Derives the nearest word selection snapshot between two grid references.
+  ///
+  /// The returned selection is not installed as the terminal's active
+  /// selection. Assign it to [selection] to make it active.
+  Selection? selectWordBetween(
+    GridRef start,
+    GridRef end, {
+    List<int>? boundaryCodepoints,
+  }) {
+    final (code, raw) = bindings.terminalSelectWordBetween(
+      _handle,
+      _checkedRef(start, 'start'),
+      _checkedRef(end, 'end'),
+      boundaryCodepoints: boundaryCodepoints,
+    );
+    if (code == .noValue) return null;
+    checkCode(code);
+    return Selection._fromRaw(this, raw!);
+  }
+
   /// Sets the maximum bytes the APC handler will buffer for all protocols.
   ///
   /// This replaces protocol-specific overrides. Pass null to remove all
   /// overrides and use the built-in defaults.
   void setApcBufferLimit(int? bytes) {
     checkCode(bindings.terminalSetApcBufferLimit(_handle, bytes));
+  }
+
+  /// Enables or disables Glyph Protocol APC handling.
+  void setGlyphProtocol({required bool enabled}) {
+    checkCode(bindings.terminalSetGlyphProtocol(_handle, enabled: enabled));
   }
 
   /// Sets the maximum bytes the APC handler will buffer for Kitty graphics
@@ -480,11 +615,6 @@ final class Terminal with Listenable {
     checkCode(
       bindings.terminalSetKittyImageMediumFile(_handle, enabled: enabled),
     );
-  }
-
-  /// Enables or disables Glyph Protocol APC handling.
-  void setGlyphProtocol({required bool enabled}) {
-    checkCode(bindings.terminalSetGlyphProtocol(_handle, enabled: enabled));
   }
 
   /// Enables or disables the shared memory medium for Kitty image loading.
@@ -518,6 +648,29 @@ final class Terminal with Listenable {
   void write(Uint8List data) {
     bindings.terminalVtWrite(_handle, data);
     notifyListeners();
+  }
+
+  RawGridRef _checkedRef(GridRef ref, [String name = 'ref']) {
+    _checkRefTerminal(ref, name);
+    return ref._value;
+  }
+
+  RawSelection? _checkedSelection(Selection? selection) {
+    if (selection == null) return null;
+    if (!identical(selection.start._terminal, this)) {
+      throw ArgumentError.value(
+        selection,
+        'selection',
+        'must belong to this terminal',
+      );
+    }
+    return selection._raw;
+  }
+
+  void _checkRefTerminal(GridRef ref, String name) {
+    if (!identical(ref._terminal, this)) {
+      throw ArgumentError.value(ref, name, 'must belong to this terminal');
+    }
   }
 
   static RgbColor? _optionalColor(CResult<RgbColor> result) {

--- a/packages/libghostty/test/impl/terminal/selection_gesture_test.dart
+++ b/packages/libghostty/test/impl/terminal/selection_gesture_test.dart
@@ -1,0 +1,166 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SelectionGesture', () {
+    late Terminal terminal;
+
+    setUp(() {
+      terminal = Terminal(cols: 80, rows: 24);
+    });
+
+    tearDown(() {
+      terminal.dispose();
+    });
+
+    group('apply', () {
+      test('drag produces a selection snapshot', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        final drag = SelectionGestureEvent.drag();
+        addTearDown(drag.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        drag.setRef(GridRef.at(terminal, col: 2, row: 0));
+        drag.setGeometry(
+          const SelectionGestureGeometry(
+            columns: 80,
+            cellWidth: 8,
+            paddingLeft: 0,
+            screenHeight: 24,
+          ),
+        );
+        gesture.apply(press);
+
+        final selection = gesture.apply(drag);
+
+        expect(terminal.formatSelection(selection: selection), 'AB');
+      });
+    });
+
+    group('state', () {
+      test('reports click count after press', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+
+        gesture.apply(press);
+
+        expect(gesture.state.clickCount, 1);
+      });
+
+      test('reports custom press behavior', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        press.setBehaviors(
+          const SelectionGestureBehaviors(
+            singleClick: .line,
+            doubleClick: .word,
+            tripleClick: .cell,
+          ),
+        );
+
+        gesture.apply(press);
+
+        expect(gesture.state.behavior, SelectionGestureBehavior.line);
+      });
+    });
+
+    group('reset', () {
+      test('clears click count', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        gesture.apply(press);
+
+        gesture.reset();
+
+        expect(gesture.state.clickCount, 0);
+      });
+    });
+
+    group('dispose', () {
+      test('succeeds while terminal is alive', () {
+        final gesture = SelectionGesture(terminal);
+
+        expect(gesture.dispose, returnsNormally);
+      });
+
+      test('succeeds after terminal disposal', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        gesture.apply(press);
+
+        terminal.dispose();
+
+        expect(gesture.dispose, returnsNormally);
+      });
+    });
+
+    group('SelectionGestureEvent', () {
+      test('press applies with optional click metadata', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        press.setPosition(4, 8);
+        press.setRepeatDistance(12);
+        press.setRepeatIntervalNs(500);
+        press.setTimeNs(1);
+        press.setWordBoundaryCodepoints('_'.codeUnits);
+
+        gesture.apply(press);
+
+        expect(gesture.state.clickCount, 1);
+      });
+
+      test('drag can produce a rectangular selection', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        final drag = SelectionGestureEvent.drag();
+        addTearDown(drag.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        drag.setRef(GridRef.at(terminal, col: 2, row: 1));
+        drag.setRectangle(value: true);
+        drag.setGeometry(
+          const SelectionGestureGeometry(
+            columns: 80,
+            cellWidth: 8,
+            paddingLeft: 0,
+            screenHeight: 24,
+          ),
+        );
+        gesture.apply(press);
+
+        final selection = gesture.apply(drag);
+
+        expect(selection?.rectangle, isTrue);
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/impl/terminal/selection_test.dart
+++ b/packages/libghostty/test/impl/terminal/selection_test.dart
@@ -1,0 +1,164 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Selection', () {
+    late Terminal terminal;
+
+    setUp(() {
+      terminal = Terminal(cols: 80, rows: 24);
+    });
+
+    tearDown(() {
+      terminal.dispose();
+    });
+
+    group('fromRefs', () {
+      test('preserves endpoint refs', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(terminal, col: 2, row: 0);
+
+        final selection = Selection.fromRefs(start: start, end: end);
+
+        expect(selection.start, start);
+        expect(selection.end, end);
+      });
+
+      test('preserves rectangle mode', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(terminal, col: 2, row: 0);
+
+        final selection = Selection.fromRefs(
+          start: start,
+          end: end,
+          rectangle: true,
+        );
+
+        expect(selection.rectangle, isTrue);
+      });
+
+      test('rejects refs from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(other, col: 0, row: 0);
+
+        expect(
+          () => Selection.fromRefs(start: start, end: end),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('contains', () {
+      test('reports included points', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final contains = selection.contains(col: 1, row: 0);
+
+        expect(contains, isTrue);
+      });
+
+      test('reports excluded points', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final contains = selection.contains(col: 4, row: 0);
+
+        expect(contains, isFalse);
+      });
+    });
+
+    group('adjust', () {
+      test('moves the logical end endpoint', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 1, row: 0),
+        );
+
+        final adjusted = selection.adjust(.right);
+
+        expect(adjusted.format(), 'ABC');
+      });
+    });
+
+    group('ordered', () {
+      test('returns requested endpoint order', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 2, row: 0),
+          end: GridRef.at(terminal, col: 0, row: 0),
+        );
+
+        final ordered = selection.ordered(.forward);
+
+        expect(ordered.order, SelectionOrder.forward);
+      });
+    });
+
+    group('equal', () {
+      test('compares selections through libghostty', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        final other = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final equal = selection.equal(other);
+
+        expect(equal, isTrue);
+      });
+
+      test('rejects selections from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        final otherSelection = Selection.fromRefs(
+          start: GridRef.at(other, col: 0, row: 0),
+          end: GridRef.at(other, col: 2, row: 0),
+        );
+
+        expect(
+          () => selection.equal(otherSelection),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('format', () {
+      test('returns selected content', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 1, row: 0),
+          end: GridRef.at(terminal, col: 3, row: 0),
+        );
+
+        final text = selection.format();
+
+        expect(text, 'BCD');
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -764,17 +764,166 @@ void main() {
         final formatter = Formatter(
           terminal: terminal,
           format: .plain,
-          selection: const Selection(
-            startCol: 0,
-            startRow: 0,
-            endCol: 2,
-            endRow: 0,
+          selection: Selection.fromRefs(
+            start: GridRef.at(terminal, col: 0, row: 0),
+            end: GridRef.at(terminal, col: 2, row: 0),
           ),
         );
         addTearDown(formatter.dispose);
         final text = formatter.format();
         expect(text, contains('ABC'));
         expect(text, isNot(contains('FGHIJ')));
+      });
+    });
+
+    group('formatSelection', () {
+      test('returns null without an active selection', () {
+        final text = terminal.formatSelection();
+
+        expect(text, isNull);
+      });
+
+      test('formats an explicit selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 1, row: 0),
+          end: GridRef.at(terminal, col: 3, row: 0),
+        );
+
+        final text = terminal.formatSelection(selection: selection);
+
+        expect(text, 'BCD');
+      });
+    });
+
+    group('selectAll', () {
+      test('selects all screen content', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+
+        final selection = terminal.selectAll();
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'ABC\nDEF',
+        );
+      });
+    });
+
+    group('selectLine', () {
+      test('selects the line under a ref', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+        final ref = GridRef.at(terminal, col: 1, row: 1);
+
+        final selection = terminal.selectLine(ref);
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'DEF',
+        );
+      });
+    });
+
+    group('selectOutput', () {
+      test('selects command output under a ref', () {
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b]133;A\x07\$ \x1b]133;B\x07ls\r\n'
+                    '\x1b]133;C\x07ABC\r\nDEF\x1b]133;D\x07'
+                .codeUnits,
+          ),
+        );
+        final ref = GridRef.at(terminal, col: 1, row: 1);
+
+        final selection = terminal.selectOutput(ref);
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'ABC\nDEF',
+        );
+      });
+    });
+
+    group('selectWord', () {
+      test('returns the selected word', () {
+        terminal.write(Uint8List.fromList('hello world'.codeUnits));
+        final ref = GridRef.at(terminal, col: 1, row: 0);
+
+        final selection = terminal.selectWord(ref);
+
+        expect(terminal.formatSelection(selection: selection), 'hello');
+      });
+
+      test('rejects refs from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final ref = GridRef.at(other, col: 0, row: 0);
+
+        expect(() => terminal.selectWord(ref), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('selectWordBetween', () {
+      test('selects the word between two refs', () {
+        terminal.write(Uint8List.fromList('hello world'.codeUnits));
+        final start = GridRef.at(terminal, col: 1, row: 0);
+        final end = GridRef.at(terminal, col: 3, row: 0);
+
+        final selection = terminal.selectWordBetween(start, end);
+
+        expect(terminal.formatSelection(selection: selection), 'hello');
+      });
+    });
+
+    group('selection', () {
+      test('setter installs active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        terminal.selection = selection;
+
+        expect(terminal.formatSelection(), 'ABC');
+      });
+
+      test('getter returns active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        terminal.selection = selection;
+
+        final active = terminal.selection;
+
+        expect(active?.equal(selection), isTrue);
+      });
+
+      test('setter clears active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        terminal.selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        terminal.selection = null;
+
+        expect(terminal.selection, isNull);
+      });
+
+      test('setter rejects selections from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final selection = Selection.fromRefs(
+          start: GridRef.at(other, col: 0, row: 0),
+          end: GridRef.at(other, col: 2, row: 0),
+        );
+
+        expect(
+          () => terminal.selection = selection,
+          throwsA(isA<ArgumentError>()),
+        );
       });
     });
 

--- a/packages/libghostty/test/wasm/terminal/selection_gesture_test.dart
+++ b/packages/libghostty/test/wasm/terminal/selection_gesture_test.dart
@@ -1,0 +1,170 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:test/test.dart';
+
+import '../helpers/setup.dart';
+
+void main() {
+  setUpAll(setUpWasm);
+
+  group('SelectionGesture', () {
+    late Terminal terminal;
+
+    setUp(() {
+      terminal = Terminal(cols: 80, rows: 24);
+    });
+
+    tearDown(() {
+      terminal.dispose();
+    });
+
+    group('apply', () {
+      test('drag produces a selection snapshot', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        final drag = SelectionGestureEvent.drag();
+        addTearDown(drag.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        drag.setRef(GridRef.at(terminal, col: 2, row: 0));
+        drag.setGeometry(
+          const SelectionGestureGeometry(
+            columns: 80,
+            cellWidth: 8,
+            paddingLeft: 0,
+            screenHeight: 24,
+          ),
+        );
+        gesture.apply(press);
+
+        final selection = gesture.apply(drag);
+
+        expect(terminal.formatSelection(selection: selection), 'AB');
+      });
+    });
+
+    group('state', () {
+      test('reports click count after press', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+
+        gesture.apply(press);
+
+        expect(gesture.state.clickCount, 1);
+      });
+
+      test('reports custom press behavior', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        press.setBehaviors(
+          const SelectionGestureBehaviors(
+            singleClick: .line,
+            doubleClick: .word,
+            tripleClick: .cell,
+          ),
+        );
+
+        gesture.apply(press);
+
+        expect(gesture.state.behavior, SelectionGestureBehavior.line);
+      });
+    });
+
+    group('reset', () {
+      test('clears click count', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        gesture.apply(press);
+
+        gesture.reset();
+
+        expect(gesture.state.clickCount, 0);
+      });
+    });
+
+    group('dispose', () {
+      test('succeeds while terminal is alive', () {
+        final gesture = SelectionGesture(terminal);
+
+        expect(gesture.dispose, returnsNormally);
+      });
+
+      test('succeeds after terminal disposal', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        gesture.apply(press);
+
+        terminal.dispose();
+
+        expect(gesture.dispose, returnsNormally);
+      });
+    });
+
+    group('SelectionGestureEvent', () {
+      test('press applies with optional click metadata', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        press.setPosition(4, 8);
+        press.setRepeatDistance(12);
+        press.setRepeatIntervalNs(500);
+        press.setTimeNs(1);
+        press.setWordBoundaryCodepoints('_'.codeUnits);
+
+        gesture.apply(press);
+
+        expect(gesture.state.clickCount, 1);
+      });
+
+      test('drag can produce a rectangular selection', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+        final gesture = SelectionGesture(terminal);
+        addTearDown(gesture.dispose);
+        final press = SelectionGestureEvent.press();
+        addTearDown(press.dispose);
+        final drag = SelectionGestureEvent.drag();
+        addTearDown(drag.dispose);
+        press.setRef(GridRef.at(terminal, col: 0, row: 0));
+        drag.setRef(GridRef.at(terminal, col: 2, row: 1));
+        drag.setRectangle(value: true);
+        drag.setGeometry(
+          const SelectionGestureGeometry(
+            columns: 80,
+            cellWidth: 8,
+            paddingLeft: 0,
+            screenHeight: 24,
+          ),
+        );
+        gesture.apply(press);
+
+        final selection = gesture.apply(drag);
+
+        expect(selection?.rectangle, isTrue);
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/wasm/terminal/selection_test.dart
+++ b/packages/libghostty/test/wasm/terminal/selection_test.dart
@@ -1,0 +1,168 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:test/test.dart';
+
+import '../helpers/setup.dart';
+
+void main() {
+  setUpAll(setUpWasm);
+
+  group('Selection', () {
+    late Terminal terminal;
+
+    setUp(() {
+      terminal = Terminal(cols: 80, rows: 24);
+    });
+
+    tearDown(() {
+      terminal.dispose();
+    });
+
+    group('fromRefs', () {
+      test('preserves endpoint refs', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(terminal, col: 2, row: 0);
+
+        final selection = Selection.fromRefs(start: start, end: end);
+
+        expect(selection.start, start);
+        expect(selection.end, end);
+      });
+
+      test('preserves rectangle mode', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(terminal, col: 2, row: 0);
+
+        final selection = Selection.fromRefs(
+          start: start,
+          end: end,
+          rectangle: true,
+        );
+
+        expect(selection.rectangle, isTrue);
+      });
+
+      test('rejects refs from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final start = GridRef.at(terminal, col: 0, row: 0);
+        final end = GridRef.at(other, col: 0, row: 0);
+
+        expect(
+          () => Selection.fromRefs(start: start, end: end),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('contains', () {
+      test('reports included points', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final contains = selection.contains(col: 1, row: 0);
+
+        expect(contains, isTrue);
+      });
+
+      test('reports excluded points', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final contains = selection.contains(col: 4, row: 0);
+
+        expect(contains, isFalse);
+      });
+    });
+
+    group('adjust', () {
+      test('moves the logical end endpoint', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 1, row: 0),
+        );
+
+        final adjusted = selection.adjust(.right);
+
+        expect(adjusted.format(), 'ABC');
+      });
+    });
+
+    group('ordered', () {
+      test('returns requested endpoint order', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 2, row: 0),
+          end: GridRef.at(terminal, col: 0, row: 0),
+        );
+
+        final ordered = selection.ordered(.forward);
+
+        expect(ordered.order, SelectionOrder.forward);
+      });
+    });
+
+    group('equal', () {
+      test('compares selections through libghostty', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        final other = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        final equal = selection.equal(other);
+
+        expect(equal, isTrue);
+      });
+
+      test('rejects selections from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        final otherSelection = Selection.fromRefs(
+          start: GridRef.at(other, col: 0, row: 0),
+          end: GridRef.at(other, col: 2, row: 0),
+        );
+
+        expect(
+          () => selection.equal(otherSelection),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('format', () {
+      test('returns selected content', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 1, row: 0),
+          end: GridRef.at(terminal, col: 3, row: 0),
+        );
+
+        final text = selection.format();
+
+        expect(text, 'BCD');
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/wasm/terminal/terminal_test.dart
+++ b/packages/libghostty/test/wasm/terminal/terminal_test.dart
@@ -748,6 +748,186 @@ void main() {
       });
     });
 
+    group('Formatter', () {
+      test('plain format returns screen content', () {
+        terminal.write(Uint8List.fromList('Hello'.codeUnits));
+        final formatter = Formatter(
+          terminal: terminal,
+          format: .plain,
+          trim: true,
+        );
+        addTearDown(formatter.dispose);
+        expect(formatter.format(), contains('Hello'));
+      });
+
+      test('selection restricts output to the given range', () {
+        terminal.write(Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits));
+        final formatter = Formatter(
+          terminal: terminal,
+          format: .plain,
+          selection: Selection.fromRefs(
+            start: GridRef.at(terminal, col: 0, row: 0),
+            end: GridRef.at(terminal, col: 2, row: 0),
+          ),
+        );
+        addTearDown(formatter.dispose);
+        final text = formatter.format();
+        expect(text, contains('ABC'));
+        expect(text, isNot(contains('FGHIJ')));
+      });
+    });
+
+    group('formatSelection', () {
+      test('returns null without an active selection', () {
+        final text = terminal.formatSelection();
+
+        expect(text, isNull);
+      });
+
+      test('formats an explicit selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 1, row: 0),
+          end: GridRef.at(terminal, col: 3, row: 0),
+        );
+
+        final text = terminal.formatSelection(selection: selection);
+
+        expect(text, 'BCD');
+      });
+    });
+
+    group('selectAll', () {
+      test('selects all screen content', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+
+        final selection = terminal.selectAll();
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'ABC\nDEF',
+        );
+      });
+    });
+
+    group('selectLine', () {
+      test('selects the line under a ref', () {
+        terminal.write(Uint8List.fromList('ABC\r\nDEF'.codeUnits));
+        final ref = GridRef.at(terminal, col: 1, row: 1);
+
+        final selection = terminal.selectLine(ref);
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'DEF',
+        );
+      });
+    });
+
+    group('selectOutput', () {
+      test('selects command output under a ref', () {
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b]133;A\x07\$ \x1b]133;B\x07ls\r\n'
+                    '\x1b]133;C\x07ABC\r\nDEF\x1b]133;D\x07'
+                .codeUnits,
+          ),
+        );
+        final ref = GridRef.at(terminal, col: 1, row: 1);
+
+        final selection = terminal.selectOutput(ref);
+
+        expect(
+          terminal.formatSelection(selection: selection, trim: true),
+          'ABC\nDEF',
+        );
+      });
+    });
+
+    group('selectWord', () {
+      test('returns the selected word', () {
+        terminal.write(Uint8List.fromList('hello world'.codeUnits));
+        final ref = GridRef.at(terminal, col: 1, row: 0);
+
+        final selection = terminal.selectWord(ref);
+
+        expect(terminal.formatSelection(selection: selection), 'hello');
+      });
+
+      test('rejects refs from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final ref = GridRef.at(other, col: 0, row: 0);
+
+        expect(() => terminal.selectWord(ref), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('selectWordBetween', () {
+      test('selects the word between two refs', () {
+        terminal.write(Uint8List.fromList('hello world'.codeUnits));
+        final start = GridRef.at(terminal, col: 1, row: 0);
+        final end = GridRef.at(terminal, col: 3, row: 0);
+
+        final selection = terminal.selectWordBetween(start, end);
+
+        expect(terminal.formatSelection(selection: selection), 'hello');
+      });
+    });
+
+    group('selection', () {
+      test('setter installs active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        terminal.selection = selection;
+
+        expect(terminal.formatSelection(), 'ABC');
+      });
+
+      test('getter returns active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        final selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+        terminal.selection = selection;
+
+        final active = terminal.selection;
+
+        expect(active?.equal(selection), isTrue);
+      });
+
+      test('setter clears active selection', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        terminal.selection = Selection.fromRefs(
+          start: GridRef.at(terminal, col: 0, row: 0),
+          end: GridRef.at(terminal, col: 2, row: 0),
+        );
+
+        terminal.selection = null;
+
+        expect(terminal.selection, isNull);
+      });
+
+      test('setter rejects selections from another terminal', () {
+        final other = Terminal(cols: 80, rows: 24);
+        addTearDown(other.dispose);
+        final selection = Selection.fromRefs(
+          start: GridRef.at(other, col: 0, row: 0),
+          end: GridRef.at(other, col: 2, row: 0),
+        );
+
+        expect(
+          () => terminal.selection = selection,
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
     group('CellIterator.select', () {
       test('reads specific column content', () {
         terminal.write(Uint8List.fromList('ABCDE'.codeUnits));


### PR DESCRIPTION
Expose libghostty selection APIs for active selection snapshots, selection formatting, word, line, output, and select-all helpers, and gesture-driven selection state while updating flterm selection formatting to use grid-reference endpoints.