### PR TITLE
chore(libghostty): prepare v0.0.10 release

### DIFF
--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.0.10
+
+### Breaking
+
+- **Position coordinates**: cursor and grid lookup APIs use `Position`
+  values. `GridRef.positionIn()` replaces `pointIn()`, and `GridRef`
+  no longer needs `dispose()`.
+
+### Added
+
+- **Selection APIs**: `Selection`, `SelectionGesture`, active terminal
+  selection, and selection formatting expose libghostty selection behavior.
+- **Tracked grid references**: `TrackedGridRef` follows a cell across
+  terminal mutations until the referenced cell is discarded.
+- **Terminal APIs**: working-directory changes, device attributes queries,
+  default cursor blink, and Glyph Protocol toggling are exposed.
+- **Render selection metadata**: `RowIterator.selection` and
+  `CellIterator.isSelected`
+  expose row-local selection state for render snapshots.
+
 ## 0.0.9
 
 ### Added

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.9
+  libghostty: ^0.0.10
 ```
 
 On web, initialize the WASM module once before using any bindings:
@@ -49,7 +49,7 @@ void main() {
   terminal.resize(cols: 120, rows: 40, cellWidthPx: 8, cellHeightPx: 16);
 
   // Read a single cell via grid reference (for ad-hoc lookups).
-  final ref = GridRef.at(terminal, col: 0, row: 0);
+  final ref = GridRef.at(terminal, const Position(row: 0, col: 0));
   print(ref.content); // the character at (0, 0)
 
   // Read screen via render state and reusable iterators.

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.9
+version: 0.0.10
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
Prepare the libghostty v0.0.10 release by updating the package version, changelog, and README example dependency.