### PR TITLE
chore(libghostty): prepare v0.0.11 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://pub.dev/packages/flterm"><img alt="flterm" src="https://img.shields.io/pub/v/flterm?label=flterm"></a>
   <a href="https://github.com/elias8/libghostty/actions"><img alt="ci" src="https://github.com/elias8/libghostty/actions/workflows/build.yml/badge.svg"></a>
   <a href="LICENSE"><img alt="license" src="https://img.shields.io/badge/license-MIT-blue"></a>
+  <a href="https://github.com/sponsors/elias8"><img alt="sponsor" src="https://img.shields.io/github/sponsors/elias8?logo=githubsponsors&label=sponsor"></a>
 </p>
 
 [Ghostty](https://ghostty.org)'s libghostty-vt engine for Dart, with

--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://pub.dev/packages/flterm"><img alt="pub package" src="https://img.shields.io/pub/v/flterm"></a>
   <a href="https://github.com/elias8/libghostty/actions"><img alt="ci" src="https://github.com/elias8/libghostty/actions/workflows/build.yml/badge.svg"></a>
+  <a href="https://github.com/sponsors/elias8"><img alt="sponsor" src="https://img.shields.io/github/sponsors/elias8?logo=githubsponsors&label=sponsor"></a>
 </p>
 
 Flutter terminal widget on top of [Ghostty](https://ghostty.org)'s

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.0.11
+
+### Added
+
+- **Color utilities**: `parseColor`, `parsePaletteEntry`,
+  `parseX11ColorName`, `x11ColorNames`, palette generation, and luminance
+  helpers expose Ghostty's runtime color behavior.
+- **Unicode width utilities**: `unicodeCodepointWidth` and
+  `unicodeGraphemeWidth` expose Ghostty's terminal cell-width rules.
+- **Color-scheme reports**: `ColorScheme.encode()` encodes terminal
+  color-scheme reporting responses.
+- **Kitty graphics cache stamps**: `KittyGraphics.generation` and
+  `KittyImage.generation` let renderers detect placement and image cache
+  invalidation without comparing image bytes.
+- **Absolute viewport scrolling**: `Terminal.scrollToRow()` restores viewport
+  positions using the same row space as `Scrollbar.offset`.
+
+### Changed
+
+- **Kitty graphics pixel data**: stored image payloads are exposed as decoded,
+  decompressed pixels, including PNG and zlib-compressed transmissions.
+- **Scrollbar metadata**: scrollbar reads use Ghostty's cached offset and
+  incrementally maintained total, reducing repeated scrollback traversal.
+
 ## 0.0.10
 
 ### Breaking

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -15,7 +15,7 @@ the terminal emulator library from [Ghostty](https://ghostty.org).
 ```yaml
 # pubspec.yaml
 dependencies:
-  libghostty: ^0.0.10
+  libghostty: ^0.0.11
 ```
 
 On web, initialize the WASM module once before using any bindings:

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -2,6 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/libghostty)](https://pub.dev/packages/libghostty)
 [![GitHub Actions](https://github.com/elias8/libghostty/actions/workflows/build.yml/badge.svg)](https://github.com/elias8/libghostty/actions)
+[![Sponsor](https://img.shields.io/github/sponsors/elias8?logo=githubsponsors&label=sponsor)](https://github.com/sponsors/elias8)
 
 Dart bindings to [libghostty-vt](https://github.com/ghostty-org/ghostty),
 the terminal emulator library from [Ghostty](https://ghostty.org).

--- a/packages/libghostty/pubspec.yaml
+++ b/packages/libghostty/pubspec.yaml
@@ -1,6 +1,6 @@
 name: libghostty
 description: Dart bindings to libghostty-vt, the terminal emulator library from Ghostty.
-version: 0.0.10
+version: 0.0.11
 repository: https://github.com/elias8/libghostty/tree/main/packages/libghostty
 resolution: workspace
 


### PR DESCRIPTION
Prepare the libghostty v0.0.11 release by updating the package version, changelog, and README dependency example.