### PR TITLE
refactor(flterm): use absolute terminal row scrolling

### DIFF
--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -547,12 +547,10 @@ class TerminalRenderBox extends RenderBox {
 
     _stickToBottom = maxExtent <= 0 || pixels >= maxExtent - cellHeight;
 
-    final targetOffset = (pixels / cellHeight).floor();
-    final delta = targetOffset - scrollbar.offset;
+    final targetRow = (pixels / cellHeight).floor();
+    if (targetRow == scrollbar.offset) return;
 
-    if (delta == 0) return;
-
-    _terminal.scrollViewport(delta);
+    _terminal.scrollToRow(targetRow);
     _markFrameDirty();
   }
 

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -70,6 +70,10 @@ void main() {
       return (controller as TerminalViewBinding).terminal.selection;
     }
 
+    Terminal terminal(TerminalController controller) {
+      return (controller as TerminalViewBinding).terminal;
+    }
+
     String decodeOutput(List<Uint8List> output) {
       return utf8.decode(
         Uint8List.fromList(output.expand((chunk) => chunk).toList()),
@@ -1240,24 +1244,89 @@ void main() {
       expect(sel!.mode, TerminalSelectionShape.normal);
     });
 
-    testWidgets('scroll event changes scroll offset', (tester) async {
-      writeNumberedLines(50);
+    group('scrolling', () {
+      Future<
+        ({
+          TerminalScrollController scrollController,
+          Terminal terminal,
+          double cellHeight,
+        })
+      >
+      pumpScrollableTerminal(WidgetTester tester) async {
+        final scrollController = TerminalScrollController();
+        addTearDown(scrollController.dispose);
 
-      await tester.pumpWidget(
-        wrapInApp(controller: controller, autofocus: true),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          wrapInApp(
+            controller: controller,
+            scrollController: scrollController,
+            showKeyboard: false,
+            width: 400,
+            height: 80,
+          ),
+        );
+        await tester.pump();
+        writeNumberedLines(80);
+        await tester.pump();
+        await tester.pump();
 
-      final center = tester.getCenter(find.byType(TerminalView));
-      await tester.sendEventToBinding(
-        PointerScrollEvent(
-          position: center,
-          scrollDelta: const Offset(0, -100),
-        ),
-      );
-      await tester.pumpAndSettle();
+        return (
+          scrollController: scrollController,
+          terminal: terminal(controller),
+          cellHeight: renderer(tester).metrics.cellHeight,
+        );
+      }
 
-      expect(find.byType(TerminalView), findsOneWidget);
+      testWidgets('scroll event changes scroll offset', (tester) async {
+        final fixture = await pumpScrollableTerminal(tester);
+        final initialPixels = fixture.scrollController.position.pixels;
+        final center = tester.getCenter(find.byType(TerminalView));
+
+        await tester.sendEventToBinding(
+          PointerScrollEvent(
+            position: center,
+            scrollDelta: const Offset(0, -100),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(fixture.scrollController.position.pixels, isNot(initialPixels));
+      });
+
+      testWidgets('pixel offset maps to terminal row after existing scroll', (
+        tester,
+      ) async {
+        final fixture = await pumpScrollableTerminal(tester);
+        final targetRow = fixture.terminal.scrollbackRows ~/ 2;
+        fixture.terminal.scrollToBottom();
+
+        fixture.scrollController.jumpTo(targetRow * fixture.cellHeight);
+        await tester.pump();
+
+        expect(fixture.terminal.scrollbar.offset, targetRow);
+      });
+
+      testWidgets('negative pixel offset clamps to top row', (tester) async {
+        final fixture = await pumpScrollableTerminal(tester);
+
+        fixture.scrollController.jumpTo(-100);
+        await tester.pump();
+
+        expect(fixture.terminal.scrollbar.offset, 0);
+      });
+
+      testWidgets('overscroll pixel offset clamps to live row', (tester) async {
+        final fixture = await pumpScrollableTerminal(tester);
+        final position = fixture.scrollController.position;
+
+        fixture.scrollController.jumpTo(position.maxScrollExtent + 100);
+        await tester.pump();
+
+        expect(
+          fixture.terminal.scrollbar.offset,
+          fixture.terminal.scrollbackRows,
+        );
+      });
     });
 
     testWidgets('selectAll via controller updates view', (tester) async {


### PR DESCRIPTION
Use absolute terminal row offsets when rendering flterm scroll positions, keeping viewport calculations aligned with libghostty terminal row semantics.