### PR TITLE
feat(libghostty): expose render selection data

### DIFF
--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -86,6 +86,7 @@ export 'src/impl/terminal/terminal.dart'
         RenderInfo,
         RenderState,
         RowIterator,
+        RowSelectionRange,
         Selection,
         SelectionGesture,
         SelectionGestureBehaviors,

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -257,6 +257,7 @@ abstract interface class GhosttyBindings {
   CResult<bool> rowIteratorGetDirty(int iterator);
   Result rowIteratorSetDirty(int iterator, {required bool dirty});
   CResult<int> rowIteratorGetRawRow(int iterator);
+  CResult<({int startCol, int endCol})> rowIteratorGetSelection(int iterator);
 
   CResult<int> rowCellsNew();
   void rowCellsFree(int handle);
@@ -271,6 +272,7 @@ abstract interface class GhosttyBindings {
   CResult<List<int>> rowCellsGetGraphemes(int cells, int len);
   CResult<String> rowCellsGetGraphemesUtf8(int cells);
   CResult<bool> rowCellsGetHasStyling(int cells);
+  CResult<bool> rowCellsGetSelected(int cells);
   CResult<RgbColor> rowCellsGetBgColor(int cells);
   CResult<RgbColor> rowCellsGetFgColor(int cells);
   CResult<int> rowCellsGetBgColorArgb(int cells);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -1159,6 +1159,26 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<({int startCol, int endCol})> rowIteratorGetSelection(int iterator) {
+    return using((arena) {
+      final selection = arena<RenderStateRowSelection>();
+      selection.ref
+        ..size = sizeOf<RenderStateRowSelection>()
+        ..start_x = 0
+        ..end_x = 0;
+      final result = ghostty_render_state_row_get(
+        Pointer.fromAddress(iterator),
+        RenderStateRowData.selection,
+        selection.cast(),
+      );
+      return (
+        result,
+        (startCol: selection.ref.start_x, endCol: selection.ref.end_x),
+      );
+    });
+  }
+
+  @override
   CResult<int> rowCellsNew() {
     return using((arena) {
       final ptr = arena<Pointer<RenderStateRowCellsImpl>>();
@@ -1280,6 +1300,16 @@ class NativeBindings implements GhosttyBindings {
     final result = ghostty_render_state_row_cells_get(
       Pointer.fromAddress(cells),
       RenderStateRowCellsData.hasStyling,
+      _outBool.cast(),
+    );
+    return (result, _outBool.value);
+  }
+
+  @override
+  CResult<bool> rowCellsGetSelected(int cells) {
+    final result = ghostty_render_state_row_cells_get(
+      Pointer.fromAddress(cells),
+      RenderStateRowCellsData.selected,
       _outBool.cast(),
     );
     return (result, _outBool.value);

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -159,6 +159,11 @@ class Layouts {
   late final int colorsCursorHasValue;
   late final int colorsPalette;
 
+  // GhosttyRenderStateRowSelection
+  late final int renderRowSelectionSize;
+  late final int renderRowSelectionStartX;
+  late final int renderRowSelectionEndX;
+
   // GhosttySizeReportSize
   late final int sizeReportSize;
   late final int sizeReportColumns;
@@ -376,6 +381,18 @@ class Layouts {
     colorsCursor = struct['cursor'];
     colorsCursorHasValue = struct['cursor_has_value'];
     colorsPalette = struct['palette'];
+
+    final renderRowSelection = types['GhosttyRenderStateRowSelection'];
+    if (renderRowSelection == null) {
+      renderRowSelectionSize = 8;
+      renderRowSelectionStartX = 4;
+      renderRowSelectionEndX = 6;
+    } else {
+      struct = _Struct(types, 'GhosttyRenderStateRowSelection');
+      renderRowSelectionSize = struct.size;
+      renderRowSelectionStartX = struct['start_x'];
+      renderRowSelectionEndX = struct['end_x'];
+    }
 
     struct = _Struct(types, 'GhosttySizeReportSize');
     sizeReportSize = struct.size;

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -1911,6 +1911,27 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<({int startCol, int endCol})> rowIteratorGetSelection(int iterator) {
+    final size = _layout.renderRowSelectionSize;
+    final outPtr = _exports.ghostty_wasm_alloc_u8_array(size);
+    _zero(outPtr, size);
+    _mem.writeU32(outPtr, size);
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_get(
+        iterator,
+        RenderStateRowData.selection.value,
+        outPtr,
+      ),
+    );
+    final value = (
+      startCol: _mem.readU16(outPtr + _layout.renderRowSelectionStartX),
+      endCol: _mem.readU16(outPtr + _layout.renderRowSelectionEndX),
+    );
+    _exports.ghostty_wasm_free_u8_array(outPtr, size);
+    return (result, value);
+  }
+
+  @override
   CResult<int> rowCellsNew() {
     final outPtr = _exports.ghostty_wasm_alloc_opaque();
     final result = Result.fromValue(
@@ -2068,6 +2089,21 @@ class WasmBindings implements GhosttyBindings {
       _exports.ghostty_render_state_row_cells_get(
         cells,
         RenderStateRowCellsData.hasStyling.value,
+        outPtr,
+      ),
+    );
+    final value = _mem.readU8(outPtr) != 0;
+    _exports.ghostty_wasm_free_u8(outPtr);
+    return (result, value);
+  }
+
+  @override
+  CResult<bool> rowCellsGetSelected(int cells) {
+    final outPtr = _exports.ghostty_wasm_alloc_u8();
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_cells_get(
+        cells,
+        RenderStateRowCellsData.selected.value,
         outPtr,
       ),
     );

--- a/packages/libghostty/lib/src/impl/terminal/cell_iterator.dart
+++ b/packages/libghostty/lib/src/impl/terminal/cell_iterator.dart
@@ -109,6 +109,13 @@ final class CellIterator {
   /// Whether the current cell is protected (DECSCA).
   bool get isProtected => check(bindings.cellGetProtected(_rawCell));
 
+  /// Whether the current cell is contained withing the current selection.
+  ///
+  /// Returns true when the cell's column is within the current row's
+  /// row-local selection range, and false otherwise. Rendering colors,
+  /// inversion, etc are caller policy.
+  bool get isSelected => check(bindings.rowCellsGetSelected(_handle));
+
   /// Semantic content type of the current cell.
   SemanticContent get semanticContent {
     return check(bindings.cellGetSemanticContent(_rawCell));

--- a/packages/libghostty/lib/src/impl/terminal/row_iterator.dart
+++ b/packages/libghostty/lib/src/impl/terminal/row_iterator.dart
@@ -1,5 +1,11 @@
 part of 'terminal.dart';
 
+/// Row-local selected column range in a [RenderState] snapshot.
+///
+/// Both columns are inclusive. [RowIterator.selection] returns null when the
+/// current row does not intersect the selection captured by the render state.
+typedef RowSelectionRange = ({int startCol, int endCol});
+
 /// Reusable iterator over the rows of a [RenderState] snapshot.
 ///
 /// Allocate once and reuse across frames. Advance with [next] and read the
@@ -61,6 +67,16 @@ final class RowIterator {
   ///
   /// Undefined before the first successful [next] call.
   int get index => _index;
+
+  /// Selected column range for the current row, or null when the row does
+  /// not intersect the selection captured by the render state.
+  ///
+  /// The returned columns are row-local and inclusive.
+  RowSelectionRange? get selection {
+    final (code, selection) = bindings.rowIteratorGetSelection(_handle);
+    if (code == .noValue) return null;
+    return check((code, selection));
+  }
 
   /// Semantic prompt state of the current row.
   SemanticPrompt get semanticPrompt {

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -608,7 +608,57 @@ void main() {
     });
   });
 
+  group('row iterator data', () {
+    group('rowIteratorGetSelection', () {
+      test('returns noValue for an unselected row', () {
+        final iterator = _selectedRowIterator(0);
+
+        final (code, _) = bindings.rowIteratorGetSelection(iterator);
+
+        expect(code, Result.noValue);
+      });
+
+      test('returns selected columns for a selected row', () {
+        final iterator = _selectedRowIterator(1);
+
+        final (code, selection) = bindings.rowIteratorGetSelection(iterator);
+
+        expect(code, Result.success);
+        expect(selection, (startCol: 1, endCol: 3));
+      });
+    });
+  });
+
   group('row cells data', () {
+    group('rowCellsGetSelected', () {
+      test('returns true for a selected cell', () {
+        final cells = _selectedRowCells(2);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isTrue);
+      });
+
+      test('returns true for the selected end column', () {
+        final cells = _selectedRowCells(3);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isTrue);
+      });
+
+      test('returns false for an unselected cell', () {
+        final cells = _selectedRowCells(4);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isFalse);
+      });
+    });
+
     group('rowCellsGetGraphemesUtf8', () {
       test('returns current cell content', () {
         final cells = _firstCellCells('\u00E9');
@@ -860,5 +910,64 @@ int _firstCellCells(String text) {
   expect(bindings.rowIteratorNext(rowIter), isTrue);
   checkCode(bindings.rowCellsInit(rowCells, rowIter));
   expect(bindings.rowCellsNext(rowCells), isTrue);
+  return rowCells;
+}
+
+int _selectedRowIterator(int row) {
+  final (_, terminal) = bindings.terminalNew(10, 3, 0);
+  final (_, renderState) = bindings.renderStateNew();
+  final (_, rowIter) = bindings.rowIteratorNew();
+  addTearDown(() => bindings.rowIteratorFree(rowIter));
+  addTearDown(() => bindings.renderStateFree(renderState));
+  addTearDown(() => bindings.terminalFree(terminal));
+  bindings.terminalVtWrite(
+    terminal,
+    Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+  );
+  final (_, start) = bindings.terminalGridRef(terminal, .active, 1, 1);
+  final (_, end) = bindings.terminalGridRef(terminal, .active, 3, 1);
+  checkCode(
+    bindings.terminalSetSelection(terminal, (
+      start: start,
+      end: end,
+      rectangle: false,
+    )),
+  );
+  checkCode(bindings.renderStateUpdate(renderState, terminal));
+  checkCode(bindings.rowIteratorInit(rowIter, renderState));
+  for (var i = 0; i <= row; i++) {
+    expect(bindings.rowIteratorNext(rowIter), isTrue);
+  }
+  return rowIter;
+}
+
+int _selectedRowCells(int col) {
+  final (_, terminal) = bindings.terminalNew(10, 3, 0);
+  final (_, renderState) = bindings.renderStateNew();
+  final (_, rowIter) = bindings.rowIteratorNew();
+  final (_, rowCells) = bindings.rowCellsNew();
+  addTearDown(() => bindings.rowCellsFree(rowCells));
+  addTearDown(() => bindings.rowIteratorFree(rowIter));
+  addTearDown(() => bindings.renderStateFree(renderState));
+  addTearDown(() => bindings.terminalFree(terminal));
+  bindings.terminalVtWrite(
+    terminal,
+    Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+  );
+  final (_, start) = bindings.terminalGridRef(terminal, .active, 1, 1);
+  final (_, end) = bindings.terminalGridRef(terminal, .active, 3, 1);
+  checkCode(
+    bindings.terminalSetSelection(terminal, (
+      start: start,
+      end: end,
+      rectangle: false,
+    )),
+  );
+  checkCode(bindings.renderStateUpdate(renderState, terminal));
+  checkCode(bindings.rowIteratorInit(rowIter, renderState));
+  expect(bindings.rowIteratorNext(rowIter), isTrue);
+  expect(bindings.rowIteratorNext(rowIter), isTrue);
+  checkCode(bindings.rowCellsInit(rowCells, rowIter));
+  checkCode(bindings.rowCellsSelect(rowCells, col));
   return rowCells;
 }

--- a/packages/libghostty/test/impl/terminal/cell_iterator_test.dart
+++ b/packages/libghostty/test/impl/terminal/cell_iterator_test.dart
@@ -1,0 +1,192 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:libghostty/libghostty.dart'
+    show
+        CellIterator,
+        GridRef,
+        RenderState,
+        RowIterator,
+        Selection,
+        SemanticContent,
+        Terminal;
+import 'package:test/test.dart';
+
+void main() {
+  group('CellIterator', () {
+    late Terminal terminal;
+    late RenderState renderState;
+    late RowIterator rows;
+    late CellIterator cells;
+
+    setUp(() {
+      terminal = Terminal(cols: 10, rows: 3);
+      renderState = RenderState();
+      rows = RowIterator();
+      cells = CellIterator();
+    });
+
+    tearDown(() {
+      cells.dispose();
+      rows.dispose();
+      renderState.dispose();
+      terminal.dispose();
+    });
+
+    void installSelection() {
+      terminal.selection = Selection.fromRefs(
+        start: GridRef.at(terminal, col: 1, row: 1),
+        end: GridRef.at(terminal, col: 3, row: 1),
+      );
+    }
+
+    void bindSelectedRow() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+      expect(rows.next(), isTrue);
+      expect(rows.next(), isTrue);
+      cells.reset(rows);
+    }
+
+    void bindFirstCell() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+      rows.next();
+      cells.reset(rows);
+      cells.next();
+    }
+
+    group('isSelected', () {
+      test('returns true for a selected cell', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(2);
+
+        final result = cells.isSelected;
+
+        expect(result, isTrue);
+      });
+
+      test('returns true for the selected end column', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(3);
+
+        final result = cells.isSelected;
+
+        expect(result, isTrue);
+      });
+
+      test('returns false for an unselected cell', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(4);
+
+        final result = cells.isSelected;
+
+        expect(result, isFalse);
+      });
+    });
+
+    group('properties', () {
+      test('returns default cell properties', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+
+        expect(cells.style.bold, isFalse);
+        expect(cells.isProtected, isFalse);
+        expect(cells.semanticContent, SemanticContent.output);
+        expect(cells.backgroundArgb, isNull);
+        expect(cells.foregroundArgb, isNull);
+      });
+
+      test('reports styled cells', () {
+        terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.hasStyling;
+
+        expect(result, isTrue);
+      });
+
+      test('returns primary codepoint', () {
+        terminal.write(Uint8List.fromList('Z'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.codepoint;
+
+        expect(result, 0x5A);
+      });
+
+      test('returns zero codepoint for an empty cell', () {
+        terminal.write(Uint8List.fromList('Z'.codeUnits));
+        bindFirstCell();
+        cells.next();
+
+        final result = cells.codepoint;
+
+        expect(result, 0);
+      });
+
+      test('tracks column position', () {
+        terminal.write(Uint8List.fromList('ABC'.codeUnits));
+        bindFirstCell();
+        final first = cells.col;
+        cells.next();
+
+        final second = cells.col;
+
+        expect(first, 0);
+        expect(second, 1);
+      });
+
+      test('returns grapheme length for text', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.graphemeLength;
+
+        expect(result, 1);
+      });
+
+      test('returns zero grapheme length for an empty cell', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+        cells.next();
+
+        final result = cells.graphemeLength;
+
+        expect(result, 0);
+      });
+
+      test('returns packed ARGB colors', () {
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b[48;2;255;128;0m\x1b[38;2;0;255;64mY'.codeUnits,
+          ),
+        );
+        bindFirstCell();
+
+        expect(cells.backgroundArgb, 0xFFFF8000);
+        expect(cells.foregroundArgb, 0xFF00FF40);
+      });
+    });
+
+    group('select', () {
+      test('reads specific column content', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+        cells.reset(rows);
+
+        cells.select(2);
+        final result = cells.content;
+
+        expect(result, 'C');
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/impl/terminal/row_iterator_test.dart
+++ b/packages/libghostty/test/impl/terminal/row_iterator_test.dart
@@ -1,0 +1,127 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:libghostty/libghostty.dart'
+    show GridRef, RenderState, RowIterator, Selection, SemanticPrompt, Terminal;
+import 'package:test/test.dart';
+
+void main() {
+  group('RowIterator', () {
+    late Terminal terminal;
+    late RenderState renderState;
+    late RowIterator rows;
+
+    setUp(() {
+      terminal = Terminal(cols: 10, rows: 3);
+      renderState = RenderState();
+      rows = RowIterator();
+    });
+
+    tearDown(() {
+      rows.dispose();
+      renderState.dispose();
+      terminal.dispose();
+    });
+
+    group('properties', () {
+      test('returns content flags for an empty row', () {
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+
+        expect(rows.hasGrapheme, isFalse);
+        expect(rows.hasStyled, isFalse);
+        expect(rows.hasHyperlink, isFalse);
+        expect(rows.hasKittyVirtualPlaceholder, isFalse);
+        expect(rows.semanticPrompt, SemanticPrompt.none);
+      });
+
+      test('reports styled rows', () {
+        terminal.write(Uint8List.fromList('\x1b[1mBold'.codeUnits));
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+
+        final result = rows.hasStyled;
+
+        expect(result, isTrue);
+      });
+
+      test('tracks row position', () {
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+        final first = rows.index;
+        rows.next();
+
+        final second = rows.index;
+
+        expect(first, 0);
+        expect(second, 1);
+      });
+    });
+
+    void installSelection() {
+      terminal.selection = Selection.fromRefs(
+        start: GridRef.at(terminal, col: 1, row: 1),
+        end: GridRef.at(terminal, col: 3, row: 1),
+      );
+    }
+
+    void bindRows() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+    }
+
+    void moveToRow(int row) {
+      for (var i = 0; i <= row; i++) {
+        expect(rows.next(), isTrue);
+      }
+    }
+
+    int rowCount() {
+      var count = 0;
+      rows.reset(renderState);
+      while (rows.next()) {
+        count++;
+      }
+      return count;
+    }
+
+    group('selection', () {
+      test('returns null for an unselected row', () {
+        installSelection();
+        bindRows();
+        moveToRow(0);
+
+        final result = rows.selection;
+
+        expect(result, isNull);
+      });
+
+      test('returns row-local selected columns', () {
+        installSelection();
+        bindRows();
+        moveToRow(1);
+
+        final result = rows.selection;
+
+        expect(result, (startCol: 1, endCol: 3));
+      });
+    });
+
+    group('reset', () {
+      test('rewinds iteration', () {
+        terminal.write(Uint8List.fromList('Hello'.codeUnits));
+        renderState.update(terminal);
+        final first = rowCount();
+
+        final second = rowCount();
+
+        expect(second, first);
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -14,17 +14,14 @@ void main() {
     late Terminal terminal;
     late RenderState renderState;
     late RowIterator rows;
-    late CellIterator cells;
 
     setUp(() {
       terminal = Terminal(cols: 80, rows: 24);
       renderState = RenderState();
       rows = RowIterator();
-      cells = CellIterator();
     });
 
     tearDown(() {
-      cells.dispose();
       rows.dispose();
       renderState.dispose();
       terminal.dispose();
@@ -644,101 +641,6 @@ void main() {
       });
     });
 
-    group('RowIterator', () {
-      group('properties', () {
-        test('empty row has no content flags', () {
-          renderState.update(terminal);
-          rows.reset(renderState);
-          rows.next();
-          expect(rows.hasGrapheme, isFalse);
-          expect(rows.hasStyled, isFalse);
-          expect(rows.hasHyperlink, isFalse);
-          expect(rows.hasKittyVirtualPlaceholder, isFalse);
-          expect(rows.semanticPrompt, SemanticPrompt.none);
-        });
-
-        test('styled row reports hasStyled', () {
-          terminal.write(Uint8List.fromList('\x1b[1mBold'.codeUnits));
-          renderState.update(terminal);
-          rows.reset(renderState);
-          rows.next();
-          expect(rows.hasStyled, isTrue);
-        });
-
-        test('index tracks row position', () {
-          renderState.update(terminal);
-          rows.reset(renderState);
-          rows.next();
-          expect(rows.index, 0);
-          rows.next();
-          expect(rows.index, 1);
-        });
-      });
-    });
-
-    group('CellIterator', () {
-      void advanceToFirstCell() {
-        renderState.update(terminal);
-        rows.reset(renderState);
-        rows.next();
-        cells.reset(rows);
-        cells.next();
-      }
-
-      group('properties', () {
-        test('default cell has no styling, protection, or special content', () {
-          terminal.write(Uint8List.fromList('A'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.style.bold, isFalse);
-          expect(cells.isProtected, isFalse);
-          expect(cells.semanticContent, SemanticContent.output);
-          expect(cells.backgroundArgb, isNull);
-          expect(cells.foregroundArgb, isNull);
-        });
-
-        test('styled cell reports hasStyling', () {
-          terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.hasStyling, isTrue);
-        });
-
-        test('codepoint returns value for text and 0 for empty cell', () {
-          terminal.write(Uint8List.fromList('Z'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.codepoint, 0x5A);
-
-          cells.next();
-          expect(cells.codepoint, 0);
-        });
-
-        test('col tracks column position', () {
-          terminal.write(Uint8List.fromList('ABC'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.col, 0);
-          cells.next();
-          expect(cells.col, 1);
-        });
-
-        test('graphemeLength is 1 for single codepoint and 0 for empty', () {
-          terminal.write(Uint8List.fromList('A'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.graphemeLength, 1);
-
-          cells.next();
-          expect(cells.graphemeLength, 0);
-        });
-
-        test('color ARGB returns packed values for RGB colors', () {
-          terminal.write(
-            .fromList('\x1b[48;2;255;128;0m\x1b[38;2;0;255;64mY'.codeUnits),
-          );
-          advanceToFirstCell();
-          expect(cells.backgroundArgb, 0xFFFF8000);
-          expect(cells.foregroundArgb, 0xFF00FF40);
-        });
-      });
-    });
-
     group('Cursor properties', () {
       test('cursor wideTail is false on normal position', () {
         renderState.update(terminal);
@@ -924,25 +826,6 @@ void main() {
           () => terminal.selection = selection,
           throwsA(isA<ArgumentError>()),
         );
-      });
-    });
-
-    group('CellIterator.select', () {
-      test('reads specific column content', () {
-        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
-        renderState.update(terminal);
-        rows.reset(renderState);
-        rows.next();
-        cells.reset(rows);
-
-        cells.select(2);
-        expect(cells.content, 'C');
-
-        cells.select(0);
-        expect(cells.content, 'A');
-
-        cells.select(4);
-        expect(cells.content, 'E');
       });
     });
   });

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -616,7 +616,57 @@ void main() {
     });
   });
 
+  group('row iterator data', () {
+    group('rowIteratorGetSelection', () {
+      test('returns noValue for an unselected row', () {
+        final iterator = _selectedRowIterator(0);
+
+        final (code, _) = bindings.rowIteratorGetSelection(iterator);
+
+        expect(code, Result.noValue);
+      });
+
+      test('returns selected columns for a selected row', () {
+        final iterator = _selectedRowIterator(1);
+
+        final (code, selection) = bindings.rowIteratorGetSelection(iterator);
+
+        expect(code, Result.success);
+        expect(selection, (startCol: 1, endCol: 3));
+      });
+    });
+  });
+
   group('row cells data', () {
+    group('rowCellsGetSelected', () {
+      test('returns true for a selected cell', () {
+        final cells = _selectedRowCells(2);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isTrue);
+      });
+
+      test('returns true for the selected end column', () {
+        final cells = _selectedRowCells(3);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isTrue);
+      });
+
+      test('returns false for an unselected cell', () {
+        final cells = _selectedRowCells(4);
+
+        final (code, selected) = bindings.rowCellsGetSelected(cells);
+
+        expect(code, Result.success);
+        expect(selected, isFalse);
+      });
+    });
+
     group('rowCellsGetGraphemesUtf8', () {
       test('returns current cell content', () {
         final cells = _firstCellCells('\u00E9');
@@ -868,5 +918,64 @@ int _firstCellCells(String text) {
   expect(bindings.rowIteratorNext(rowIter), isTrue);
   checkCode(bindings.rowCellsInit(rowCells, rowIter));
   expect(bindings.rowCellsNext(rowCells), isTrue);
+  return rowCells;
+}
+
+int _selectedRowIterator(int row) {
+  final (_, terminal) = bindings.terminalNew(10, 3, 0);
+  final (_, renderState) = bindings.renderStateNew();
+  final (_, rowIter) = bindings.rowIteratorNew();
+  addTearDown(() => bindings.rowIteratorFree(rowIter));
+  addTearDown(() => bindings.renderStateFree(renderState));
+  addTearDown(() => bindings.terminalFree(terminal));
+  bindings.terminalVtWrite(
+    terminal,
+    Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+  );
+  final (_, start) = bindings.terminalGridRef(terminal, .active, 1, 1);
+  final (_, end) = bindings.terminalGridRef(terminal, .active, 3, 1);
+  checkCode(
+    bindings.terminalSetSelection(terminal, (
+      start: start,
+      end: end,
+      rectangle: false,
+    )),
+  );
+  checkCode(bindings.renderStateUpdate(renderState, terminal));
+  checkCode(bindings.rowIteratorInit(rowIter, renderState));
+  for (var i = 0; i <= row; i++) {
+    expect(bindings.rowIteratorNext(rowIter), isTrue);
+  }
+  return rowIter;
+}
+
+int _selectedRowCells(int col) {
+  final (_, terminal) = bindings.terminalNew(10, 3, 0);
+  final (_, renderState) = bindings.renderStateNew();
+  final (_, rowIter) = bindings.rowIteratorNew();
+  final (_, rowCells) = bindings.rowCellsNew();
+  addTearDown(() => bindings.rowCellsFree(rowCells));
+  addTearDown(() => bindings.rowIteratorFree(rowIter));
+  addTearDown(() => bindings.renderStateFree(renderState));
+  addTearDown(() => bindings.terminalFree(terminal));
+  bindings.terminalVtWrite(
+    terminal,
+    Uint8List.fromList('ABCDE\r\nFGHIJ'.codeUnits),
+  );
+  final (_, start) = bindings.terminalGridRef(terminal, .active, 1, 1);
+  final (_, end) = bindings.terminalGridRef(terminal, .active, 3, 1);
+  checkCode(
+    bindings.terminalSetSelection(terminal, (
+      start: start,
+      end: end,
+      rectangle: false,
+    )),
+  );
+  checkCode(bindings.renderStateUpdate(renderState, terminal));
+  checkCode(bindings.rowIteratorInit(rowIter, renderState));
+  expect(bindings.rowIteratorNext(rowIter), isTrue);
+  expect(bindings.rowIteratorNext(rowIter), isTrue);
+  checkCode(bindings.rowCellsInit(rowCells, rowIter));
+  checkCode(bindings.rowCellsSelect(rowCells, col));
   return rowCells;
 }

--- a/packages/libghostty/test/wasm/impl/terminal/cell_iterator_test.dart
+++ b/packages/libghostty/test/wasm/impl/terminal/cell_iterator_test.dart
@@ -1,0 +1,196 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:libghostty/libghostty.dart'
+    show
+        CellIterator,
+        GridRef,
+        RenderState,
+        RowIterator,
+        Selection,
+        SemanticContent,
+        Terminal;
+import 'package:test/test.dart';
+
+import '../../helpers/setup.dart';
+
+void main() {
+  setUpAll(setUpWasm);
+
+  group('CellIterator', () {
+    late Terminal terminal;
+    late RenderState renderState;
+    late RowIterator rows;
+    late CellIterator cells;
+
+    setUp(() {
+      terminal = Terminal(cols: 10, rows: 3);
+      renderState = RenderState();
+      rows = RowIterator();
+      cells = CellIterator();
+    });
+
+    tearDown(() {
+      cells.dispose();
+      rows.dispose();
+      renderState.dispose();
+      terminal.dispose();
+    });
+
+    void installSelection() {
+      terminal.selection = Selection.fromRefs(
+        start: GridRef.at(terminal, col: 1, row: 1),
+        end: GridRef.at(terminal, col: 3, row: 1),
+      );
+    }
+
+    void bindSelectedRow() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+      expect(rows.next(), isTrue);
+      expect(rows.next(), isTrue);
+      cells.reset(rows);
+    }
+
+    void bindFirstCell() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+      rows.next();
+      cells.reset(rows);
+      cells.next();
+    }
+
+    group('isSelected', () {
+      test('returns true for a selected cell', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(2);
+
+        final result = cells.isSelected;
+
+        expect(result, isTrue);
+      });
+
+      test('returns true for the selected end column', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(3);
+
+        final result = cells.isSelected;
+
+        expect(result, isTrue);
+      });
+
+      test('returns false for an unselected cell', () {
+        installSelection();
+        bindSelectedRow();
+        cells.select(4);
+
+        final result = cells.isSelected;
+
+        expect(result, isFalse);
+      });
+    });
+
+    group('properties', () {
+      test('returns default cell properties', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+
+        expect(cells.style.bold, isFalse);
+        expect(cells.isProtected, isFalse);
+        expect(cells.semanticContent, SemanticContent.output);
+        expect(cells.backgroundArgb, isNull);
+        expect(cells.foregroundArgb, isNull);
+      });
+
+      test('reports styled cells', () {
+        terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.hasStyling;
+
+        expect(result, isTrue);
+      });
+
+      test('returns primary codepoint', () {
+        terminal.write(Uint8List.fromList('Z'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.codepoint;
+
+        expect(result, 0x5A);
+      });
+
+      test('returns zero codepoint for an empty cell', () {
+        terminal.write(Uint8List.fromList('Z'.codeUnits));
+        bindFirstCell();
+        cells.next();
+
+        final result = cells.codepoint;
+
+        expect(result, 0);
+      });
+
+      test('tracks column position', () {
+        terminal.write(Uint8List.fromList('ABC'.codeUnits));
+        bindFirstCell();
+        final first = cells.col;
+        cells.next();
+
+        final second = cells.col;
+
+        expect(first, 0);
+        expect(second, 1);
+      });
+
+      test('returns grapheme length for text', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+
+        final result = cells.graphemeLength;
+
+        expect(result, 1);
+      });
+
+      test('returns zero grapheme length for an empty cell', () {
+        terminal.write(Uint8List.fromList('A'.codeUnits));
+        bindFirstCell();
+        cells.next();
+
+        final result = cells.graphemeLength;
+
+        expect(result, 0);
+      });
+
+      test('returns packed ARGB colors', () {
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b[48;2;255;128;0m\x1b[38;2;0;255;64mY'.codeUnits,
+          ),
+        );
+        bindFirstCell();
+
+        expect(cells.backgroundArgb, 0xFFFF8000);
+        expect(cells.foregroundArgb, 0xFF00FF40);
+      });
+    });
+
+    group('select', () {
+      test('reads specific column content', () {
+        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+        cells.reset(rows);
+
+        cells.select(2);
+        final result = cells.content;
+
+        expect(result, 'C');
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/wasm/impl/terminal/row_iterator_test.dart
+++ b/packages/libghostty/test/wasm/impl/terminal/row_iterator_test.dart
@@ -1,0 +1,131 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:libghostty/libghostty.dart'
+    show GridRef, RenderState, RowIterator, Selection, SemanticPrompt, Terminal;
+import 'package:test/test.dart';
+
+import '../../helpers/setup.dart';
+
+void main() {
+  setUpAll(setUpWasm);
+
+  group('RowIterator', () {
+    late Terminal terminal;
+    late RenderState renderState;
+    late RowIterator rows;
+
+    setUp(() {
+      terminal = Terminal(cols: 10, rows: 3);
+      renderState = RenderState();
+      rows = RowIterator();
+    });
+
+    tearDown(() {
+      rows.dispose();
+      renderState.dispose();
+      terminal.dispose();
+    });
+
+    group('properties', () {
+      test('returns content flags for an empty row', () {
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+
+        expect(rows.hasGrapheme, isFalse);
+        expect(rows.hasStyled, isFalse);
+        expect(rows.hasHyperlink, isFalse);
+        expect(rows.hasKittyVirtualPlaceholder, isFalse);
+        expect(rows.semanticPrompt, SemanticPrompt.none);
+      });
+
+      test('reports styled rows', () {
+        terminal.write(Uint8List.fromList('\x1b[1mBold'.codeUnits));
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+
+        final result = rows.hasStyled;
+
+        expect(result, isTrue);
+      });
+
+      test('tracks row position', () {
+        renderState.update(terminal);
+        rows.reset(renderState);
+        rows.next();
+        final first = rows.index;
+        rows.next();
+
+        final second = rows.index;
+
+        expect(first, 0);
+        expect(second, 1);
+      });
+    });
+
+    void installSelection() {
+      terminal.selection = Selection.fromRefs(
+        start: GridRef.at(terminal, col: 1, row: 1),
+        end: GridRef.at(terminal, col: 3, row: 1),
+      );
+    }
+
+    void bindRows() {
+      renderState.update(terminal);
+      rows.reset(renderState);
+    }
+
+    void moveToRow(int row) {
+      for (var i = 0; i <= row; i++) {
+        expect(rows.next(), isTrue);
+      }
+    }
+
+    int rowCount() {
+      var count = 0;
+      rows.reset(renderState);
+      while (rows.next()) {
+        count++;
+      }
+      return count;
+    }
+
+    group('selection', () {
+      test('returns null for an unselected row', () {
+        installSelection();
+        bindRows();
+        moveToRow(0);
+
+        final result = rows.selection;
+
+        expect(result, isNull);
+      });
+
+      test('returns row-local selected columns', () {
+        installSelection();
+        bindRows();
+        moveToRow(1);
+
+        final result = rows.selection;
+
+        expect(result, (startCol: 1, endCol: 3));
+      });
+    });
+
+    group('reset', () {
+      test('rewinds iteration', () {
+        terminal.write(Uint8List.fromList('Hello'.codeUnits));
+        renderState.update(terminal);
+        final first = rowCount();
+
+        final second = rowCount();
+
+        expect(second, first);
+      });
+    });
+  });
+}

--- a/packages/libghostty/test/wasm/terminal/terminal_test.dart
+++ b/packages/libghostty/test/wasm/terminal/terminal_test.dart
@@ -17,17 +17,14 @@ void main() {
     late Terminal terminal;
     late RenderState renderState;
     late RowIterator rows;
-    late CellIterator cells;
 
     setUp(() {
       terminal = Terminal(cols: 80, rows: 24);
       renderState = RenderState();
       rows = RowIterator();
-      cells = CellIterator();
     });
 
     tearDown(() {
-      cells.dispose();
       rows.dispose();
       renderState.dispose();
       terminal.dispose();
@@ -678,73 +675,11 @@ void main() {
       });
     });
 
-    group('RowIterator', () {
-      group('properties', () {
-        test('empty row has no content flags', () {
-          renderState.update(terminal);
-          rows.reset(renderState);
-          rows.next();
-          expect(rows.hasGrapheme, isFalse);
-          expect(rows.hasStyled, isFalse);
-          expect(rows.hasHyperlink, isFalse);
-          expect(rows.hasKittyVirtualPlaceholder, isFalse);
-          expect(rows.semanticPrompt, SemanticPrompt.none);
-        });
-
-        test('styled row reports hasStyled', () {
-          terminal.write(Uint8List.fromList('\x1b[1mBold'.codeUnits));
-          renderState.update(terminal);
-          rows.reset(renderState);
-          rows.next();
-          expect(rows.hasStyled, isTrue);
-        });
-      });
-    });
-
-    group('CellIterator', () {
-      void advanceToFirstCell() {
-        renderState.update(terminal);
-        rows.reset(renderState);
-        rows.next();
-        cells.reset(rows);
-        cells.next();
-      }
-
-      group('properties', () {
-        test('default cell has no styling, protection, or special content', () {
-          terminal.write(Uint8List.fromList('A'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.style.bold, isFalse);
-          expect(cells.isProtected, isFalse);
-          expect(cells.semanticContent, SemanticContent.output);
-        });
-
-        test('styled cell reports hasStyling', () {
-          terminal.write(Uint8List.fromList('\x1b[1mB'.codeUnits));
-          advanceToFirstCell();
-          expect(cells.hasStyling, isTrue);
-        });
-      });
-    });
-
     group('Cursor properties', () {
       test('cursor wideTail is false on normal position', () {
         renderState.update(terminal);
         final cursor = renderState.cursor;
         expect(cursor.wideTail, isFalse);
-      });
-    });
-
-    group('re-iteration', () {
-      test('rebinding the iterator starts from the first row', () {
-        terminal.write(Uint8List.fromList('Hello'.codeUnits));
-        renderState.update(terminal);
-
-        final count1 = _rowCount(rows, renderState);
-        final count2 = _rowCount(rows, renderState);
-
-        expect(count1, greaterThan(0));
-        expect(count2, count1);
       });
     });
 
@@ -927,26 +862,6 @@ void main() {
         );
       });
     });
-
-    group('CellIterator.select', () {
-      test('reads specific column content', () {
-        terminal.write(Uint8List.fromList('ABCDE'.codeUnits));
-        renderState.update(terminal);
-
-        rows.reset(renderState);
-        rows.next();
-        cells.reset(rows);
-
-        cells.select(2);
-        expect(cells.content, 'C');
-
-        cells.select(0);
-        expect(cells.content, 'A');
-
-        cells.select(4);
-        expect(cells.content, 'E');
-      });
-    });
   });
 }
 
@@ -956,15 +871,6 @@ void clearDirty(RenderState renderState, RowIterator rows) {
     rows.dirty = false;
   }
   renderState.dirty = DirtyState.clean;
-}
-
-int _rowCount(RowIterator rows, RenderState renderState) {
-  var count = 0;
-  rows.reset(renderState);
-  while (rows.next()) {
-    count++;
-  }
-  return count;
 }
 
 void _expectAllCellsEmpty(Terminal terminal) {


### PR DESCRIPTION
Expose render selection data through libghostty row and cell iterators, including row-local selected ranges and per-cell selected state across native and WASM bindings, with iterator-focused coverage for selection-aware rendering.