### PR TITLE
perf(flterm): cache Kitty graphics snapshots

### DIFF
--- a/packages/flterm/lib/src/rendering/kitty_image_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_image_cache.dart
@@ -4,6 +4,16 @@ import 'dart:ui';
 import 'package:libghostty/libghostty.dart';
 import 'package:meta/meta.dart';
 
+/// Converts raw RGBA image bytes into a Flutter [Image].
+typedef KittyImageDecoder =
+    void Function(
+      Uint8List pixels,
+      int width,
+      int height,
+      PixelFormat format,
+      ImageDecoderCallback callback,
+    );
+
 /// Async decoder cache that maps Kitty image ids to drawable [Image]s.
 ///
 /// PNG payloads are already decoded to RGBA by libghostty via the
@@ -11,18 +21,22 @@ import 'package:meta/meta.dart';
 /// RGBA formats reach this cache; anything else is stored as
 /// [KittyImageUnsupported] so subsequent paints do not retry.
 ///
-/// Re-transmissions under the same id are detected by a
-/// `(width, height)` fingerprint, which catches resize-style
-/// replacements. Byte-level overwrites that keep the same dimensions
-/// continue to serve the previously decoded image.
+/// Re-transmissions under the same id are detected by
+/// [KittyImage.generation], so same-sized replacements cannot reuse stale
+/// decoded images.
 class KittyImageCache {
   final VoidCallback _onImageReady;
+  final KittyImageDecoder _decodeImage;
+
   final Map<int, KittyImageCacheEntry> _entries = {};
-  final Map<int, ({int width, int height})> _fingerprints = {};
+  final Map<int, int> _generations = {};
 
   /// [onImageReady] fires when a pending decode completes; typically
   /// wired to a render box's `markNeedsPaint`.
-  KittyImageCache({required this._onImageReady});
+  KittyImageCache({
+    required this._onImageReady,
+    this._decodeImage = decodeImageFromPixels,
+  });
 
   /// Releases every cached entry. Call before discarding the cache.
   void dispose() {
@@ -30,7 +44,7 @@ class KittyImageCache {
       if (entry is KittyImageReady) entry.image.dispose();
     }
     _entries.clear();
-    _fingerprints.clear();
+    _generations.clear();
   }
 
   /// Releases any cached entries whose id is not in [live].
@@ -38,22 +52,22 @@ class KittyImageCache {
     _entries.removeWhere((id, entry) {
       if (live.contains(id)) return false;
       if (entry is KittyImageReady) entry.image.dispose();
-      _fingerprints.remove(id);
+      _generations.remove(id);
       return true;
     });
   }
 
   /// Returns the entry for [image], starting a decode on first lookup
-  /// or when the image's dimensions have changed. Never blocks.
+  /// or when the image's generation has changed. Never blocks.
   KittyImageCacheEntry lookup(KittyImage image) {
-    final fingerprint = (width: image.width, height: image.height);
+    final generation = image.generation;
     final existing = _entries[image.id];
-    if (existing != null && _fingerprints[image.id] == fingerprint) {
+    if (existing != null && _generations[image.id] == generation) {
       return existing;
     }
     if (existing is KittyImageReady) existing.image.dispose();
     _entries[image.id] = KittyImagePending();
-    _fingerprints[image.id] = fingerprint;
+    _generations[image.id] = generation;
     _beginDecode(image);
     return _entries[image.id]!;
   }
@@ -68,32 +82,26 @@ class KittyImageCache {
     final existing = _entries[imageId];
     if (existing is KittyImageReady) existing.image.dispose();
     _entries[imageId] = KittyImageReady(image);
-    _fingerprints[imageId] = (width: image.width, height: image.height);
+    _generations[imageId] = 0;
   }
 
   void _beginDecode(KittyImage image) {
     final imageId = image.id;
-    final fingerprint = _fingerprints[imageId];
+    final generation = _generations[imageId];
     final rgba = _ensureRgba(image);
     if (rgba == null) {
       _entries[imageId] = KittyImageUnsupported();
       return;
     }
-    decodeImageFromPixels(
-      rgba,
-      image.width,
-      image.height,
-      PixelFormat.rgba8888,
-      (decoded) {
-        if (_fingerprints[imageId] != fingerprint ||
-            _entries[imageId] is! KittyImagePending) {
-          decoded.dispose();
-          return;
-        }
+    _decodeImage(rgba, image.width, image.height, .rgba8888, (decoded) {
+      if (_generations[imageId] == generation &&
+          _entries[imageId] is KittyImagePending) {
         _entries[imageId] = KittyImageReady(decoded);
         _onImageReady();
-      },
-    );
+      } else {
+        decoded.dispose();
+      }
+    });
   }
 
   Uint8List? _ensureRgba(KittyImage image) {

--- a/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
@@ -1,0 +1,170 @@
+import 'dart:ui';
+
+import 'package:libghostty/libghostty.dart';
+import 'package:meta/meta.dart';
+
+import 'kitty_image_cache.dart';
+import 'paint_state.dart';
+
+/// Caches paint-safe snapshots of Kitty graphics placements.
+///
+/// Libghostty generations invalidate protocol content, while terminal geometry
+/// invalidates resolved placement rectangles. Unchanged inputs avoid placement
+/// iteration, image lookup, sorting, and image eviction.
+final class KittyPlacementCache {
+  final TerminalPaintState _state;
+  final KittyImageCache _images;
+  final List<KittyPlacementSnapshot> _snapshots = [];
+  final Set<int> _liveImageIds = {};
+  _SnapshotKey? _key;
+
+  KittyPlacementCache({required this._state, required this._images});
+
+  /// Placement snapshots ordered by their signed z-index.
+  Iterable<KittyPlacementSnapshot> get snapshots => _snapshots;
+
+  /// Refreshes snapshots from [terminal] when protocol or geometry inputs have
+  /// changed.
+  ///
+  /// [geometryDirty] must be true after terminal mutations that can change
+  /// placement render information without changing Kitty storage generation.
+  ///
+  /// Returns whether callers must rebuild their paint-order buckets.
+  bool sync(Terminal terminal, {required bool geometryDirty}) {
+    final graphics = KittyGraphics.of(terminal);
+    if (graphics == null) {
+      final changed = _key != null || _snapshots.isNotEmpty;
+      _clear();
+      _images.evict(_liveImageIds);
+      _key = null;
+      return changed;
+    }
+
+    final key = _SnapshotKey(
+      generation: graphics.generation,
+      cellWidth: _state.metrics.cellWidth,
+      cellHeight: _state.metrics.cellHeight,
+      devicePixelRatio: _state.devicePixelRatio,
+      viewportOffset: _state.viewportOffset,
+      rows: _state.rows,
+      cols: _state.cols,
+    );
+    if (!geometryDirty && _key == key) return false;
+
+    _clear();
+    for (final placement in graphics.placements()) {
+      _liveImageIds.add(placement.imageId);
+
+      final info = placement.renderInfo;
+      if (!info.viewportVisible) continue;
+      if (info.pixelWidth == 0 || info.pixelHeight == 0) continue;
+
+      final image = graphics.image(placement.imageId);
+      if (image == null) continue;
+
+      _images.lookup(image);
+      _snapshots.add(
+        KittyPlacementSnapshot(
+          imageId: placement.imageId,
+          dst: Rect.fromLTWH(
+            info.viewportCol * key.cellWidth +
+                placement.xOffset / key.devicePixelRatio,
+            info.viewportRow * key.cellHeight +
+                placement.yOffset / key.devicePixelRatio,
+            info.pixelWidth / key.devicePixelRatio,
+            info.pixelHeight / key.devicePixelRatio,
+          ),
+          src: Rect.fromLTWH(
+            info.sourceX.toDouble(),
+            info.sourceY.toDouble(),
+            info.sourceWidth.toDouble(),
+            info.sourceHeight.toDouble(),
+          ),
+          z: placement.z,
+        ),
+      );
+    }
+
+    if (_snapshots.length > 1) _snapshots.sort(_compareZ);
+    _images.evict(_liveImageIds);
+    _key = key;
+    return true;
+  }
+
+  void _clear() {
+    _snapshots.clear();
+    _liveImageIds.clear();
+  }
+
+  static int _compareZ(KittyPlacementSnapshot a, KittyPlacementSnapshot b) {
+    return a.z.compareTo(b.z);
+  }
+}
+
+/// Placement data copied from libghostty for use during paint.
+///
+/// The snapshot remains valid when subsequent terminal mutations invalidate
+/// libghostty's borrowed placement handles.
+final class KittyPlacementSnapshot {
+  final int imageId;
+
+  /// Destination rectangle in the same logical-pixel space as cells.
+  final Rect dst;
+
+  /// Source rectangle in the image's own pixel space.
+  final Rect src;
+
+  /// Signed z-index from the Kitty graphics protocol.
+  final int z;
+
+  const KittyPlacementSnapshot({
+    required this.imageId,
+    required this.dst,
+    required this.src,
+    required this.z,
+  });
+}
+
+@immutable
+final class _SnapshotKey {
+  final int generation;
+  final double cellWidth;
+  final double cellHeight;
+  final double devicePixelRatio;
+  final int viewportOffset;
+  final int rows;
+  final int cols;
+
+  const _SnapshotKey({
+    required this.generation,
+    required this.cellWidth,
+    required this.cellHeight,
+    required this.devicePixelRatio,
+    required this.viewportOffset,
+    required this.rows,
+    required this.cols,
+  });
+
+  @override
+  int get hashCode => Object.hash(
+    generation,
+    cellWidth,
+    cellHeight,
+    devicePixelRatio,
+    viewportOffset,
+    rows,
+    cols,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    return other is _SnapshotKey &&
+        generation == other.generation &&
+        cellWidth == other.cellWidth &&
+        cellHeight == other.cellHeight &&
+        devicePixelRatio == other.devicePixelRatio &&
+        viewportOffset == other.viewportOffset &&
+        rows == other.rows &&
+        cols == other.cols;
+  }
+}

--- a/packages/flterm/lib/src/rendering/painters/kitty_graphics_painter.dart
+++ b/packages/flterm/lib/src/rendering/painters/kitty_graphics_painter.dart
@@ -3,13 +3,14 @@ import 'dart:ui';
 import 'package:flutter/painting.dart';
 
 import '../kitty_image_cache.dart';
+import '../kitty_placement_cache.dart';
 import '../paint_state.dart';
 import 'terminal_painter.dart';
 
 /// Paints one ordered Kitty graphics placement list.
 ///
-/// [TerminalPainterStack] splits placements by [KittyPaintLayer] before paint,
-/// so this painter only clips and draws the list it receives.
+/// The caller chooses where the list belongs in the surrounding paint order;
+/// this painter only clips and draws the snapshots it receives.
 class KittyGraphicsPainter implements TerminalPainter {
   final Paint _paint;
   final KittyImageCache _cache;
@@ -39,52 +40,4 @@ class KittyGraphicsPainter implements TerminalPainter {
     }
     canvas.restore();
   }
-}
-
-/// Paint-order bucket a Kitty placement falls into based on its z-index.
-///
-/// Mirrors the Kitty graphics protocol's three-bucket convention.
-enum KittyPaintLayer {
-  /// Painted beneath cell backgrounds.
-  belowBg,
-
-  /// Painted between cell backgrounds and text.
-  belowText,
-
-  /// Painted above text, beneath the selection overlay.
-  aboveText;
-
-  // The protocol splits negative z values in half at INT32_MIN / 2:
-  // anything further negative than that paints below the cell
-  // background, the rest paints above the background but below text.
-  static const int _bgThreshold = -1 << 30;
-
-  /// Returns the layer for a placement with the given [z].
-  static KittyPaintLayer forZ(int z) {
-    if (z >= 0) return aboveText;
-    if (z < _bgThreshold) return belowBg;
-    return belowText;
-  }
-}
-
-/// Placement data consumed by [KittyGraphicsPainter], decoupled from
-/// the live terminal so paint never reaches back into libghostty.
-class KittyPlacementSnapshot {
-  final int imageId;
-
-  /// Destination rectangle in the same logical-pixel space as cells.
-  final Rect dst;
-
-  /// Source rectangle in the image's own pixel space.
-  final Rect src;
-
-  /// Signed z-index. See [KittyPaintLayer] for the layer mapping.
-  final int z;
-
-  const KittyPlacementSnapshot({
-    required this.imageId,
-    required this.dst,
-    required this.src,
-    required this.z,
-  });
 }

--- a/packages/flterm/lib/src/rendering/terminal_painter_stack.dart
+++ b/packages/flterm/lib/src/rendering/terminal_painter_stack.dart
@@ -1,10 +1,11 @@
-import 'dart:ui';
+import 'dart:ui' show Canvas;
 
 import 'package:libghostty/libghostty.dart';
 
 import 'atlas/atlas.dart';
 import 'atlas/sprite_buffer.dart';
 import 'kitty_image_cache.dart';
+import 'kitty_placement_cache.dart';
 import 'paint_state.dart';
 import 'painters/background_painter.dart';
 import 'painters/cursor_painter.dart';
@@ -18,20 +19,22 @@ import 'painters/underline_painter.dart';
 
 /// Owns paint helpers, paint order, and paint-only terminal resources.
 final class TerminalPainterStack {
+  // The protocol splits negative z values in half at INT32_MIN / 2.
+  static const int _kittyBelowBackgroundThreshold = -1 << 30;
+
   final SpriteBuffer _sprites;
   final TerminalPaintState _state;
-  final _liveKittyImageIds = <int>{};
   final KittyImageCache _kittyImageCache;
-  final ShapedRunPainter _shapedRunPainter;
-  final List<KittyPlacementSnapshot> _kittyBelowBg = [];
+  final List<KittyPlacementSnapshot> _kittyBelowBackground = [];
   final List<KittyPlacementSnapshot> _kittyBelowText = [];
   final List<KittyPlacementSnapshot> _kittyAboveText = [];
-
+  final ShapedRunPainter _shapedRunPainter;
   final BackgroundPainter _backgroundPainter;
   final DecorationPainter _decorationPainter;
-  late final KittyGraphicsPainter _kittyBelowBgPainter;
+  late final KittyGraphicsPainter _kittyBelowBackgroundPainter;
   late final KittyGraphicsPainter _kittyBelowTextPainter;
   late final KittyGraphicsPainter _kittyAboveTextPainter;
+  late final KittyPlacementCache _kittyPlacementCache;
 
   late EmojiPainter _emojiPainter;
   late SpritePainter _spritePainter;
@@ -48,10 +51,14 @@ final class TerminalPainterStack {
        _shapedRunPainter = ShapedRunPainter(_sprites.shaped),
        _backgroundPainter = BackgroundPainter(_state, _sprites),
        _decorationPainter = DecorationPainter(_sprites) {
-    _kittyBelowBgPainter = KittyGraphicsPainter(
+    _kittyPlacementCache = KittyPlacementCache(
+      state: _state,
+      images: _kittyImageCache,
+    );
+    _kittyBelowBackgroundPainter = KittyGraphicsPainter(
       state: _state,
       cache: _kittyImageCache,
-      snapshots: _kittyBelowBg,
+      snapshots: _kittyBelowBackground,
     );
     _kittyBelowTextPainter = KittyGraphicsPainter(
       state: _state,
@@ -74,12 +81,10 @@ final class TerminalPainterStack {
     _underlinePainter = UnderlinePainter(atlas, _sprites);
   }
 
-  void dispose() {
-    _kittyImageCache.dispose();
-  }
+  void dispose() => _kittyImageCache.dispose();
 
   void paint(Canvas canvas) {
-    _kittyBelowBgPainter.paint(canvas);
+    _kittyBelowBackgroundPainter.paint(canvas);
     _backgroundPainter.paint(canvas);
     _kittyBelowTextPainter.paint(canvas);
     _underlinePainter.paint(canvas);
@@ -92,72 +97,25 @@ final class TerminalPainterStack {
     _kittyAboveTextPainter.paint(canvas);
   }
 
-  void sync(Terminal terminal) {
-    _kittyBelowBg.clear();
-    _kittyBelowText.clear();
-    _kittyAboveText.clear();
-    _liveKittyImageIds.clear();
-
-    final graphics = KittyGraphics.of(terminal);
-    if (graphics == null) {
-      _kittyImageCache.evict(_liveKittyImageIds);
+  void sync(Terminal terminal, {required bool geometryDirty}) {
+    if (!_kittyPlacementCache.sync(terminal, geometryDirty: geometryDirty)) {
       return;
     }
-
-    final cellWidth = _state.metrics.cellWidth;
-    final cellHeight = _state.metrics.cellHeight;
-    final dpr = _state.devicePixelRatio;
-
-    for (final placement in graphics.placements()) {
-      final info = placement.renderInfo;
-      if (!info.viewportVisible) continue;
-      if (info.pixelWidth == 0 || info.pixelHeight == 0) continue;
-
-      final image = graphics.image(placement.imageId);
-      if (image == null) continue;
-
-      _liveKittyImageIds.add(placement.imageId);
-      _kittyImageCache.lookup(image);
-
-      _placementsFor(placement.z).add(
-        KittyPlacementSnapshot(
-          imageId: placement.imageId,
-          dst: Rect.fromLTWH(
-            info.viewportCol * cellWidth + placement.xOffset / dpr,
-            info.viewportRow * cellHeight + placement.yOffset / dpr,
-            info.pixelWidth / dpr,
-            info.pixelHeight / dpr,
-          ),
-          src: Rect.fromLTWH(
-            info.sourceX.toDouble(),
-            info.sourceY.toDouble(),
-            info.sourceWidth.toDouble(),
-            info.sourceHeight.toDouble(),
-          ),
-          z: placement.z,
-        ),
-      );
-    }
-
-    _sort(_kittyBelowBg);
-    _sort(_kittyBelowText);
-    _sort(_kittyAboveText);
-    _kittyImageCache.evict(_liveKittyImageIds);
+    _rebuildKittyLayers();
   }
 
-  List<KittyPlacementSnapshot> _placementsFor(int z) {
-    switch (KittyPaintLayer.forZ(z)) {
-      case .belowBg:
-        return _kittyBelowBg;
-      case .belowText:
-        return _kittyBelowText;
-      case .aboveText:
-        return _kittyAboveText;
+  void _rebuildKittyLayers() {
+    _kittyBelowBackground.clear();
+    _kittyBelowText.clear();
+    _kittyAboveText.clear();
+    for (final snapshot in _kittyPlacementCache.snapshots) {
+      if (snapshot.z >= 0) {
+        _kittyAboveText.add(snapshot);
+      } else if (snapshot.z < _kittyBelowBackgroundThreshold) {
+        _kittyBelowBackground.add(snapshot);
+      } else {
+        _kittyBelowText.add(snapshot);
+      }
     }
-  }
-
-  void _sort(List<KittyPlacementSnapshot> snapshots) {
-    if (snapshots.length < 2) return;
-    snapshots.sort((a, b) => a.z.compareTo(b.z));
   }
 }

--- a/packages/flterm/lib/src/rendering/terminal_render_pipeline.dart
+++ b/packages/flterm/lib/src/rendering/terminal_render_pipeline.dart
@@ -71,6 +71,8 @@ final class TerminalRenderPipeline {
   ///
   /// [preeditText] does not enter libghostty state. The frame builder overlays
   /// it on terminal-cell boundaries at the current cursor position.
+  /// Terminal-dirty frames also refresh Kitty placement geometry because screen
+  /// mutations can move placements without changing Kitty storage generation.
   void sync(
     Terminal terminal, {
     required bool terminalDirty,
@@ -85,6 +87,6 @@ final class TerminalRenderPipeline {
       preeditText: preeditText,
       linkSnapshot: linkSnapshot,
     );
-    _painters.sync(terminal);
+    _painters.sync(terminal, geometryDirty: syncTerminal);
   }
 }

--- a/packages/flterm/test/rendering/kitty_graphics_painter_golden_test.dart
+++ b/packages/flterm/test/rendering/kitty_graphics_painter_golden_test.dart
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/rendering/kitty_image_cache.dart';
+import 'package:flterm/src/rendering/kitty_placement_cache.dart';
 import 'package:flterm/src/rendering/paint_state.dart';
 import 'package:flterm/src/rendering/painters/kitty_graphics_painter.dart';
 import 'package:flutter/painting.dart';

--- a/packages/flterm/test/rendering/kitty_image_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_image_cache_test.dart
@@ -1,9 +1,14 @@
+@Tags(['ffi'])
+library;
+
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flterm/src/rendering/kitty_image_cache.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
 
 void main() {
   group('KittyImageCache', () {
@@ -19,18 +24,79 @@ void main() {
       return completer.future;
     }
 
-    test('dispose clears ready entries and is idempotent', () async {
-      final cache = KittyImageCache(onImageReady: () {});
-      addTearDown(cache.dispose);
-      final image = await testImage();
+    group('dispose', () {
+      test('clears ready entries', () async {
+        final cache = KittyImageCache(onImageReady: () {});
+        addTearDown(cache.dispose);
+        final image = await testImage();
+        cache.putReady(1, image);
 
-      cache.putReady(1, image);
-      expect(cache.lookupById(1), isA<KittyImageReady>());
+        cache.dispose();
 
-      cache.dispose();
-      cache.dispose();
+        expect(cache.lookupById(1), isNull);
+      });
 
-      expect(cache.lookupById(1), isNull);
+      test('allows repeated calls', () {
+        final cache = KittyImageCache(onImageReady: () {});
+        addTearDown(cache.dispose);
+        cache.dispose();
+
+        expect(cache.dispose, returnsNormally);
+      });
+    });
+
+    group('lookup', () {
+      Uint8List transmitPixel({required int id, required List<int> rgb}) {
+        final payload = base64Encode(rgb);
+        return Uint8List.fromList(
+          '\x1b_Gf=24,s=1,v=1,a=t,i=$id;$payload\x1b\\'.codeUnits,
+        );
+      }
+
+      late Terminal terminal;
+
+      setUp(() {
+        terminal = Terminal(cols: 4, rows: 2)..kittyImageStorageLimit = 1 << 20;
+      });
+
+      tearDown(() {
+        terminal.dispose();
+      });
+
+      test('invalidates ready entry when image generation changes', () async {
+        final cache = KittyImageCache(onImageReady: () {});
+        addTearDown(cache.dispose);
+        final decoded = await testImage();
+        cache.putReady(7, decoded);
+        terminal.write(transmitPixel(id: 7, rgb: [0xff, 0x00, 0x00]));
+        final image = KittyGraphics.of(terminal)!.image(7)!;
+
+        final entry = cache.lookup(image);
+
+        expect(entry, isA<KittyImagePending>());
+      });
+
+      test('discards stale pending decode after generation changes', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, callback) {
+            callbacks.add(callback);
+          },
+        );
+        addTearDown(cache.dispose);
+        final stale = await testImage();
+        terminal.write(transmitPixel(id: 8, rgb: [0xff, 0x00, 0x00]));
+        final staleImage = KittyGraphics.of(terminal)!.image(8)!;
+        cache.lookup(staleImage);
+        terminal.write(transmitPixel(id: 8, rgb: [0x00, 0xff, 0x00]));
+        final currentImage = KittyGraphics.of(terminal)!.image(8)!;
+        cache.lookup(currentImage);
+
+        callbacks[0](stale);
+
+        expect(cache.lookupById(8), isA<KittyImagePending>());
+      });
     });
   });
 }

--- a/packages/flterm/test/rendering/kitty_placement_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_placement_cache_test.dart
@@ -1,0 +1,73 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/terminal_theme.dart';
+import 'package:flterm/src/rendering/kitty_image_cache.dart';
+import 'package:flterm/src/rendering/kitty_placement_cache.dart';
+import 'package:flterm/src/rendering/paint_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libghostty/libghostty.dart';
+
+void main() {
+  group('KittyPlacementCache', () {
+    const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+    void writePlacedImage(Terminal terminal) {
+      final payload = base64Encode([0xff, 0x00, 0x00]);
+      terminal.write(
+        Uint8List.fromList(
+          '\x1b_Gf=24,s=1,v=1,a=T,i=11,c=1,r=1;$payload\x1b\\'.codeUnits,
+        ),
+      );
+    }
+
+    late Terminal terminal;
+    late TerminalPaintState state;
+    late KittyImageCache images;
+    late KittyPlacementCache placements;
+
+    setUp(() {
+      terminal = Terminal(cols: 8, rows: 2)..kittyImageStorageLimit = 1 << 20;
+      state = TerminalPaintState(TerminalTheme.dark(), metrics)
+        ..cols = 8
+        ..rows = 2;
+      images = KittyImageCache(onImageReady: () {});
+      placements = KittyPlacementCache(state: state, images: images);
+      writePlacedImage(terminal);
+      placements.sync(terminal, geometryDirty: false);
+    });
+
+    tearDown(() {
+      images.dispose();
+      terminal.dispose();
+    });
+
+    group('sync', () {
+      test('returns false when generation and geometry are unchanged', () {
+        final rebuilt = placements.sync(terminal, geometryDirty: false);
+
+        expect(rebuilt, isFalse);
+      });
+
+      test('returns true when geometry changes', () {
+        state.devicePixelRatio = 2.0;
+
+        final rebuilt = placements.sync(terminal, geometryDirty: false);
+
+        expect(rebuilt, isTrue);
+      });
+
+      test('removes snapshots hidden by terminal scrolling', () {
+        terminal.write(Uint8List.fromList('\x1b[2;1H\n'.codeUnits));
+
+        placements.sync(terminal, geometryDirty: true);
+
+        expect(placements.snapshots, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Cache Kitty graphics placement snapshots across unchanged frames, invalidate decoded images by libghostty generation, and cover geometry and stale-decode invalidation so repeated paints avoid placement traversal, sorting, and image eviction.