### PR TITLE
feat(libghostty): expose batched terminal state queries

### DIFF
--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -7,7 +7,7 @@ library;
 
 export 'src/bindings/bindings.dart' show initializeForWeb;
 export 'src/bindings/types/aliases.dart'
-    show DecodedImage, PngDecoder, X11ColorName;
+    show DecodedImage, PngDecoder, TerminalGeometry, X11ColorName;
 export 'src/bindings/types/types.dart'
     show
         CellColor,

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -140,6 +140,7 @@ abstract interface class GhosttyBindings {
   CResult<int> terminalGetScrollbackRows(int handle);
   CResult<int> terminalGetWidthPx(int handle);
   CResult<int> terminalGetHeightPx(int handle);
+  CResult<TerminalGeometry> terminalGetGeometry(int handle);
   CResult<bool> terminalGetViewportActive(int handle);
   Result terminalSetTitle(int handle, String? title);
   Result terminalSetPwd(int handle, String? pwd);
@@ -259,6 +260,7 @@ abstract interface class GhosttyBindings {
   CResult<int> renderStateGetCols(int state);
   CResult<int> renderStateGetRows(int state);
   CResult<RenderStateDirty> renderStateGetDirty(int state);
+  CResult<RawRenderStateSummary> renderStateGetSummary(int state);
   Result renderStateSetDirty(int state, RenderStateDirty dirty);
   CResult<TerminalColors> renderStateGetColors(int state);
   CResult<RenderStateCursorVisualStyle> renderStateGetCursorVisualStyle(
@@ -271,6 +273,7 @@ abstract interface class GhosttyBindings {
   CResult<int> renderStateGetCursorViewportX(int state);
   CResult<int> renderStateGetCursorViewportY(int state);
   CResult<bool> renderStateGetCursorViewportWideTail(int state);
+  CResult<RawRenderStateCursor> renderStateGetCursor(int state);
 
   CResult<int> rowIteratorNew();
   void rowIteratorFree(int handle);
@@ -279,6 +282,7 @@ abstract interface class GhosttyBindings {
   Result rowIteratorInit(int iterator, int renderState);
   bool rowIteratorNext(int iterator);
   CResult<bool> rowIteratorGetDirty(int iterator);
+  CResult<RawRowIteratorSummary> rowIteratorGetSummary(int iterator);
   Result rowIteratorSetDirty(int iterator, {required bool dirty});
   CResult<int> rowIteratorGetRawRow(int iterator);
   CResult<({int startCol, int endCol})> rowIteratorGetSelection(int iterator);
@@ -291,6 +295,7 @@ abstract interface class GhosttyBindings {
   bool rowCellsNext(int cells);
   Result rowCellsSelect(int cells, int x);
   CResult<int> rowCellsGetRawCell(int cells);
+  CResult<RawRowCellsSummary> rowCellsGetSummary(int cells);
   CResult<Style> rowCellsGetStyle(int cells);
   CResult<int> rowCellsGetGraphemeLen(int cells);
   CResult<List<int>> rowCellsGetGraphemes(int cells, int len);
@@ -303,6 +308,7 @@ abstract interface class GhosttyBindings {
   CResult<int> rowCellsGetFgColorArgb(int cells);
 
   CResult<int> cellGetCodepoint(int cell);
+  CResult<RawCellSummary> cellGetSummary(int cell);
   CResult<CellContentTag> cellGetContentTag(int cell);
   CResult<CellWide> cellGetWide(int cell);
   CResult<bool> cellGetHasText(int cell);
@@ -322,6 +328,7 @@ abstract interface class GhosttyBindings {
   CResult<RowSemanticPrompt> rowGetSemanticPrompt(int row);
   CResult<bool> rowGetKittyVirtualPlaceholder(int row);
   CResult<bool> rowGetDirty(int row);
+  CResult<RawRowSummary> rowGetSummary(int row);
 
   CResult<String> focusEncode(FocusEvent event);
 
@@ -479,6 +486,10 @@ abstract interface class GhosttyBindings {
     int terminal,
   );
   CResult<RawGridRef> selectionGestureGetAnchor(int gesture, int terminal);
+  CResult<RawSelectionGestureState> selectionGestureGetState(
+    int gesture,
+    int terminal,
+  );
 
   CResult<int> formatterTerminalNew(
     int terminal,

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -48,6 +48,84 @@ const RawPlacementRenderInfo _emptyRenderInfo = (
 );
 
 const RawGridRef _emptyGridRef = (node: 0, x: 0, y: 0);
+const TerminalGeometry _emptyTerminalGeometry = (
+  cols: 0,
+  rows: 0,
+  widthPx: 0,
+  heightPx: 0,
+);
+const RawRenderStateSummary _emptyRenderStateSummary = (
+  cols: 0,
+  rows: 0,
+  dirty: .false$,
+);
+const RawRenderStateCursor _emptyRenderStateCursor = (
+  visualStyle: .block,
+  visible: false,
+  blinking: false,
+  passwordInput: false,
+  inViewport: false,
+  viewportX: 0,
+  viewportY: 0,
+  viewportWideTail: false,
+);
+const RawSelectionGestureState _emptySelectionGestureState = (
+  clickCount: 0,
+  dragged: false,
+  autoscroll: .none,
+  behavior: .cell,
+  anchor: null,
+);
+
+const _rowIteratorSummaryKeys = <RenderStateRowData>[.dirty, .raw];
+const _rowCellsSummaryKeys = <RenderStateRowCellsData>[
+  .raw,
+  .graphemesLen,
+  .selected,
+];
+const _cellSummaryKeys = <CellData>[.codepoint, .styleId, .wide];
+const _rowSummaryKeys = <RowData>[
+  .wrap,
+  .wrapContinuation,
+  .grapheme,
+  .styled,
+  .hyperlink,
+  .semanticPrompt,
+  .kittyVirtualPlaceholder,
+];
+const _selectionGestureStateKeys = <SelectionGestureData>[
+  .clickCount,
+  .dragged,
+  .autoscroll,
+  .behavior,
+  .anchor,
+];
+const _kittyImagePixelDataKeys = <KittyGraphicsImageData>[.dataPtr, .dataLen];
+const _kittyPlacementKeys = <KittyGraphicsPlacementData>[
+  .imageId,
+  .placementId,
+  .isVirtual,
+  .xOffset,
+  .yOffset,
+  .sourceX,
+  .sourceY,
+  .sourceWidth,
+  .sourceHeight,
+  .columns,
+  .rows,
+  .z,
+];
+const _cursorStateKeys = <RenderStateData>[
+  .cursorVisualStyle,
+  .cursorVisible,
+  .cursorBlinking,
+  .cursorPasswordInput,
+  .cursorViewportHasValue,
+  .cursorViewportX,
+  .cursorViewportY,
+  .cursorViewportWideTail,
+];
+const _renderStateSummaryKeys = <RenderStateData>[.cols, .rows, .dirty];
 
 class NativeBindings implements GhosttyBindings {
   final _utf8Ptrs = <int, Pointer<Char>>{};
@@ -71,10 +149,54 @@ class NativeBindings implements GhosttyBindings {
   final _outColorRgb = calloc<ColorRgb>();
   final _graphemeBuf = calloc<Uint32>(32);
   final _outOpaque = calloc<Pointer<Void>>();
+  final _multiKeys = calloc<UnsignedInt>(12);
+  final _multiValues = calloc<Pointer<Void>>(12);
+  final _multiOut = calloc<Uint64>(12);
+  final _multiGridRef = calloc<GridRef>();
+  final _renderStateSummaryMultiKeys = calloc<UnsignedInt>(
+    _renderStateSummaryKeys.length,
+  );
+  final _renderStateSummaryMultiValues = calloc<Pointer<Void>>(
+    _renderStateSummaryKeys.length,
+  );
+  final _renderStateSummaryMultiOut = calloc<Uint64>(
+    _renderStateSummaryKeys.length,
+  );
+  final _cursorMultiKeys = calloc<UnsignedInt>(_cursorStateKeys.length);
+  final _cursorMultiValues = calloc<Pointer<Void>>(_cursorStateKeys.length);
+  final _cursorMultiOut = calloc<Uint64>(_cursorStateKeys.length);
+  final _rowCellsMultiKeys = calloc<UnsignedInt>(_rowCellsSummaryKeys.length);
+  final _rowCellsMultiValues = calloc<Pointer<Void>>(
+    _rowCellsSummaryKeys.length,
+  );
+  final _rowCellsMultiOut = calloc<Uint64>(_rowCellsSummaryKeys.length);
+  final _cellMultiKeys = calloc<UnsignedInt>(_cellSummaryKeys.length);
+  final _cellMultiValues = calloc<Pointer<Void>>(_cellSummaryKeys.length);
+  final _cellMultiOut = calloc<Uint64>(_cellSummaryKeys.length);
+  Pointer<Uint8> _formatBuffer = calloc<Uint8>(4096);
+  late int _formatBufferCapacity;
 
   NativeBindings() {
+    _formatBufferCapacity = 4096;
     _outColors.ref.size = sizeOf<RenderStateColors>();
     _outStyle.ref.size = sizeOf<native.Style>();
+    for (var i = 0; i < _renderStateSummaryKeys.length; i++) {
+      _renderStateSummaryMultiKeys[i] = _renderStateSummaryKeys[i].value;
+      _renderStateSummaryMultiValues[i] = (_renderStateSummaryMultiOut + i)
+          .cast();
+    }
+    for (var i = 0; i < _cursorStateKeys.length; i++) {
+      _cursorMultiKeys[i] = _cursorStateKeys[i].value;
+      _cursorMultiValues[i] = (_cursorMultiOut + i).cast();
+    }
+    for (var i = 0; i < _rowCellsSummaryKeys.length; i++) {
+      _rowCellsMultiKeys[i] = _rowCellsSummaryKeys[i].value;
+      _rowCellsMultiValues[i] = (_rowCellsMultiOut + i).cast();
+    }
+    for (var i = 0; i < _cellSummaryKeys.length; i++) {
+      _cellMultiKeys[i] = _cellSummaryKeys[i].value;
+      _cellMultiValues[i] = (_cellMultiOut + i).cast();
+    }
   }
 
   @override
@@ -943,6 +1065,22 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<TerminalGeometry> terminalGetGeometry(int handle) {
+    const keys = <TerminalData>[.cols, .rows, .widthPx, .heightPx];
+    final result = _terminalGetMulti(handle, keys);
+    if (result != .success) return (result, _emptyTerminalGeometry);
+    return (
+      result,
+      (
+        cols: (_multiOut + 0).cast<Uint16>().value,
+        rows: (_multiOut + 1).cast<Uint16>().value,
+        widthPx: (_multiOut + 2).cast<Uint32>().value,
+        heightPx: (_multiOut + 3).cast<Uint32>().value,
+      ),
+    );
+  }
+
+  @override
   CResult<bool> terminalGetViewportActive(int handle) {
     return _terminalGetBool(handle, .viewportActive);
   }
@@ -1210,6 +1348,28 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawRenderStateSummary> renderStateGetSummary(int state) {
+    final result = ghostty_render_state_get_multi(
+      Pointer.fromAddress(state),
+      _renderStateSummaryKeys.length,
+      _renderStateSummaryMultiKeys,
+      _renderStateSummaryMultiValues,
+      _outSize,
+    );
+    if (result != .success) return (result, _emptyRenderStateSummary);
+    return (
+      result,
+      (
+        cols: (_renderStateSummaryMultiOut + 0).cast<Uint16>().value,
+        rows: (_renderStateSummaryMultiOut + 1).cast<Uint16>().value,
+        dirty: .fromValue(
+          (_renderStateSummaryMultiOut + 2).cast<Int32>().value,
+        ),
+      ),
+    );
+  }
+
+  @override
   Result renderStateSetDirty(int state, RenderStateDirty dirty) {
     _outI32.value = dirty.value;
     return ghostty_render_state_set(
@@ -1299,6 +1459,58 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawRenderStateCursor> renderStateGetCursor(int state) {
+    final result = ghostty_render_state_get_multi(
+      Pointer.fromAddress(state),
+      _cursorStateKeys.length,
+      _cursorMultiKeys,
+      _cursorMultiValues,
+      _outSize,
+    );
+    final written = _outSize.value;
+    final cursorOffscreen = result == .invalidValue && written == 5;
+    if (result != .success && !cursorOffscreen) {
+      return (result, _emptyRenderStateCursor);
+    }
+    final visualStyle = RenderStateCursorVisualStyle.fromValue(
+      (_cursorMultiOut + 0).cast<Int32>().value,
+    );
+    final visible = (_cursorMultiOut + 1).cast<Bool>().value;
+    final blinking = (_cursorMultiOut + 2).cast<Bool>().value;
+    final passwordInput = (_cursorMultiOut + 3).cast<Bool>().value;
+    final inViewport = (_cursorMultiOut + 4).cast<Bool>().value;
+    if (!inViewport) {
+      return (
+        .success,
+        (
+          visualStyle: visualStyle,
+          visible: visible,
+          blinking: blinking,
+          passwordInput: passwordInput,
+          inViewport: false,
+          viewportX: 0,
+          viewportY: 0,
+          viewportWideTail: false,
+        ),
+      );
+    }
+
+    return (
+      result,
+      (
+        visualStyle: visualStyle,
+        visible: visible,
+        blinking: blinking,
+        passwordInput: passwordInput,
+        inViewport: true,
+        viewportX: (_cursorMultiOut + 5).cast<Uint16>().value,
+        viewportY: (_cursorMultiOut + 6).cast<Uint16>().value,
+        viewportWideTail: (_cursorMultiOut + 7).cast<Bool>().value,
+      ),
+    );
+  }
+
+  @override
   CResult<int> rowIteratorNew() {
     return using((arena) {
       final ptr = arena<Pointer<RenderStateRowIteratorImpl>>();
@@ -1340,6 +1552,29 @@ class NativeBindings implements GhosttyBindings {
       _outBool.cast(),
     );
     return (result, _outBool.value);
+  }
+
+  @override
+  CResult<RawRowIteratorSummary> rowIteratorGetSummary(int iterator) {
+    const keys = _rowIteratorSummaryKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
+    }
+    final result = ghostty_render_state_row_get_multi(
+      Pointer.fromAddress(iterator),
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
+    );
+    return (
+      result,
+      (
+        dirty: (_multiOut + 0).cast<Bool>().value,
+        rawRow: (_multiOut + 1).value,
+      ),
+    );
   }
 
   @override
@@ -1427,6 +1662,25 @@ class NativeBindings implements GhosttyBindings {
       _outU64.cast(),
     );
     return (result, _outU64.value);
+  }
+
+  @override
+  CResult<RawRowCellsSummary> rowCellsGetSummary(int cells) {
+    final result = ghostty_render_state_row_cells_get_multi(
+      Pointer.fromAddress(cells),
+      _rowCellsSummaryKeys.length,
+      _rowCellsMultiKeys,
+      _rowCellsMultiValues,
+      _outSize,
+    );
+    return (
+      result,
+      (
+        rawCell: (_rowCellsMultiOut + 0).value,
+        graphemeLen: (_rowCellsMultiOut + 1).cast<Uint32>().value,
+        selected: (_rowCellsMultiOut + 2).cast<Bool>().value,
+      ),
+    );
   }
 
   @override
@@ -1571,6 +1825,25 @@ class NativeBindings implements GhosttyBindings {
   CResult<int> cellGetCodepoint(int cell) => _cellGetU32(cell, .codepoint);
 
   @override
+  CResult<RawCellSummary> cellGetSummary(int cell) {
+    final result = ghostty_cell_get_multi(
+      cell,
+      _cellSummaryKeys.length,
+      _cellMultiKeys,
+      _cellMultiValues,
+      _outSize,
+    );
+    return (
+      result,
+      (
+        codepoint: (_cellMultiOut + 0).cast<Uint32>().value,
+        styleId: (_cellMultiOut + 1).cast<Uint16>().value,
+        wide: .fromValue((_cellMultiOut + 2).cast<Int32>().value),
+      ),
+    );
+  }
+
+  @override
   CResult<CellContentTag> cellGetContentTag(int cell) {
     final raw = _cellGetI32(cell, .contentTag);
     return (raw.$1, CellContentTag.fromValue(raw.$2));
@@ -1653,6 +1926,34 @@ class NativeBindings implements GhosttyBindings {
 
   @override
   CResult<bool> rowGetDirty(int row) => _rowGetBool(row, .dirty);
+
+  @override
+  CResult<RawRowSummary> rowGetSummary(int row) {
+    const keys = _rowSummaryKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
+    }
+    final result = ghostty_row_get_multi(
+      row,
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
+    );
+    return (
+      result,
+      (
+        wrap: (_multiOut + 0).cast<Bool>().value,
+        wrapContinuation: (_multiOut + 1).cast<Bool>().value,
+        grapheme: (_multiOut + 2).cast<Bool>().value,
+        styled: (_multiOut + 3).cast<Bool>().value,
+        hyperlink: (_multiOut + 4).cast<Bool>().value,
+        semanticPrompt: .fromValue((_multiOut + 5).cast<Int32>().value),
+        kittyVirtualPlaceholder: (_multiOut + 6).cast<Bool>().value,
+      ),
+    );
+  }
 
   @override
   CResult<String> focusEncode(FocusEvent event) {
@@ -1863,6 +2164,28 @@ class NativeBindings implements GhosttyBindings {
       _outBool.cast(),
     );
     return (result, _outBool.value);
+  }
+
+  Result _terminalGetMulti(int handle, List<TerminalData> keys) {
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
+    }
+    return ghostty_terminal_get_multi(
+      Pointer.fromAddress(handle),
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
+    );
+  }
+
+  void _growFormatBuffer(int capacity) {
+    if (capacity <= _formatBufferCapacity) return;
+    final replacement = calloc<Uint8>(capacity);
+    calloc.free(_formatBuffer);
+    _formatBuffer = replacement;
+    _formatBufferCapacity = capacity;
   }
 
   CResult<int> _cellGetU32(int cell, CellData data) {
@@ -2623,8 +2946,6 @@ class NativeBindings implements GhosttyBindings {
   }) {
     return using((arena) {
       final opts = arena<TerminalSelectionFormatOptions>();
-      final outPtr = arena<Pointer<Uint8>>();
-      final outLen = arena<Size>();
       opts.ref
         ..size = sizeOf<TerminalSelectionFormatOptions>()
         ..emitAsInt = format.value
@@ -2637,21 +2958,26 @@ class NativeBindings implements GhosttyBindings {
         _writeSelection(sel.ref, selection);
         opts.ref.selection = sel;
       }
-      final result = ghostty_terminal_selection_format_alloc(
+      var result = ghostty_terminal_selection_format_buf(
         Pointer.fromAddress(terminal),
-        nullptr,
         opts.ref,
-        outPtr,
-        outLen,
+        _formatBuffer,
+        _formatBufferCapacity,
+        _outSize,
       );
-      final len = outLen.value;
-      final buf = outPtr.value;
-      if (result != .success || len == 0 || buf == nullptr) {
-        return (result, '');
+      if (result == .outOfSpace) {
+        _growFormatBuffer(_outSize.value);
+        result = ghostty_terminal_selection_format_buf(
+          Pointer.fromAddress(terminal),
+          opts.ref,
+          _formatBuffer,
+          _formatBufferCapacity,
+          _outSize,
+        );
       }
-      final encoded = utf8.decode(buf.asTypedList(len));
-      ghostty_free(nullptr, buf, len);
-      return (result, encoded);
+      final len = _outSize.value;
+      if (result != .success || len == 0) return (result, '');
+      return (result, utf8.decode(_formatBuffer.asTypedList(len)));
     });
   }
 
@@ -2967,6 +3293,42 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawSelectionGestureState> selectionGestureGetState(
+    int gesture,
+    int terminal,
+  ) {
+    const keys = _selectionGestureStateKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
+    }
+    _multiGridRef.ref.size = sizeOf<GridRef>();
+    _multiValues[4] = _multiGridRef.cast();
+    final result = ghostty_selection_gesture_get_multi(
+      Pointer.fromAddress(gesture),
+      Pointer.fromAddress(terminal),
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
+    );
+    final anchorAbsent = result == .noValue && _outSize.value == 4;
+    if (result != .success && !anchorAbsent) {
+      return (result, _emptySelectionGestureState);
+    }
+    return (
+      anchorAbsent ? .success : result,
+      (
+        clickCount: (_multiOut + 0).cast<Uint8>().value,
+        dragged: (_multiOut + 1).cast<Bool>().value,
+        autoscroll: .fromValue((_multiOut + 2).cast<Int32>().value),
+        behavior: .fromValue((_multiOut + 3).cast<Int32>().value),
+        anchor: anchorAbsent ? null : _readGridRef(_multiGridRef.ref),
+      ),
+    );
+  }
+
+  @override
   CResult<int> formatterTerminalNew(
     int terminal,
     FormatterFormat format, {
@@ -3030,22 +3392,24 @@ class NativeBindings implements GhosttyBindings {
 
   @override
   CResult<String> formatterFormat(int formatter) {
-    return using((arena) {
-      final outPtr = arena<Pointer<Uint8>>();
-      final outLen = arena<Size>();
-      final result = ghostty_formatter_format_alloc(
+    var result = ghostty_formatter_format_buf(
+      Pointer.fromAddress(formatter),
+      _formatBuffer,
+      _formatBufferCapacity,
+      _outSize,
+    );
+    if (result == .outOfSpace) {
+      _growFormatBuffer(_outSize.value);
+      result = ghostty_formatter_format_buf(
         Pointer.fromAddress(formatter),
-        nullptr,
-        outPtr,
-        outLen,
+        _formatBuffer,
+        _formatBufferCapacity,
+        _outSize,
       );
-      final len = outLen.value;
-      final buf = outPtr.value;
-      if (len == 0 || buf == nullptr) return (result, '');
-      final encoded = utf8.decode(buf.cast<Uint8>().asTypedList(len));
-      ghostty_free(nullptr, buf, len);
-      return (result, encoded);
-    });
+    }
+    final len = _outSize.value;
+    if (result != .success || len == 0) return (result, '');
+    return (result, utf8.decode(_formatBuffer.asTypedList(len)));
   }
 
   @override
@@ -3601,29 +3965,23 @@ class NativeBindings implements GhosttyBindings {
   @override
   CResult<Uint8List> kittyGraphicsImageGetPixelData(int image) {
     if (image == 0) return (Result.invalidValue, Uint8List(0));
-    final ptrOut = calloc<Pointer<Uint8>>();
-    final lenOut = calloc<Size>();
-    try {
-      final ptrCode = ghostty_kitty_graphics_image_get(
-        Pointer.fromAddress(image),
-        KittyGraphicsImageData.dataPtr,
-        ptrOut.cast(),
-      );
-      if (ptrCode != Result.success) return (ptrCode, Uint8List(0));
-      final lenCode = ghostty_kitty_graphics_image_get(
-        Pointer.fromAddress(image),
-        KittyGraphicsImageData.dataLen,
-        lenOut.cast(),
-      );
-      if (lenCode != Result.success) return (lenCode, Uint8List(0));
-      final ptr = ptrOut.value;
-      final len = lenOut.value;
-      if (ptr == nullptr || len == 0) return (Result.success, Uint8List(0));
-      return (Result.success, Uint8List.fromList(ptr.asTypedList(len)));
-    } finally {
-      calloc.free(ptrOut);
-      calloc.free(lenOut);
+    const keys = _kittyImagePixelDataKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
     }
+    final result = ghostty_kitty_graphics_image_get_multi(
+      Pointer.fromAddress(image),
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
+    );
+    if (result != .success) return (result, Uint8List(0));
+    final ptr = (_multiOut + 0).cast<Pointer<Uint8>>().value;
+    final len = (_multiOut + 1).cast<Size>().value;
+    if (ptr == nullptr || len == 0) return (Result.success, Uint8List(0));
+    return (Result.success, Uint8List.fromList(ptr.asTypedList(len)));
   }
 
   CResult<int> _kittyImageGetU32(int image, KittyGraphicsImageData data) {
@@ -3706,39 +4064,34 @@ class NativeBindings implements GhosttyBindings {
   @override
   CResult<RawPlacement> kittyGraphicsPlacementGet(int iterator) {
     if (iterator == 0) return (Result.invalidValue, _emptyPlacement);
-    final iter = Pointer<KittyGraphicsPlacementIteratorImpl>.fromAddress(
-      iterator,
+    const keys = _kittyPlacementKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _multiKeys[i] = keys[i].value;
+      _multiValues[i] = (_multiOut + i).cast();
+    }
+    final result = ghostty_kitty_graphics_placement_get_multi(
+      Pointer.fromAddress(iterator),
+      keys.length,
+      _multiKeys,
+      _multiValues,
+      _outSize,
     );
-    int readU32(KittyGraphicsPlacementData tag) {
-      ghostty_kitty_graphics_placement_get(iter, tag, _outU32.cast());
-      return _outU32.value;
-    }
-
-    int readI32(KittyGraphicsPlacementData tag) {
-      ghostty_kitty_graphics_placement_get(iter, tag, _outI32.cast());
-      return _outI32.value;
-    }
-
-    bool readBool(KittyGraphicsPlacementData tag) {
-      ghostty_kitty_graphics_placement_get(iter, tag, _outBool.cast());
-      return _outBool.value;
-    }
-
+    if (result != .success) return (result, _emptyPlacement);
     return (
-      Result.success,
+      result,
       (
-        imageId: readU32(KittyGraphicsPlacementData.imageId),
-        placementId: readU32(KittyGraphicsPlacementData.placementId),
-        isVirtual: readBool(KittyGraphicsPlacementData.isVirtual),
-        xOffset: readU32(KittyGraphicsPlacementData.xOffset),
-        yOffset: readU32(KittyGraphicsPlacementData.yOffset),
-        sourceX: readU32(KittyGraphicsPlacementData.sourceX),
-        sourceY: readU32(KittyGraphicsPlacementData.sourceY),
-        sourceWidth: readU32(KittyGraphicsPlacementData.sourceWidth),
-        sourceHeight: readU32(KittyGraphicsPlacementData.sourceHeight),
-        columns: readU32(KittyGraphicsPlacementData.columns),
-        rows: readU32(KittyGraphicsPlacementData.rows),
-        z: readI32(KittyGraphicsPlacementData.z),
+        imageId: (_multiOut + 0).cast<Uint32>().value,
+        placementId: (_multiOut + 1).cast<Uint32>().value,
+        isVirtual: (_multiOut + 2).cast<Bool>().value,
+        xOffset: (_multiOut + 3).cast<Uint32>().value,
+        yOffset: (_multiOut + 4).cast<Uint32>().value,
+        sourceX: (_multiOut + 5).cast<Uint32>().value,
+        sourceY: (_multiOut + 6).cast<Uint32>().value,
+        sourceWidth: (_multiOut + 7).cast<Uint32>().value,
+        sourceHeight: (_multiOut + 8).cast<Uint32>().value,
+        columns: (_multiOut + 9).cast<Uint32>().value,
+        rows: (_multiOut + 10).cast<Uint32>().value,
+        z: (_multiOut + 11).cast<Int32>().value,
       ),
     );
   }

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -46,6 +46,60 @@ typedef RawGridRef = ({int node, int x, int y});
 /// text range.
 typedef RawSelection = ({RawGridRef start, RawGridRef end, bool rectangle});
 
+/// Terminal dimensions in cells and pixels.
+///
+/// `cols` and `rows` describe the active grid. `widthPx` and `heightPx`
+/// describe its total pixel extent and are zero when no pixel size has been
+/// configured.
+typedef TerminalGeometry = ({int cols, int rows, int widthPx, int heightPx});
+
+/// Render-state dimensions and dirty state returned by one batched query.
+typedef RawRenderStateSummary = ({int cols, int rows, RenderStateDirty dirty});
+
+/// Complete cursor data from one render-state snapshot query.
+///
+/// The viewport coordinates and wide-tail flag are meaningful only when
+/// `inViewport` is true.
+typedef RawRenderStateCursor = ({
+  RenderStateCursorVisualStyle visualStyle,
+  bool visible,
+  bool blinking,
+  bool passwordInput,
+  bool inViewport,
+  int viewportX,
+  int viewportY,
+  bool viewportWideTail,
+});
+
+/// Current render row data captured in one boundary query.
+typedef RawRowIteratorSummary = ({bool dirty, int rawRow});
+
+/// Scalar row metadata captured in one boundary query.
+typedef RawRowSummary = ({
+  bool wrap,
+  bool wrapContinuation,
+  bool grapheme,
+  bool styled,
+  bool hyperlink,
+  RowSemanticPrompt semanticPrompt,
+  bool kittyVirtualPlaceholder,
+});
+
+/// Current render cell data captured in one boundary query.
+typedef RawRowCellsSummary = ({int rawCell, int graphemeLen, bool selected});
+
+/// Scalar cell metadata captured in one boundary query.
+typedef RawCellSummary = ({int codepoint, int styleId, CellWide wide});
+
+/// Readable selection gesture state captured in one boundary query.
+typedef RawSelectionGestureState = ({
+  int clickCount,
+  bool dragged,
+  SelectionGestureAutoscroll autoscroll,
+  SelectionGestureBehavior behavior,
+  RawGridRef? anchor,
+});
+
 /// Callback invoked for each internal libghostty log message, after the
 /// scope and message byte slices have been decoded to Dart strings.
 typedef SysLogCallback =

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -52,6 +52,15 @@ JSObject _buildImports() {
 @JS('WebAssembly.instantiate')
 external JSPromise _wasmInstantiate(JSArrayBuffer bytes, JSObject imports);
 
+const _wasmEnumSize = 4;
+const _wasmPointerSize = 4;
+const _wasmSizeSize = 4;
+const _wasmOutputSlotSize = 8;
+const _maxMultiQueryCount = 12;
+
+final JSString _cellGetMultiMethod = 'ghostty_cell_get_multi'.toJS;
+final JSString _rowGetMultiMethod = 'ghostty_row_get_multi'.toJS;
+
 const RawPlacement _emptyPlacement = (
   imageId: 0,
   placementId: 0,
@@ -82,6 +91,84 @@ const RawPlacementRenderInfo _emptyRenderInfo = (
 );
 
 const RawGridRef _emptyGridRef = (node: 0, x: 0, y: 0);
+const TerminalGeometry _emptyTerminalGeometry = (
+  cols: 0,
+  rows: 0,
+  widthPx: 0,
+  heightPx: 0,
+);
+const RawRenderStateSummary _emptyRenderStateSummary = (
+  cols: 0,
+  rows: 0,
+  dirty: .false$,
+);
+const RawRenderStateCursor _emptyRenderStateCursor = (
+  visualStyle: .block,
+  visible: false,
+  blinking: false,
+  passwordInput: false,
+  inViewport: false,
+  viewportX: 0,
+  viewportY: 0,
+  viewportWideTail: false,
+);
+const RawSelectionGestureState _emptySelectionGestureState = (
+  clickCount: 0,
+  dragged: false,
+  autoscroll: .none,
+  behavior: .cell,
+  anchor: null,
+);
+
+const _rowIteratorSummaryKeys = <RenderStateRowData>[.dirty, .raw];
+const _rowCellsSummaryKeys = <RenderStateRowCellsData>[
+  .raw,
+  .graphemesLen,
+  .selected,
+];
+const _cellSummaryKeys = <CellData>[.codepoint, .styleId, .wide];
+const _rowSummaryKeys = <RowData>[
+  .wrap,
+  .wrapContinuation,
+  .grapheme,
+  .styled,
+  .hyperlink,
+  .semanticPrompt,
+  .kittyVirtualPlaceholder,
+];
+const _selectionGestureStateKeys = <SelectionGestureData>[
+  .clickCount,
+  .dragged,
+  .autoscroll,
+  .behavior,
+  .anchor,
+];
+const _kittyImagePixelDataKeys = <KittyGraphicsImageData>[.dataPtr, .dataLen];
+const _kittyPlacementKeys = <KittyGraphicsPlacementData>[
+  .imageId,
+  .placementId,
+  .isVirtual,
+  .xOffset,
+  .yOffset,
+  .sourceX,
+  .sourceY,
+  .sourceWidth,
+  .sourceHeight,
+  .columns,
+  .rows,
+  .z,
+];
+const _cursorStateKeys = <RenderStateData>[
+  .cursorVisualStyle,
+  .cursorVisible,
+  .cursorBlinking,
+  .cursorPasswordInput,
+  .cursorViewportHasValue,
+  .cursorViewportX,
+  .cursorViewportY,
+  .cursorViewportWideTail,
+];
+const _renderStateSummaryKeys = <RenderStateData>[.cols, .rows, .dirty];
 
 class WasmBindings implements GhosttyBindings {
   final Mem _mem;
@@ -91,6 +178,27 @@ class WasmBindings implements GhosttyBindings {
   final _utf8Ptrs = <int, (int ptr, int len)>{};
   final _callbacks = <int, Map<TerminalOption, (int index, Function fn)>>{};
   final _stringBufs = <int, Map<TerminalOption, (int ptr, int len)>>{};
+  final _cellGetMultiArguments = List<JSAny?>.filled(5, null);
+  final _rowGetMultiArguments = List<JSAny?>.filled(5, null);
+  late final int _multiKeys;
+  late final int _multiValues;
+  late final int _multiOut;
+  late final int _multiWritten;
+  late final int _multiGridRef;
+  late final int _renderStateSummaryMultiKeys;
+  late final int _renderStateSummaryMultiValues;
+  late final int _renderStateSummaryMultiOut;
+  late final int _cursorMultiKeys;
+  late final int _cursorMultiValues;
+  late final int _cursorMultiOut;
+  late final int _rowCellsMultiKeys;
+  late final int _rowCellsMultiValues;
+  late final int _rowCellsMultiOut;
+  late final int _cellMultiKeys;
+  late final int _cellMultiValues;
+  late final int _cellMultiOut;
+  late int _formatBuffer;
+  late int _formatBufferCapacity;
 
   WasmBindings._(JSObject exports)
     : _exports = GhosttyExports(exports),
@@ -102,6 +210,133 @@ class WasmBindings implements GhosttyBindings {
           )) {
     final json = jsonDecode(_mem.readCString(_exports.ghostty_type_json()));
     _layout = Layouts(json as Map<String, dynamic>);
+    _multiKeys = _allocateBytes(
+      _maxMultiQueryCount * _wasmEnumSize,
+      alignment: _wasmEnumSize,
+    );
+    _multiValues = _allocateBytes(
+      _maxMultiQueryCount * _wasmPointerSize,
+      alignment: _wasmPointerSize,
+    );
+    _multiOut = _allocateBytes(
+      _maxMultiQueryCount * _wasmOutputSlotSize,
+      alignment: _wasmOutputSlotSize,
+    );
+    _multiWritten = _allocateSize();
+    _multiGridRef = _allocateBytes(
+      _layout.gridRefSize,
+      alignment: _wasmPointerSize,
+    );
+    _renderStateSummaryMultiKeys = _allocateBytes(
+      _renderStateSummaryKeys.length * _wasmEnumSize,
+      alignment: _wasmEnumSize,
+    );
+    _renderStateSummaryMultiValues = _allocateBytes(
+      _renderStateSummaryKeys.length * _wasmPointerSize,
+      alignment: _wasmPointerSize,
+    );
+    _renderStateSummaryMultiOut = _allocateBytes(
+      _renderStateSummaryKeys.length * _wasmOutputSlotSize,
+      alignment: _wasmOutputSlotSize,
+    );
+    for (var i = 0; i < _renderStateSummaryKeys.length; i++) {
+      _mem.writeU32(
+        _renderStateSummaryMultiKeys + i * _wasmEnumSize,
+        _renderStateSummaryKeys[i].value,
+      );
+      _mem.writeU32(
+        _renderStateSummaryMultiValues + i * _wasmPointerSize,
+        _renderStateSummaryMultiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    _cursorMultiKeys = _allocateBytes(
+      _cursorStateKeys.length * _wasmEnumSize,
+      alignment: _wasmEnumSize,
+    );
+    _cursorMultiValues = _allocateBytes(
+      _cursorStateKeys.length * _wasmPointerSize,
+      alignment: _wasmPointerSize,
+    );
+    _cursorMultiOut = _allocateBytes(
+      _cursorStateKeys.length * _wasmOutputSlotSize,
+      alignment: _wasmOutputSlotSize,
+    );
+    for (var i = 0; i < _cursorStateKeys.length; i++) {
+      _mem.writeU32(
+        _cursorMultiKeys + i * _wasmEnumSize,
+        _cursorStateKeys[i].value,
+      );
+      _mem.writeU32(
+        _cursorMultiValues + i * _wasmPointerSize,
+        _cursorMultiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    _rowCellsMultiKeys = _allocateBytes(
+      _rowCellsSummaryKeys.length * _wasmEnumSize,
+      alignment: _wasmEnumSize,
+    );
+    _rowCellsMultiValues = _allocateBytes(
+      _rowCellsSummaryKeys.length * _wasmPointerSize,
+      alignment: _wasmPointerSize,
+    );
+    _rowCellsMultiOut = _allocateBytes(
+      _rowCellsSummaryKeys.length * _wasmOutputSlotSize,
+      alignment: _wasmOutputSlotSize,
+    );
+    for (var i = 0; i < _rowCellsSummaryKeys.length; i++) {
+      _mem.writeU32(
+        _rowCellsMultiKeys + i * _wasmEnumSize,
+        _rowCellsSummaryKeys[i].value,
+      );
+      _mem.writeU32(
+        _rowCellsMultiValues + i * _wasmPointerSize,
+        _rowCellsMultiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    _cellMultiKeys = _allocateBytes(
+      _cellSummaryKeys.length * _wasmEnumSize,
+      alignment: _wasmEnumSize,
+    );
+    _cellMultiValues = _allocateBytes(
+      _cellSummaryKeys.length * _wasmPointerSize,
+      alignment: _wasmPointerSize,
+    );
+    _cellMultiOut = _allocateBytes(
+      _cellSummaryKeys.length * _wasmOutputSlotSize,
+      alignment: _wasmOutputSlotSize,
+    );
+    for (var i = 0; i < _cellSummaryKeys.length; i++) {
+      _mem.writeU32(
+        _cellMultiKeys + i * _wasmEnumSize,
+        _cellSummaryKeys[i].value,
+      );
+      _mem.writeU32(
+        _cellMultiValues + i * _wasmPointerSize,
+        _cellMultiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    _formatBufferCapacity = 4096;
+    _formatBuffer = _allocateBytes(_formatBufferCapacity);
+  }
+
+  int _allocateBytes(int size, {int alignment = 1}) {
+    final pointer = _exports.ghostty_wasm_alloc_u8_array(size);
+    if (pointer == 0) throw const OutOfMemoryException();
+    if (pointer % alignment != 0) {
+      _exports.ghostty_wasm_free_u8_array(pointer, size);
+      throw StateError('libghostty WASM allocator returned misaligned memory.');
+    }
+    return pointer;
+  }
+
+  int _allocateSize() {
+    final pointer = _exports.ghostty_wasm_alloc_usize();
+    if (pointer == 0) throw const OutOfMemoryException();
+    if (pointer % _wasmSizeSize != 0) {
+      _exports.ghostty_wasm_free_usize(pointer);
+      throw StateError('libghostty WASM allocator returned misaligned memory.');
+    }
+    return pointer;
   }
 
   int _registerCallback(
@@ -1013,6 +1248,22 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<TerminalGeometry> terminalGetGeometry(int handle) {
+    const keys = <TerminalData>[.cols, .rows, .widthPx, .heightPx];
+    final result = _terminalGetMulti(handle, keys);
+    if (result != .success) return (result, _emptyTerminalGeometry);
+    return (
+      result,
+      (
+        cols: _mem.readU16(_multiOut),
+        rows: _mem.readU16(_multiOut + _wasmOutputSlotSize),
+        widthPx: _mem.readU32(_multiOut + 2 * _wasmOutputSlotSize),
+        heightPx: _mem.readU32(_multiOut + 3 * _wasmOutputSlotSize),
+      ),
+    );
+  }
+
+  @override
   CResult<bool> terminalGetViewportActive(int handle) {
     return _terminalGetBool(handle, .viewportActive);
   }
@@ -1717,38 +1968,30 @@ class WasmBindings implements GhosttyBindings {
   @override
   CResult<Uint8List> kittyGraphicsImageGetPixelData(int image) {
     if (image == 0) return (Result.invalidValue, Uint8List(0));
-    final ptrOut = _exports.ghostty_wasm_alloc_opaque();
-    final lenOut = _exports.ghostty_wasm_alloc_usize();
-    try {
-      final ptrCode = _exports.ghostty_kitty_graphics_image_get(
-        image,
-        KittyGraphicsImageData.dataPtr.value,
-        ptrOut,
-      );
-      if (ptrCode != Result.success.value) {
-        return (Result.fromValue(ptrCode), Uint8List(0));
-      }
-      final lenCode = _exports.ghostty_kitty_graphics_image_get(
-        image,
-        KittyGraphicsImageData.dataLen.value,
-        lenOut,
-      );
-      if (lenCode != Result.success.value) {
-        return (Result.fromValue(lenCode), Uint8List(0));
-      }
-      final dataPtr = _mem.readPtr(ptrOut);
-      final dataLen = _mem.readU32(lenOut);
-      if (dataPtr == 0 || dataLen == 0) {
-        return (Result.success, Uint8List(0));
-      }
-      return (
-        Result.success,
-        Uint8List.fromList(_mem.readBytes(dataPtr, dataLen)),
-      );
-    } finally {
-      _exports.ghostty_wasm_free_opaque(ptrOut);
-      _exports.ghostty_wasm_free_usize(lenOut);
+    const keys = _kittyImagePixelDataKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * 4, keys[i].value);
+      _mem.writeU32(_multiValues + i * 4, _multiOut + i * 8);
     }
+    final result = Result.fromValue(
+      _exports.ghostty_kitty_graphics_image_get_multi(
+        image,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
+    );
+    if (result != .success) return (result, Uint8List(0));
+    final dataPtr = _mem.readPtr(_multiOut);
+    final dataLen = _mem.readU32(_multiOut + 8);
+    if (dataPtr == 0 || dataLen == 0) {
+      return (Result.success, Uint8List(0));
+    }
+    return (
+      Result.success,
+      Uint8List.fromList(_mem.readBytes(dataPtr, dataLen)),
+    );
   }
 
   CResult<int> _kittyImageGetU32(int image, KittyGraphicsImageData data) {
@@ -1832,38 +2075,36 @@ class WasmBindings implements GhosttyBindings {
   @override
   CResult<RawPlacement> kittyGraphicsPlacementGet(int iterator) {
     if (iterator == 0) return (Result.invalidValue, _emptyPlacement);
-    final out = _exports.ghostty_wasm_alloc_usize();
-    int readU32(KittyGraphicsPlacementData tag) {
-      _exports.ghostty_kitty_graphics_placement_get(iterator, tag.value, out);
-      return _mem.readU32(out);
+    const keys = _kittyPlacementKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * 4, keys[i].value);
+      _mem.writeU32(_multiValues + i * 4, _multiOut + i * 8);
     }
-
-    int readI32(KittyGraphicsPlacementData tag) {
-      _exports.ghostty_kitty_graphics_placement_get(iterator, tag.value, out);
-      return _mem.readI32(out);
-    }
-
-    bool readBool(KittyGraphicsPlacementData tag) {
-      _exports.ghostty_kitty_graphics_placement_get(iterator, tag.value, out);
-      return _mem.readU8(out) != 0;
-    }
-
-    final placement = (
-      imageId: readU32(KittyGraphicsPlacementData.imageId),
-      placementId: readU32(KittyGraphicsPlacementData.placementId),
-      isVirtual: readBool(KittyGraphicsPlacementData.isVirtual),
-      xOffset: readU32(KittyGraphicsPlacementData.xOffset),
-      yOffset: readU32(KittyGraphicsPlacementData.yOffset),
-      sourceX: readU32(KittyGraphicsPlacementData.sourceX),
-      sourceY: readU32(KittyGraphicsPlacementData.sourceY),
-      sourceWidth: readU32(KittyGraphicsPlacementData.sourceWidth),
-      sourceHeight: readU32(KittyGraphicsPlacementData.sourceHeight),
-      columns: readU32(KittyGraphicsPlacementData.columns),
-      rows: readU32(KittyGraphicsPlacementData.rows),
-      z: readI32(KittyGraphicsPlacementData.z),
+    final result = Result.fromValue(
+      _exports.ghostty_kitty_graphics_placement_get_multi(
+        iterator,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
     );
-    _exports.ghostty_wasm_free_usize(out);
-    return (Result.success, placement);
+    if (result != .success) return (result, _emptyPlacement);
+    final placement = (
+      imageId: _mem.readU32(_multiOut),
+      placementId: _mem.readU32(_multiOut + 8),
+      isVirtual: _mem.readU8(_multiOut + 16) != 0,
+      xOffset: _mem.readU32(_multiOut + 24),
+      yOffset: _mem.readU32(_multiOut + 32),
+      sourceX: _mem.readU32(_multiOut + 40),
+      sourceY: _mem.readU32(_multiOut + 48),
+      sourceWidth: _mem.readU32(_multiOut + 56),
+      sourceHeight: _mem.readU32(_multiOut + 64),
+      columns: _mem.readU32(_multiOut + 72),
+      rows: _mem.readU32(_multiOut + 80),
+      z: _mem.readI32(_multiOut + 88),
+    );
+    return (result, placement);
   }
 
   @override
@@ -1993,6 +2234,30 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawRenderStateSummary> renderStateGetSummary(int state) {
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_get_multi(
+        state,
+        _renderStateSummaryKeys.length,
+        _renderStateSummaryMultiKeys,
+        _renderStateSummaryMultiValues,
+        _multiWritten,
+      ),
+    );
+    if (result != .success) return (result, _emptyRenderStateSummary);
+    return (
+      result,
+      (
+        cols: _mem.readU16(_renderStateSummaryMultiOut),
+        rows: _mem.readU16(_renderStateSummaryMultiOut + _wasmOutputSlotSize),
+        dirty: .fromValue(
+          _mem.readI32(_renderStateSummaryMultiOut + 2 * _wasmOutputSlotSize),
+        ),
+      ),
+    );
+  }
+
+  @override
   Result renderStateSetDirty(int state, RenderStateDirty dirty) {
     final valPtr = _exports.ghostty_wasm_alloc_usize();
     _mem.writeI32(valPtr, dirty.value);
@@ -2086,6 +2351,64 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawRenderStateCursor> renderStateGetCursor(int state) {
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_get_multi(
+        state,
+        _cursorStateKeys.length,
+        _cursorMultiKeys,
+        _cursorMultiValues,
+        _multiWritten,
+      ),
+    );
+    final written = _mem.readU32(_multiWritten);
+    final cursorOffscreen = result == .invalidValue && written == 5;
+    if (result != .success && !cursorOffscreen) {
+      return (result, _emptyRenderStateCursor);
+    }
+    final visualStyle = RenderStateCursorVisualStyle.fromValue(
+      _mem.readI32(_cursorMultiOut),
+    );
+    final visible = _mem.readU8(_cursorMultiOut + _wasmOutputSlotSize) != 0;
+    final blinking =
+        _mem.readU8(_cursorMultiOut + 2 * _wasmOutputSlotSize) != 0;
+    final passwordInput =
+        _mem.readU8(_cursorMultiOut + 3 * _wasmOutputSlotSize) != 0;
+    final inViewport =
+        _mem.readU8(_cursorMultiOut + 4 * _wasmOutputSlotSize) != 0;
+    if (!inViewport) {
+      return (
+        .success,
+        (
+          visualStyle: visualStyle,
+          visible: visible,
+          blinking: blinking,
+          passwordInput: passwordInput,
+          inViewport: false,
+          viewportX: 0,
+          viewportY: 0,
+          viewportWideTail: false,
+        ),
+      );
+    }
+
+    return (
+      result,
+      (
+        visualStyle: visualStyle,
+        visible: visible,
+        blinking: blinking,
+        passwordInput: passwordInput,
+        inViewport: true,
+        viewportX: _mem.readU16(_cursorMultiOut + 5 * _wasmOutputSlotSize),
+        viewportY: _mem.readU16(_cursorMultiOut + 6 * _wasmOutputSlotSize),
+        viewportWideTail:
+            _mem.readU8(_cursorMultiOut + 7 * _wasmOutputSlotSize) != 0,
+      ),
+    );
+  }
+
+  @override
   CResult<int> rowIteratorNew() {
     final outPtr = _exports.ghostty_wasm_alloc_opaque();
     final result = Result.fromValue(
@@ -2132,6 +2455,34 @@ class WasmBindings implements GhosttyBindings {
     final value = _mem.readU8(outPtr) != 0;
     _exports.ghostty_wasm_free_u8(outPtr);
     return (result, value);
+  }
+
+  @override
+  CResult<RawRowIteratorSummary> rowIteratorGetSummary(int iterator) {
+    const keys = _rowIteratorSummaryKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * _wasmEnumSize, keys[i].value);
+      _mem.writeU32(
+        _multiValues + i * _wasmPointerSize,
+        _multiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_get_multi(
+        iterator,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
+    );
+    return (
+      result,
+      (
+        dirty: _mem.readU8(_multiOut) != 0,
+        rawRow: _mem.readU64(_multiOut + _wasmOutputSlotSize),
+      ),
+    );
   }
 
   @override
@@ -2238,6 +2589,27 @@ class WasmBindings implements GhosttyBindings {
     final value = _mem.readU64(outPtr);
     _exports.ghostty_wasm_free_u8_array(outPtr, u64Size);
     return (result, value);
+  }
+
+  @override
+  CResult<RawRowCellsSummary> rowCellsGetSummary(int cells) {
+    final result = Result.fromValue(
+      _exports.ghostty_render_state_row_cells_get_multi(
+        cells,
+        _rowCellsSummaryKeys.length,
+        _rowCellsMultiKeys,
+        _rowCellsMultiValues,
+        _multiWritten,
+      ),
+    );
+    return (
+      result,
+      (
+        rawCell: _mem.readU64(_rowCellsMultiOut),
+        graphemeLen: _mem.readU32(_rowCellsMultiOut + _wasmOutputSlotSize),
+        selected: _mem.readU8(_rowCellsMultiOut + 2 * _wasmOutputSlotSize) != 0,
+      ),
+    );
   }
 
   @override
@@ -2445,6 +2817,27 @@ class WasmBindings implements GhosttyBindings {
   CResult<int> cellGetCodepoint(int cell) => _cellGetU32(cell, .codepoint);
 
   @override
+  CResult<RawCellSummary> cellGetSummary(int cell) {
+    final result = Result.fromValue(
+      _callCellGetMulti(
+        cell,
+        _cellSummaryKeys.length,
+        _cellMultiKeys,
+        _cellMultiValues,
+        _multiWritten,
+      ),
+    );
+    return (
+      result,
+      (
+        codepoint: _mem.readU32(_cellMultiOut),
+        styleId: _mem.readU16(_cellMultiOut + _wasmOutputSlotSize),
+        wide: .fromValue(_mem.readI32(_cellMultiOut + 2 * _wasmOutputSlotSize)),
+      ),
+    );
+  }
+
+  @override
   CResult<CellContentTag> cellGetContentTag(int cell) {
     final raw = _cellGetI32(cell, .contentTag);
     return (raw.$1, CellContentTag.fromValue(raw.$2));
@@ -2534,6 +2927,42 @@ class WasmBindings implements GhosttyBindings {
 
   @override
   CResult<bool> rowGetDirty(int row) => _rowGetBool(row, .dirty);
+
+  @override
+  CResult<RawRowSummary> rowGetSummary(int row) {
+    const keys = _rowSummaryKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * _wasmEnumSize, keys[i].value);
+      _mem.writeU32(
+        _multiValues + i * _wasmPointerSize,
+        _multiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    final result = Result.fromValue(
+      _callRowGetMulti(
+        row,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
+    );
+    return (
+      result,
+      (
+        wrap: _mem.readU8(_multiOut) != 0,
+        wrapContinuation: _mem.readU8(_multiOut + _wasmOutputSlotSize) != 0,
+        grapheme: _mem.readU8(_multiOut + 2 * _wasmOutputSlotSize) != 0,
+        styled: _mem.readU8(_multiOut + 3 * _wasmOutputSlotSize) != 0,
+        hyperlink: _mem.readU8(_multiOut + 4 * _wasmOutputSlotSize) != 0,
+        semanticPrompt: .fromValue(
+          _mem.readI32(_multiOut + 5 * _wasmOutputSlotSize),
+        ),
+        kittyVirtualPlaceholder:
+            _mem.readU8(_multiOut + 6 * _wasmOutputSlotSize) != 0,
+      ),
+    );
+  }
 
   @override
   CResult<String> focusEncode(FocusEvent event) {
@@ -3155,8 +3584,6 @@ class WasmBindings implements GhosttyBindings {
     final optsPtr = _exports.ghostty_wasm_alloc_u8_array(
       _layout.selectionFormatSize,
     );
-    final outPtr = _exports.ghostty_wasm_alloc_opaque();
-    final outLen = _exports.ghostty_wasm_alloc_usize();
     _zero(optsPtr, _layout.selectionFormatSize);
     _mem.writeU32(optsPtr, _layout.selectionFormatSize);
     _mem.writeU32(optsPtr + _layout.selectionFormatEmit, format.value);
@@ -3167,29 +3594,35 @@ class WasmBindings implements GhosttyBindings {
       selPtr = _allocSelection(selection);
     }
     _mem.writeU32(optsPtr + _layout.selectionFormatSelection, selPtr);
-    final result = Result.fromValue(
-      _exports.ghostty_terminal_selection_format_alloc(
+    var result = Result.fromValue(
+      _exports.ghostty_terminal_selection_format_buf(
         terminal,
-        0,
         optsPtr,
-        outPtr,
-        outLen,
+        _formatBuffer,
+        _formatBufferCapacity,
+        _multiWritten,
       ),
     );
-    final dataPtr = _mem.readPtr(outPtr);
-    final len = _mem.readU32(outLen);
-    final value = result == .success && dataPtr != 0 && len > 0
-        ? utf8.decode(_mem.readBytes(dataPtr, len))
-        : '';
-    if (dataPtr != 0 && len > 0) {
-      _exports.ghostty_free(0, dataPtr, len);
+    if (result == .outOfSpace) {
+      _growFormatBuffer(_mem.readU32(_multiWritten));
+      result = Result.fromValue(
+        _exports.ghostty_terminal_selection_format_buf(
+          terminal,
+          optsPtr,
+          _formatBuffer,
+          _formatBufferCapacity,
+          _multiWritten,
+        ),
+      );
     }
+    final len = _mem.readU32(_multiWritten);
+    final value = result == .success && len > 0
+        ? utf8.decode(_mem.readBytes(_formatBuffer, len))
+        : '';
     if (selPtr != 0) {
       _exports.ghostty_wasm_free_u8_array(selPtr, _layout.selectionSize);
     }
     _exports.ghostty_wasm_free_u8_array(optsPtr, _layout.selectionFormatSize);
-    _exports.ghostty_wasm_free_opaque(outPtr);
-    _exports.ghostty_wasm_free_usize(outLen);
     return (result, value);
   }
 
@@ -3541,6 +3974,49 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  CResult<RawSelectionGestureState> selectionGestureGetState(
+    int gesture,
+    int terminal,
+  ) {
+    const keys = _selectionGestureStateKeys;
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * _wasmEnumSize, keys[i].value);
+      _mem.writeU32(
+        _multiValues + i * _wasmPointerSize,
+        _multiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    _writeGridRef(_multiGridRef, _emptyGridRef);
+    _mem.writeU32(_multiValues + 4 * _wasmPointerSize, _multiGridRef);
+    final result = Result.fromValue(
+      _exports.ghostty_selection_gesture_get_multi(
+        gesture,
+        terminal,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
+    );
+    final anchorAbsent = result == .noValue && _mem.readU32(_multiWritten) == 4;
+    if (result != .success && !anchorAbsent) {
+      return (result, _emptySelectionGestureState);
+    }
+    return (
+      anchorAbsent ? .success : result,
+      (
+        clickCount: _mem.readU8(_multiOut),
+        dragged: _mem.readU8(_multiOut + _wasmOutputSlotSize) != 0,
+        autoscroll: .fromValue(
+          _mem.readI32(_multiOut + 2 * _wasmOutputSlotSize),
+        ),
+        behavior: .fromValue(_mem.readI32(_multiOut + 3 * _wasmOutputSlotSize)),
+        anchor: anchorAbsent ? null : _readGridRef(_multiGridRef),
+      ),
+    );
+  }
+
+  @override
   CResult<int> formatterTerminalNew(
     int terminal,
     FormatterFormat format, {
@@ -3651,22 +4127,28 @@ class WasmBindings implements GhosttyBindings {
 
   @override
   CResult<String> formatterFormat(int formatter) {
-    final outPtr = _exports.ghostty_wasm_alloc_opaque();
-    final outLen = _exports.ghostty_wasm_alloc_usize();
-    final result = _exports.ghostty_formatter_format_alloc(
-      formatter,
-      0,
-      outPtr,
-      outLen,
+    var result = Result.fromValue(
+      _exports.ghostty_formatter_format_buf(
+        formatter,
+        _formatBuffer,
+        _formatBufferCapacity,
+        _multiWritten,
+      ),
     );
-    final len = _mem.readU32(outLen);
-    final buf = _mem.readPtr(outPtr);
-    _exports.ghostty_wasm_free_opaque(outPtr);
-    _exports.ghostty_wasm_free_usize(outLen);
-    if (len == 0 || buf == 0) return (.fromValue(result), '');
-    final encoded = utf8.decode(_mem.readBytes(buf, len));
-    _exports.ghostty_free(0, buf, len);
-    return (.fromValue(result), encoded);
+    if (result == .outOfSpace) {
+      _growFormatBuffer(_mem.readU32(_multiWritten));
+      result = Result.fromValue(
+        _exports.ghostty_formatter_format_buf(
+          formatter,
+          _formatBuffer,
+          _formatBufferCapacity,
+          _multiWritten,
+        ),
+      );
+    }
+    final len = _mem.readU32(_multiWritten);
+    if (result != .success || len == 0) return (result, '');
+    return (result, utf8.decode(_mem.readBytes(_formatBuffer, len)));
   }
 
   CResult<int> _terminalGetU16(int handle, TerminalData data) {
@@ -3860,6 +4342,33 @@ class WasmBindings implements GhosttyBindings {
     return (.fromValue(result), value);
   }
 
+  Result _terminalGetMulti(int handle, List<TerminalData> keys) {
+    for (var i = 0; i < keys.length; i++) {
+      _mem.writeU32(_multiKeys + i * _wasmEnumSize, keys[i].value);
+      _mem.writeU32(
+        _multiValues + i * _wasmPointerSize,
+        _multiOut + i * _wasmOutputSlotSize,
+      );
+    }
+    return .fromValue(
+      _exports.ghostty_terminal_get_multi(
+        handle,
+        keys.length,
+        _multiKeys,
+        _multiValues,
+        _multiWritten,
+      ),
+    );
+  }
+
+  void _growFormatBuffer(int capacity) {
+    if (capacity <= _formatBufferCapacity) return;
+    final replacement = _allocateBytes(capacity);
+    _exports.ghostty_wasm_free_u8_array(_formatBuffer, _formatBufferCapacity);
+    _formatBuffer = replacement;
+    _formatBufferCapacity = capacity;
+  }
+
   CResult<int> _renderStateGetI32(int state, RenderStateData data) {
     final outPtr = _exports.ghostty_wasm_alloc_usize();
     final result = _exports.ghostty_render_state_get(state, data.value, outPtr);
@@ -3920,6 +4429,29 @@ class WasmBindings implements GhosttyBindings {
         .toDartInt;
   }
 
+  int _callCellGetMulti(
+    int cell,
+    int count,
+    int keys,
+    int values,
+    int outWritten,
+  ) {
+    // WebAssembly exposes i64 parameters as JavaScript BigInt values, while
+    // Dart's typed callAsFunction overload accepts only four arguments. These
+    // C functions take five, so callMethodVarArgs is the supported bridge. The
+    // argument lists are reused because this path runs for every cell and row.
+    // https://api.dart.dev/dart-js_interop_unsafe/JSObjectUnsafeUtilExtension/callMethodVarArgs.html
+    final arguments = _cellGetMultiArguments;
+    arguments[0] = _toBigInt(cell);
+    arguments[1] = count.toJS;
+    arguments[2] = keys.toJS;
+    arguments[3] = values.toJS;
+    arguments[4] = outWritten.toJS;
+    return (_exports as JSObject)
+        .callMethodVarArgs<JSNumber>(_cellGetMultiMethod, arguments)
+        .toDartInt;
+  }
+
   int _callRowGet(int row, RowData data, int outPtr) {
     final fn = (_exports as JSObject)['ghostty_row_get']! as JSFunction;
     return (fn.callAsFunction(
@@ -3929,6 +4461,24 @@ class WasmBindings implements GhosttyBindings {
               outPtr.toJS,
             )!
             as JSNumber)
+        .toDartInt;
+  }
+
+  int _callRowGetMulti(
+    int row,
+    int count,
+    int keys,
+    int values,
+    int outWritten,
+  ) {
+    final arguments = _rowGetMultiArguments;
+    arguments[0] = _toBigInt(row);
+    arguments[1] = count.toJS;
+    arguments[2] = keys.toJS;
+    arguments[3] = values.toJS;
+    arguments[4] = outWritten.toJS;
+    return (_exports as JSObject)
+        .callMethodVarArgs<JSNumber>(_rowGetMultiMethod, arguments)
         .toDartInt;
   }
 

--- a/packages/libghostty/lib/src/impl/terminal/cell_iterator.dart
+++ b/packages/libghostty/lib/src/impl/terminal/cell_iterator.dart
@@ -35,6 +35,10 @@ final class CellIterator {
   var _cachedStyle = const Style();
   var _wide = CellWidth.narrow;
   var _col = -1;
+  var _isSelected = false;
+  var _textValid = false;
+  var _metadataValid = false;
+  var _selectedValid = false;
 
   /// Creates an unbound cell iterator.
   ///
@@ -60,7 +64,10 @@ final class CellIterator {
   }
 
   /// Primary codepoint of the current cell, or 0 if the cell has no text.
-  int get codepoint => _codepoint;
+  int get codepoint {
+    _ensureText();
+    return _codepoint;
+  }
 
   /// Column index of the current cell within the row (zero-based).
   ///
@@ -70,6 +77,7 @@ final class CellIterator {
   /// Full grapheme cluster of the current cell as a string, or empty if
   /// the cell has no text.
   String get content {
+    _ensureText();
     if (_graphemeLen == 0) return '';
     if (_graphemeLen == 1) return String.fromCharCode(_codepoint);
     return String.fromCharCodes(
@@ -95,35 +103,55 @@ final class CellIterator {
 
   /// Number of codepoints in the current cell's grapheme cluster (0 =
   /// empty).
-  int get graphemeLength => _graphemeLen;
+  int get graphemeLength {
+    _ensureText();
+    return _graphemeLen;
+  }
 
   /// Whether the current cell has a hyperlink (OSC 8).
-  bool get hasHyperlink => bindings.cellGetHasHyperlink(_rawCell).$2;
+  bool get hasHyperlink {
+    _ensureText();
+    return check(bindings.cellGetHasHyperlink(_rawCell));
+  }
 
   /// Whether the current cell has non-default styling attributes.
   bool get hasStyling => check(bindings.rowCellsGetHasStyling(_handle));
 
   /// Whether the current cell contains any text.
-  bool get hasText => _graphemeLen > 0;
+  bool get hasText {
+    _ensureText();
+    return _graphemeLen > 0;
+  }
 
   /// Whether the current cell is protected (DECSCA).
-  bool get isProtected => check(bindings.cellGetProtected(_rawCell));
+  bool get isProtected {
+    _ensureText();
+    return check(bindings.cellGetProtected(_rawCell));
+  }
 
-  /// Whether the current cell is contained withing the current selection.
+  /// Whether the current cell is contained within the current selection.
   ///
   /// Returns true when the cell's column is within the current row's
   /// row-local selection range, and false otherwise. Rendering colors,
   /// inversion, etc are caller policy.
-  bool get isSelected => check(bindings.rowCellsGetSelected(_handle));
+  bool get isSelected {
+    if (!_selectedValid) {
+      _isSelected = check(bindings.rowCellsGetSelected(_handle));
+      _selectedValid = true;
+    }
+    return _isSelected;
+  }
 
   /// Semantic content type of the current cell.
   SemanticContent get semanticContent {
+    _ensureText();
     return check(bindings.cellGetSemanticContent(_rawCell));
   }
 
   /// Style of the current cell. Cached per style id to avoid redundant
   /// lookups across cells sharing the same style.
   Style get style {
+    _ensureMetadata();
     if (_styleId != _prevStyleId) {
       _prevStyleId = _styleId;
       _cachedStyle = check(bindings.rowCellsGetStyle(_handle));
@@ -133,11 +161,17 @@ final class CellIterator {
 
   /// Internal style identifier for the current cell. Cells with the same
   /// style id share identical styling attributes.
-  int get styleId => _styleId;
+  int get styleId {
+    _ensureMetadata();
+    return _styleId;
+  }
 
   /// Cell width: [CellWidth.narrow], [CellWidth.wide], or
   /// [CellWidth.spacerTail] (the second cell of a wide character).
-  CellWidth get wide => _wide;
+  CellWidth get wide {
+    _ensureMetadata();
+    return _wide;
+  }
 
   /// Releases the native iterator handle.
   ///
@@ -154,7 +188,7 @@ final class CellIterator {
   bool next() {
     if (!bindings.rowCellsNext(_handle)) return false;
     _col++;
-    _refresh();
+    _invalidate();
     return true;
   }
 
@@ -168,6 +202,7 @@ final class CellIterator {
     checkCode(bindings.rowCellsInit(_handle, rowIterator._handle));
     _col = -1;
     _prevStyleId = -1;
+    _invalidate();
   }
 
   /// Positions the iterator at column [col] within the current row so
@@ -180,26 +215,35 @@ final class CellIterator {
   void select(int col) {
     checkCode(bindings.rowCellsSelect(_handle, col));
     _col = col;
-    _refresh();
+    _invalidate();
   }
 
-  void _refresh() {
-    _rawCell = check(bindings.rowCellsGetRawCell(_handle));
-    _graphemeLen = check(bindings.rowCellsGetGraphemeLen(_handle));
-    _styleId = check(bindings.cellGetStyleId(_rawCell));
-    _codepoint = _graphemeLen > 0
-        ? check(bindings.cellGetCodepoint(_rawCell))
-        : 0;
-    // Fast path: single-codepoint cells in narrow Unicode ranges are always
-    // narrow. All others need FFI: empty cells can be spacer tails, and
-    // multi-codepoint graphemes can be widened by VS16 (mode 2027).
-    _wide = _graphemeLen == 1 && !_couldBeWide(_codepoint)
-        ? .narrow
-        : bindings.cellGetWide(_rawCell).$2;
+  void _ensureMetadata() {
+    if (!_metadataValid) _refreshMetadata();
   }
 
-  // Codepoints below U+1100 are always narrow. Multi-codepoint cells still
-  // need the FFI check because emoji-base codepoints in that range (digits,
-  // `#`, `*`) can be widened by VS16 in a grapheme cluster.
-  static bool _couldBeWide(int codepoint) => codepoint >= 0x1100;
+  void _ensureText() {
+    if (!_textValid) _refreshMetadata();
+  }
+
+  void _invalidate() {
+    _textValid = false;
+    _metadataValid = false;
+    _selectedValid = false;
+  }
+
+  void _refreshMetadata() {
+    final rowCell = check(bindings.rowCellsGetSummary(_handle));
+    _rawCell = rowCell.rawCell;
+    _graphemeLen = rowCell.graphemeLen;
+    _isSelected = rowCell.selected;
+    _selectedValid = true;
+
+    final cell = check(bindings.cellGetSummary(_rawCell));
+    _styleId = cell.styleId;
+    _codepoint = _graphemeLen > 0 ? cell.codepoint : 0;
+    _wide = cell.wide;
+    _textValid = true;
+    _metadataValid = true;
+  }
 }

--- a/packages/libghostty/lib/src/impl/terminal/render_state.dart
+++ b/packages/libghostty/lib/src/impl/terminal/render_state.dart
@@ -97,35 +97,22 @@ final class RenderState {
   /// viewport, [Cursor.position] defaults to zero and [Cursor.wideTail]
   /// defaults to false.
   Cursor get cursor {
-    final inViewport = check(bindings.renderStateGetCursorInViewport(_handle));
-    final visible = check(bindings.renderStateGetCursorVisible(_handle));
-    final blinking = check(bindings.renderStateGetCursorBlinking(_handle));
-    final passwordInput = check(
-      bindings.renderStateGetCursorPasswordInput(_handle),
-    );
-    final visualStyle = check(
-      bindings.renderStateGetCursorVisualStyle(_handle),
-    );
-    if (!inViewport) {
+    final raw = check(bindings.renderStateGetCursor(_handle));
+    if (!raw.inViewport) {
       return Cursor(
-        visible: visible,
-        blinking: blinking,
-        passwordInput: passwordInput,
-        shape: visualStyle,
+        visible: raw.visible,
+        blinking: raw.blinking,
+        passwordInput: raw.passwordInput,
+        shape: raw.visualStyle,
       );
     }
-    final col = check(bindings.renderStateGetCursorViewportX(_handle));
-    final row = check(bindings.renderStateGetCursorViewportY(_handle));
-    final wideTail = check(
-      bindings.renderStateGetCursorViewportWideTail(_handle),
-    );
     return Cursor(
-      position: Position(row: row, col: col),
-      visible: visible,
-      blinking: blinking,
-      wideTail: wideTail,
-      passwordInput: passwordInput,
-      shape: visualStyle,
+      position: Position(row: raw.viewportY, col: raw.viewportX),
+      visible: raw.visible,
+      blinking: raw.blinking,
+      wideTail: raw.viewportWideTail,
+      passwordInput: raw.passwordInput,
+      shape: raw.visualStyle,
     );
   }
 
@@ -177,9 +164,10 @@ final class RenderState {
   /// that allocation fails.
   DirtyState update(Terminal terminal) {
     checkCode(bindings.renderStateUpdate(_handle, terminal._handle));
-    _dirty = DirtyState._fromRaw(check(bindings.renderStateGetDirty(_handle)));
-    _cols = check(bindings.renderStateGetCols(_handle));
-    _rows = check(bindings.renderStateGetRows(_handle));
+    final summary = check(bindings.renderStateGetSummary(_handle));
+    _dirty = DirtyState._fromRaw(summary.dirty);
+    _cols = summary.cols;
+    _rows = summary.rows;
     return _dirty;
   }
 }

--- a/packages/libghostty/lib/src/impl/terminal/row_iterator.dart
+++ b/packages/libghostty/lib/src/impl/terminal/row_iterator.dart
@@ -27,8 +27,8 @@ final class RowIterator {
 
   final int _handle;
 
-  var _cachedRawRow = 0;
-  var _rawRowValid = false;
+  late RawRowSummary _rowSummary;
+  var _rowSummaryValid = false;
   var _index = -1;
 
   /// Creates an unbound row iterator.
@@ -50,18 +50,28 @@ final class RowIterator {
 
   /// Whether any cell in the current row contains a grapheme cluster
   /// (multi-codepoint character).
-  bool get hasGrapheme => check(bindings.rowGetGrapheme(_rawRow));
+  bool get hasGrapheme {
+    _ensureMetadata();
+    return _rowSummary.grapheme;
+  }
 
   /// Whether any cell in the current row has a hyperlink (OSC 8).
-  bool get hasHyperlink => check(bindings.rowGetHyperlink(_rawRow));
+  bool get hasHyperlink {
+    _ensureMetadata();
+    return _rowSummary.hyperlink;
+  }
 
   /// Whether any cell in the current row has a Kitty virtual placeholder.
   bool get hasKittyVirtualPlaceholder {
-    return check(bindings.rowGetKittyVirtualPlaceholder(_rawRow));
+    _ensureMetadata();
+    return _rowSummary.kittyVirtualPlaceholder;
   }
 
   /// Whether any cell in the current row has non-default styling.
-  bool get hasStyled => check(bindings.rowGetStyled(_rawRow));
+  bool get hasStyled {
+    _ensureMetadata();
+    return _rowSummary.styled;
+  }
 
   /// Viewport-relative row index of the current row (zero-based).
   ///
@@ -80,22 +90,21 @@ final class RowIterator {
 
   /// Semantic prompt state of the current row.
   SemanticPrompt get semanticPrompt {
-    return check(bindings.rowGetSemanticPrompt(_rawRow));
+    _ensureMetadata();
+    return _rowSummary.semanticPrompt;
   }
 
   /// Whether the current row is soft-wrapped into the next row.
-  bool get wrap => check(bindings.rowGetWrap(_rawRow));
+  bool get wrap {
+    _ensureMetadata();
+    return _rowSummary.wrap;
+  }
 
   /// Whether the current row is a continuation of a soft-wrap from the
   /// previous row.
-  bool get wrapContinuation => check(bindings.rowGetWrapContinuation(_rawRow));
-
-  int get _rawRow {
-    if (!_rawRowValid) {
-      _cachedRawRow = check(bindings.rowIteratorGetRawRow(_handle));
-      _rawRowValid = true;
-    }
-    return _cachedRawRow;
+  bool get wrapContinuation {
+    _ensureMetadata();
+    return _rowSummary.wrapContinuation;
   }
 
   /// Releases the native iterator handle.
@@ -113,7 +122,7 @@ final class RowIterator {
   bool next() {
     final hasNext = bindings.rowIteratorNext(_handle);
     if (hasNext) {
-      _rawRowValid = false;
+      _rowSummaryValid = false;
       _index++;
     }
     return hasNext;
@@ -126,7 +135,17 @@ final class RowIterator {
   /// via [CellIterator.reset] before further use.
   void reset(RenderState renderState) {
     checkCode(bindings.rowIteratorInit(_handle, renderState._handle));
-    _rawRowValid = false;
+    _rowSummaryValid = false;
     _index = -1;
+  }
+
+  void _ensureMetadata() {
+    if (!_rowSummaryValid) _refreshMetadata();
+  }
+
+  void _refreshMetadata() {
+    final rawRow = check(bindings.rowIteratorGetRawRow(_handle));
+    _rowSummary = check(bindings.rowGetSummary(rawRow));
+    _rowSummaryValid = true;
   }
 }

--- a/packages/libghostty/lib/src/impl/terminal/selection_gesture.dart
+++ b/packages/libghostty/lib/src/impl/terminal/selection_gesture.dart
@@ -28,24 +28,15 @@ final class SelectionGesture {
 
   /// Current readable gesture state.
   SelectionGestureState get state {
-    final terminal = _terminal._handle;
-    final anchorResult = bindings.selectionGestureGetAnchor(_handle, terminal);
-    if (anchorResult.$1 != .success && anchorResult.$1 != .noValue) {
-      checkCode(anchorResult.$1);
-    }
-
+    final raw = check(
+      bindings.selectionGestureGetState(_handle, _terminal._handle),
+    );
     return SelectionGestureState(
-      clickCount: check(
-        bindings.selectionGestureGetClickCount(_handle, terminal),
-      ),
-      dragged: check(bindings.selectionGestureGetDragged(_handle, terminal)),
-      autoscroll: check(
-        bindings.selectionGestureGetAutoscroll(_handle, terminal),
-      ),
-      behavior: check(bindings.selectionGestureGetBehavior(_handle, terminal)),
-      anchor: anchorResult.$1 == .success
-          ? GridRef._fromValue(_terminal, anchorResult.$2)
-          : null,
+      clickCount: raw.clickCount,
+      dragged: raw.dragged,
+      autoscroll: raw.autoscroll,
+      behavior: raw.behavior,
+      anchor: raw.anchor == null ? null : ._fromValue(_terminal, raw.anchor!),
     );
   }
 

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -190,6 +190,16 @@ final class Terminal with Listenable {
     return _optionalColor(bindings.terminalGetColorForegroundDefault(_handle));
   }
 
+  /// Current terminal dimensions in cells and pixels.
+  ///
+  /// Pixel dimensions are zero when no cell pixel size has been configured.
+  ///
+  /// ```dart
+  /// final geometry = terminal.geometry;
+  /// final cellWidth = geometry.widthPx ~/ geometry.cols;
+  /// ```
+  TerminalGeometry get geometry => check(bindings.terminalGetGeometry(_handle));
+
   /// Total terminal height in pixels (rows * cell height).
   int get heightPx => check(bindings.terminalGetHeightPx(_handle));
 
@@ -502,9 +512,6 @@ final class Terminal with Listenable {
   /// Scrolls the viewport to the bottom (active area).
   void scrollToBottom() => bindings.terminalScrollViewport(_handle, .bottom, 0);
 
-  /// Scrolls the viewport to the top of the scrollback history.
-  void scrollToTop() => bindings.terminalScrollViewport(_handle, .top, 0);
-
   /// Scrolls the viewport to an absolute row in the scrollable area.
   ///
   /// Row zero is the top of scrollback. The requested row becomes the first
@@ -518,6 +525,9 @@ final class Terminal with Listenable {
     RangeError.checkNotNegative(row, 'row');
     bindings.terminalScrollViewport(_handle, .row, row);
   }
+
+  /// Scrolls the viewport to the top of the scrollback history.
+  void scrollToTop() => bindings.terminalScrollViewport(_handle, .top, 0);
 
   /// Scrolls the viewport by [delta] rows. Positive values scroll down
   /// (toward the active area), negative values scroll up (toward history).

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -122,6 +122,119 @@ void main() {
       });
     });
 
+    group('renderStateGetSummary', () {
+      test('returns the current render state snapshot', () {
+        checkCode(bindings.renderStateUpdate(renderState, terminal));
+
+        final summary = check(bindings.renderStateGetSummary(renderState));
+        const RawRenderStateSummary expected = (
+          cols: 80,
+          rows: 24,
+          dirty: .full,
+        );
+
+        expect(summary, expected);
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.renderStateGetSummary(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (cols: 0, rows: 0, dirty: RenderStateDirty.false$),
+        ));
+      });
+    });
+
+    group('renderStateGetCursor', () {
+      test('returns the current cursor snapshot', () {
+        bindings.terminalVtWrite(terminal, Uint8List.fromList('ABC'.codeUnits));
+        checkCode(bindings.renderStateUpdate(renderState, terminal));
+
+        final cursor = check(bindings.renderStateGetCursor(renderState));
+        const RawRenderStateCursor expected = (
+          visualStyle: .block,
+          visible: true,
+          blinking: false,
+          passwordInput: false,
+          inViewport: true,
+          viewportX: 3,
+          viewportY: 0,
+          viewportWideTail: false,
+        );
+
+        expect(cursor, expected);
+      });
+
+      test('omits viewport coordinates for an offscreen cursor', () {
+        final scrolledTerminal = check(bindings.terminalNew(5, 2, 100));
+        addTearDown(() => bindings.terminalFree(scrolledTerminal));
+        final scrolledRenderState = check(bindings.renderStateNew());
+        addTearDown(() => bindings.renderStateFree(scrolledRenderState));
+        bindings.terminalVtWrite(
+          scrolledTerminal,
+          Uint8List.fromList('one\r\ntwo\r\nthree'.codeUnits),
+        );
+        bindings.terminalScrollViewport(scrolledTerminal, .delta, -1);
+        checkCode(
+          bindings.renderStateUpdate(scrolledRenderState, scrolledTerminal),
+        );
+
+        final cursor = check(
+          bindings.renderStateGetCursor(scrolledRenderState),
+        );
+        const RawRenderStateCursor expected = (
+          visualStyle: .block,
+          visible: true,
+          blinking: false,
+          passwordInput: false,
+          inViewport: false,
+          viewportX: 0,
+          viewportY: 0,
+          viewportWideTail: false,
+        );
+
+        expect(cursor, expected);
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.renderStateGetCursor(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (
+            visualStyle: RenderStateCursorVisualStyle.block,
+            visible: false,
+            blinking: false,
+            passwordInput: false,
+            inViewport: false,
+            viewportX: 0,
+            viewportY: 0,
+            viewportWideTail: false,
+          ),
+        ));
+      });
+    });
+
+    group('terminalGetGeometry', () {
+      test('returns the current terminal geometry', () {
+        checkCode(bindings.terminalResize(terminal, 40, 10, 8, 16));
+
+        final geometry = check(bindings.terminalGetGeometry(terminal));
+
+        expect(geometry, (cols: 40, rows: 10, widthPx: 320, heightPx: 160));
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.terminalGetGeometry(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (cols: 0, rows: 0, widthPx: 0, heightPx: 0),
+        ));
+      });
+    });
+
     group('terminalModeGet', () {
       test('reflects terminalModeSet value', () {
         expect(
@@ -625,6 +738,64 @@ void main() {
   });
 
   group('row iterator data', () {
+    int firstRowIterator(String text) {
+      final terminal = check(bindings.terminalNew(10, 3, 0));
+      final renderState = check(bindings.renderStateNew());
+      final iterator = check(bindings.rowIteratorNew());
+      addTearDown(() => bindings.rowIteratorFree(iterator));
+      addTearDown(() => bindings.renderStateFree(renderState));
+      addTearDown(() => bindings.terminalFree(terminal));
+      bindings.terminalVtWrite(terminal, Uint8List.fromList(utf8.encode(text)));
+      checkCode(bindings.renderStateUpdate(renderState, terminal));
+      checkCode(bindings.rowIteratorInit(iterator, renderState));
+      expect(bindings.rowIteratorNext(iterator), isTrue);
+      return iterator;
+    }
+
+    group('rowIteratorGetSummary', () {
+      test('returns the current render row snapshot', () {
+        final iterator = _selectedRowIterator(0);
+
+        final summary = check(bindings.rowIteratorGetSummary(iterator));
+
+        expect((summary.dirty, summary.rawRow != 0), (true, true));
+      });
+
+      test('rejects an invalid handle', () {
+        final (code, _) = bindings.rowIteratorGetSummary(0);
+
+        expect(code, Result.invalidValue);
+      });
+
+      test('preserves packed row bits above 32 bits', () {
+        final iterator = firstRowIterator('\x1b[1mA');
+
+        final summary = check(bindings.rowIteratorGetSummary(iterator));
+
+        expect(summary.rawRow, greaterThan(0xFFFFFFFF));
+      });
+    });
+
+    group('rowGetSummary', () {
+      test('returns the current row metadata', () {
+        final iterator = _selectedRowIterator(0);
+        final rawRow = check(bindings.rowIteratorGetRawRow(iterator));
+
+        final summary = check(bindings.rowGetSummary(rawRow));
+        const RawRowSummary expected = (
+          wrap: false,
+          wrapContinuation: false,
+          grapheme: false,
+          styled: false,
+          hyperlink: false,
+          semanticPrompt: .none,
+          kittyVirtualPlaceholder: false,
+        );
+
+        expect(summary, expected);
+      });
+    });
+
     group('rowIteratorGetSelection', () {
       test('returns noValue for an unselected row', () {
         final iterator = _selectedRowIterator(0);
@@ -646,6 +817,48 @@ void main() {
   });
 
   group('row cells data', () {
+    group('rowCellsGetSummary', () {
+      test('returns the current render cell snapshot', () {
+        final cells = _firstCellCells('A');
+
+        final summary = check(bindings.rowCellsGetSummary(cells));
+
+        expect(
+          (
+            rawCellPresent: summary.rawCell != 0,
+            graphemeLen: summary.graphemeLen,
+            selected: summary.selected,
+          ),
+          (rawCellPresent: true, graphemeLen: 1, selected: false),
+        );
+      });
+
+      test('rejects an invalid handle', () {
+        final (code, _) = bindings.rowCellsGetSummary(0);
+
+        expect(code, Result.invalidValue);
+      });
+    });
+
+    group('cellGetSummary', () {
+      test('returns cell metadata', () {
+        final cells = _firstCellCells('A');
+        final rawCell = check(bindings.rowCellsGetRawCell(cells));
+
+        final summary = check(bindings.cellGetSummary(rawCell));
+
+        expect(summary, (codepoint: 0x41, styleId: 0, wide: CellWide.narrow));
+      });
+
+      test('preserves packed cell bits above 32 bits', () {
+        final cells = _firstCellCells('\u754C');
+
+        final summary = check(bindings.rowCellsGetSummary(cells));
+
+        expect(summary.rawCell, greaterThan(0xFFFFFFFF));
+      });
+    });
+
     group('rowCellsGetSelected', () {
       test('returns true for a selected cell', () {
         final cells = _selectedRowCells(2);
@@ -694,6 +907,48 @@ void main() {
 
         expect(code, Result.success);
         expect(value, isTrue);
+      });
+    });
+  });
+
+  group('selection gesture data', () {
+    group('selectionGestureGetState', () {
+      test('returns the initial gesture state', () {
+        final terminal = check(bindings.terminalNew(80, 24, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+        final gesture = check(bindings.selectionGestureNew());
+        addTearDown(() => bindings.selectionGestureFree(gesture, terminal));
+
+        final state = check(
+          bindings.selectionGestureGetState(gesture, terminal),
+        );
+        const RawSelectionGestureState expected = (
+          clickCount: 0,
+          dragged: false,
+          autoscroll: .none,
+          behavior: .cell,
+          anchor: null,
+        );
+
+        expect(state, expected);
+      });
+
+      test('rejects an invalid gesture handle', () {
+        final terminal = check(bindings.terminalNew(80, 24, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+
+        final result = bindings.selectionGestureGetState(0, terminal);
+
+        expect(result, (
+          Result.invalidValue,
+          (
+            clickCount: 0,
+            dragged: false,
+            autoscroll: SelectionGestureAutoscroll.none,
+            behavior: SelectionGestureBehavior.cell,
+            anchor: null,
+          ),
+        ));
       });
     });
   });
@@ -823,6 +1078,66 @@ void main() {
     tearDown(() => bindings.terminalFree(terminal));
 
     group('formatterFormat', () {
+      ({int terminal, String expected}) largeContentFixture() {
+        final terminal = check(bindings.terminalNew(6000, 1, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+        final expected = String.fromCharCodes(List<int>.filled(5000, 0x41));
+        bindings.terminalVtWrite(
+          terminal,
+          Uint8List.fromList(expected.codeUnits),
+        );
+        return (terminal: terminal, expected: expected);
+      }
+
+      int plainFormatter(int terminal) {
+        final formatter = check(
+          bindings.formatterTerminalNew(terminal, .plain, trim: true),
+        );
+        addTearDown(() => bindings.formatterFree(formatter));
+        return formatter;
+      }
+
+      test('rejects an invalid formatter handle', () {
+        final (code, _) = bindings.formatterFormat(0);
+
+        expect(code, Result.invalidValue);
+      });
+
+      test('returns content beyond the initial buffer capacity', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final formatter = plainFormatter(terminal);
+
+        final text = check(bindings.formatterFormat(formatter));
+
+        expect(text, expected);
+      });
+
+      test('returns content after reusing a grown buffer', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final formatter = plainFormatter(terminal);
+        check(bindings.formatterFormat(formatter));
+
+        final text = check(bindings.formatterFormat(formatter));
+
+        expect(text, expected);
+      });
+
+      test('formats selected content beyond the initial buffer capacity', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final selection = check(bindings.terminalSelectAll(terminal));
+
+        final text = check(
+          bindings.terminalSelectionFormat(
+            terminal,
+            .plain,
+            trim: true,
+            selection: selection,
+          ),
+        );
+
+        expect(text, expected);
+      });
+
       test('returns terminal content for plain format', () {
         final (_, formatter) = bindings.formatterTerminalNew(
           terminal,

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -35,6 +35,16 @@ void main() {
       });
     });
 
+    group('geometry', () {
+      test('returns cell and pixel dimensions', () {
+        terminal.resize(cols: 40, rows: 10, cellWidthPx: 8, cellHeightPx: 16);
+
+        final result = terminal.geometry;
+
+        expect(result, (cols: 40, rows: 10, widthPx: 320, heightPx: 160));
+      });
+    });
+
     group('write', () {
       test('updates screen cells', () {
         terminal.write(Uint8List.fromList('Hello'.codeUnits));

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -153,6 +153,119 @@ void main() {
       });
     });
 
+    group('renderStateGetSummary', () {
+      test('returns the current render state snapshot', () {
+        checkCode(bindings.renderStateUpdate(renderState, terminal));
+
+        final summary = check(bindings.renderStateGetSummary(renderState));
+        const RawRenderStateSummary expected = (
+          cols: 80,
+          rows: 24,
+          dirty: .full,
+        );
+
+        expect(summary, expected);
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.renderStateGetSummary(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (cols: 0, rows: 0, dirty: RenderStateDirty.false$),
+        ));
+      });
+    });
+
+    group('renderStateGetCursor', () {
+      test('returns the current cursor snapshot', () {
+        bindings.terminalVtWrite(terminal, Uint8List.fromList('ABC'.codeUnits));
+        checkCode(bindings.renderStateUpdate(renderState, terminal));
+
+        final cursor = check(bindings.renderStateGetCursor(renderState));
+        const RawRenderStateCursor expected = (
+          visualStyle: .block,
+          visible: true,
+          blinking: false,
+          passwordInput: false,
+          inViewport: true,
+          viewportX: 3,
+          viewportY: 0,
+          viewportWideTail: false,
+        );
+
+        expect(cursor, expected);
+      });
+
+      test('omits viewport coordinates for an offscreen cursor', () {
+        final scrolledTerminal = check(bindings.terminalNew(5, 2, 100));
+        addTearDown(() => bindings.terminalFree(scrolledTerminal));
+        final scrolledRenderState = check(bindings.renderStateNew());
+        addTearDown(() => bindings.renderStateFree(scrolledRenderState));
+        bindings.terminalVtWrite(
+          scrolledTerminal,
+          Uint8List.fromList('one\r\ntwo\r\nthree'.codeUnits),
+        );
+        bindings.terminalScrollViewport(scrolledTerminal, .delta, -1);
+        checkCode(
+          bindings.renderStateUpdate(scrolledRenderState, scrolledTerminal),
+        );
+
+        final cursor = check(
+          bindings.renderStateGetCursor(scrolledRenderState),
+        );
+        const RawRenderStateCursor expected = (
+          visualStyle: .block,
+          visible: true,
+          blinking: false,
+          passwordInput: false,
+          inViewport: false,
+          viewportX: 0,
+          viewportY: 0,
+          viewportWideTail: false,
+        );
+
+        expect(cursor, expected);
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.renderStateGetCursor(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (
+            visualStyle: RenderStateCursorVisualStyle.block,
+            visible: false,
+            blinking: false,
+            passwordInput: false,
+            inViewport: false,
+            viewportX: 0,
+            viewportY: 0,
+            viewportWideTail: false,
+          ),
+        ));
+      });
+    });
+
+    group('terminalGetGeometry', () {
+      test('returns the current terminal geometry', () {
+        checkCode(bindings.terminalResize(terminal, 40, 10, 8, 16));
+
+        final geometry = check(bindings.terminalGetGeometry(terminal));
+
+        expect(geometry, (cols: 40, rows: 10, widthPx: 320, heightPx: 160));
+      });
+
+      test('rejects an invalid handle', () {
+        final result = bindings.terminalGetGeometry(0);
+
+        expect(result, (
+          Result.invalidValue,
+          (cols: 0, rows: 0, widthPx: 0, heightPx: 0),
+        ));
+      });
+    });
+
     group('terminalModeGet', () {
       test('reflects terminalModeSet value', () {
         expect(
@@ -660,6 +773,64 @@ void main() {
   });
 
   group('row iterator data', () {
+    int firstRowIterator(String text) {
+      final terminal = check(bindings.terminalNew(10, 3, 0));
+      final renderState = check(bindings.renderStateNew());
+      final iterator = check(bindings.rowIteratorNew());
+      addTearDown(() => bindings.rowIteratorFree(iterator));
+      addTearDown(() => bindings.renderStateFree(renderState));
+      addTearDown(() => bindings.terminalFree(terminal));
+      bindings.terminalVtWrite(terminal, Uint8List.fromList(utf8.encode(text)));
+      checkCode(bindings.renderStateUpdate(renderState, terminal));
+      checkCode(bindings.rowIteratorInit(iterator, renderState));
+      expect(bindings.rowIteratorNext(iterator), isTrue);
+      return iterator;
+    }
+
+    group('rowIteratorGetSummary', () {
+      test('returns the current render row snapshot', () {
+        final iterator = _selectedRowIterator(0);
+
+        final summary = check(bindings.rowIteratorGetSummary(iterator));
+
+        expect((summary.dirty, summary.rawRow != 0), (true, true));
+      });
+
+      test('rejects an invalid handle', () {
+        final (code, _) = bindings.rowIteratorGetSummary(0);
+
+        expect(code, Result.invalidValue);
+      });
+
+      test('preserves packed row bits above 32 bits', () {
+        final iterator = firstRowIterator('\x1b[1mA');
+
+        final summary = check(bindings.rowIteratorGetSummary(iterator));
+
+        expect(summary.rawRow, greaterThan(0xFFFFFFFF));
+      });
+    });
+
+    group('rowGetSummary', () {
+      test('returns the current row metadata', () {
+        final iterator = _selectedRowIterator(0);
+        final rawRow = check(bindings.rowIteratorGetRawRow(iterator));
+
+        final summary = check(bindings.rowGetSummary(rawRow));
+        const RawRowSummary expected = (
+          wrap: false,
+          wrapContinuation: false,
+          grapheme: false,
+          styled: false,
+          hyperlink: false,
+          semanticPrompt: .none,
+          kittyVirtualPlaceholder: false,
+        );
+
+        expect(summary, expected);
+      });
+    });
+
     group('rowIteratorGetSelection', () {
       test('returns noValue for an unselected row', () {
         final iterator = _selectedRowIterator(0);
@@ -681,6 +852,48 @@ void main() {
   });
 
   group('row cells data', () {
+    group('rowCellsGetSummary', () {
+      test('returns the current render cell snapshot', () {
+        final cells = _firstCellCells('A');
+
+        final summary = check(bindings.rowCellsGetSummary(cells));
+
+        expect(
+          (
+            rawCellPresent: summary.rawCell != 0,
+            graphemeLen: summary.graphemeLen,
+            selected: summary.selected,
+          ),
+          (rawCellPresent: true, graphemeLen: 1, selected: false),
+        );
+      });
+
+      test('rejects an invalid handle', () {
+        final (code, _) = bindings.rowCellsGetSummary(0);
+
+        expect(code, Result.invalidValue);
+      });
+    });
+
+    group('cellGetSummary', () {
+      test('returns cell metadata', () {
+        final cells = _firstCellCells('A');
+        final rawCell = check(bindings.rowCellsGetRawCell(cells));
+
+        final summary = check(bindings.cellGetSummary(rawCell));
+
+        expect(summary, (codepoint: 0x41, styleId: 0, wide: CellWide.narrow));
+      });
+
+      test('preserves packed cell bits above 32 bits', () {
+        final cells = _firstCellCells('\u754C');
+
+        final summary = check(bindings.rowCellsGetSummary(cells));
+
+        expect(summary.rawCell, greaterThan(0xFFFFFFFF));
+      });
+    });
+
     group('rowCellsGetSelected', () {
       test('returns true for a selected cell', () {
         final cells = _selectedRowCells(2);
@@ -729,6 +942,48 @@ void main() {
 
         expect(code, Result.success);
         expect(value, isTrue);
+      });
+    });
+  });
+
+  group('selection gesture data', () {
+    group('selectionGestureGetState', () {
+      test('returns the initial gesture state', () {
+        final terminal = check(bindings.terminalNew(80, 24, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+        final gesture = check(bindings.selectionGestureNew());
+        addTearDown(() => bindings.selectionGestureFree(gesture, terminal));
+
+        final state = check(
+          bindings.selectionGestureGetState(gesture, terminal),
+        );
+        const RawSelectionGestureState expected = (
+          clickCount: 0,
+          dragged: false,
+          autoscroll: .none,
+          behavior: .cell,
+          anchor: null,
+        );
+
+        expect(state, expected);
+      });
+
+      test('rejects an invalid gesture handle', () {
+        final terminal = check(bindings.terminalNew(80, 24, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+
+        final result = bindings.selectionGestureGetState(0, terminal);
+
+        expect(result, (
+          Result.invalidValue,
+          (
+            clickCount: 0,
+            dragged: false,
+            autoscroll: SelectionGestureAutoscroll.none,
+            behavior: SelectionGestureBehavior.cell,
+            anchor: null,
+          ),
+        ));
       });
     });
   });
@@ -858,6 +1113,66 @@ void main() {
     tearDown(() => bindings.terminalFree(terminal));
 
     group('formatterFormat', () {
+      ({int terminal, String expected}) largeContentFixture() {
+        final terminal = check(bindings.terminalNew(6000, 1, 0));
+        addTearDown(() => bindings.terminalFree(terminal));
+        final expected = String.fromCharCodes(List<int>.filled(5000, 0x41));
+        bindings.terminalVtWrite(
+          terminal,
+          Uint8List.fromList(expected.codeUnits),
+        );
+        return (terminal: terminal, expected: expected);
+      }
+
+      int plainFormatter(int terminal) {
+        final formatter = check(
+          bindings.formatterTerminalNew(terminal, .plain, trim: true),
+        );
+        addTearDown(() => bindings.formatterFree(formatter));
+        return formatter;
+      }
+
+      test('rejects an invalid formatter handle', () {
+        final (code, _) = bindings.formatterFormat(0);
+
+        expect(code, Result.invalidValue);
+      });
+
+      test('returns content beyond the initial buffer capacity', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final formatter = plainFormatter(terminal);
+
+        final text = check(bindings.formatterFormat(formatter));
+
+        expect(text, expected);
+      });
+
+      test('returns content after reusing a grown buffer', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final formatter = plainFormatter(terminal);
+        check(bindings.formatterFormat(formatter));
+
+        final text = check(bindings.formatterFormat(formatter));
+
+        expect(text, expected);
+      });
+
+      test('formats selected content beyond the initial buffer capacity', () {
+        final (:terminal, :expected) = largeContentFixture();
+        final selection = check(bindings.terminalSelectAll(terminal));
+
+        final text = check(
+          bindings.terminalSelectionFormat(
+            terminal,
+            .plain,
+            trim: true,
+            selection: selection,
+          ),
+        );
+
+        expect(text, expected);
+      });
+
       test('returns terminal content for plain format', () {
         final (_, formatter) = bindings.formatterTerminalNew(
           terminal,


### PR DESCRIPTION
Expose batched query APIs for terminal geometry, render-state dimensions and cursor data, row and cell metadata, and selection gestures across native and WASM bindings. Higher-level terminal state, iterators, and gesture handling consume these snapshots and cache metadata lazily, reducing repeated boundary crossings, while formatter and selection output reuse a buffer that grows when content exceeds its initial capacity.