### PR TITLE
ci: pin macOS Zig jobs to macOS 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,20 +70,20 @@ jobs:
       matrix:
         include:
           - target: aarch64-macos
-            runner: macos-latest
+            runner: macos-15
             ext: dylib
           - target: x86_64-macos
-            runner: macos-latest
+            runner: macos-15
             ext: dylib
           - target: aarch64-ios
-            runner: macos-latest
+            runner: macos-15
             ext: dylib
           - target: aarch64-ios-simulator
-            runner: macos-latest
+            runner: macos-15
             ext: dylib
             extra_args: -Dcpu=apple_a17
           - target: x86_64-ios-simulator
-            runner: macos-latest
+            runner: macos-15
             ext: dylib
           - target: x86_64-linux-gnu
             runner: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,7 +152,7 @@ jobs:
       matrix:
         include:
           - os: macos-arm64
-            runner: macos-latest
+            runner: macos-15
           - os: linux-x64
             runner: ubuntu-latest
           - os: windows-x64


### PR DESCRIPTION
Pin libghostty Zig macOS test and artifact build jobs to macOS 15, keeping native CI on the known-good runner image while allowing the matrix to report Linux and Windows results when one platform fails.