### PR TITLE
feat(libghostty): expose OSC 52 clipboard writes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes text eol=lf
+*.patch text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,13 +121,17 @@ jobs:
         id: ghostty-cache
         with:
           path: ghostty-src
-          key: ghostty-src-${{ steps.ghostty.outputs.full }}
+          key: ghostty-src-${{ steps.ghostty.outputs.full }}-${{ hashFiles('packages/libghostty/patches/*.patch') }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.full }}.tar.gz" -o ghostty.tar.gz
           mkdir -p ghostty-src
           tar xzf ghostty.tar.gz -C ghostty-src --strip-components=1
+          git -C ghostty-src init --quiet
+          git -C ghostty-src apply --unidiff-zero "$GITHUB_WORKSPACE/packages/libghostty/patches/osc52-clipboard-write.patch"
+          rm -rf ghostty-src/.git
+          touch ghostty-src/.git
           rm ghostty.tar.gz
       - name: compile
         working-directory: ghostty-src
@@ -164,13 +168,17 @@ jobs:
         id: ghostty-cache
         with:
           path: ghostty-src
-          key: ghostty-src-${{ steps.ghostty.outputs.full }}
+          key: ghostty-src-${{ steps.ghostty.outputs.full }}-${{ hashFiles('packages/libghostty/patches/*.patch') }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.full }}.tar.gz" -o ghostty.tar.gz
           mkdir -p ghostty-src
           tar xzf ghostty.tar.gz -C ghostty-src --strip-components=1
+          git -C ghostty-src init --quiet
+          git -C ghostty-src apply --unidiff-zero "$GITHUB_WORKSPACE/packages/libghostty/patches/osc52-clipboard-write.patch"
+          rm -rf ghostty-src/.git
+          touch ghostty-src/.git
           rm ghostty.tar.gz
       - name: compile wasm
         working-directory: ghostty-src

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -183,7 +183,7 @@ jobs:
         id: ghostty-cache
         with:
           path: ghostty
-          key: ghostty-src-${{ steps.ghostty.outputs.commit }}
+          key: ghostty-src-${{ steps.ghostty.outputs.commit }}-${{ hashFiles('packages/libghostty/patches/*.patch') }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         shell: bash
@@ -191,6 +191,9 @@ jobs:
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.commit }}.tar.gz" -o ghostty.tar.gz
           mkdir -p ghostty
           tar xzf ghostty.tar.gz -C ghostty --strip-components=1
+          git -C ghostty init --quiet
+          git -C ghostty apply --unidiff-zero "$GITHUB_WORKSPACE/packages/libghostty/patches/osc52-clipboard-write.patch"
+          rm -rf ghostty/.git
           rm ghostty.tar.gz
       - run: flutter pub get
       - run: dart pub global activate very_good_cli
@@ -229,13 +232,16 @@ jobs:
         id: ghostty-cache
         with:
           path: ghostty
-          key: ghostty-src-${{ steps.ghostty.outputs.commit }}
+          key: ghostty-src-${{ steps.ghostty.outputs.commit }}-${{ hashFiles('packages/libghostty/patches/*.patch') }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         run: |
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.commit }}.tar.gz" -o ghostty.tar.gz
           mkdir -p ghostty
           tar xzf ghostty.tar.gz -C ghostty --strip-components=1
+          git -C ghostty init --quiet
+          git -C ghostty apply --unidiff-zero "$GITHUB_WORKSPACE/packages/libghostty/patches/osc52-clipboard-write.patch"
+          rm -rf ghostty/.git
           rm ghostty.tar.gz
       - name: isolate from repo git
         run: touch ghostty/.git
@@ -282,7 +288,7 @@ jobs:
         id: ghostty-cache
         with:
           path: ghostty
-          key: ghostty-src-${{ steps.ghostty.outputs.commit }}
+          key: ghostty-src-${{ steps.ghostty.outputs.commit }}-${{ hashFiles('packages/libghostty/patches/*.patch') }}
       - name: download ghostty source
         if: steps.ghostty-cache.outputs.cache-hit != 'true'
         shell: bash
@@ -290,6 +296,9 @@ jobs:
           curl -fsSL "https://github.com/ghostty-org/ghostty/archive/${{ steps.ghostty.outputs.commit }}.tar.gz" -o ghostty.tar.gz
           mkdir -p ghostty
           tar xzf ghostty.tar.gz -C ghostty --strip-components=1
+          git -C ghostty init --quiet
+          git -C ghostty apply --unidiff-zero "$GITHUB_WORKSPACE/packages/libghostty/patches/osc52-clipboard-write.patch"
+          rm -rf ghostty/.git
           rm ghostty.tar.gz
       - run: flutter pub get
       - name: install very_good_cli

--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **OSC 52 clipboard writes**: `TerminalController.onClipboardWrite` forwards
+  write-only clipboard requests from libghostty to terminal embedders.
+
 ## 0.0.4
 
 ### Breaking

--- a/packages/flterm/lib/src/widgets/terminal_controller.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller.dart
@@ -35,6 +35,9 @@ abstract class TerminalController extends ChangeNotifier
   /// Called when the terminal receives a BEL character (0x07).
   VoidCallback? onBell;
 
+  /// Called when the terminal receives an OSC 52 clipboard write request.
+  ValueChanged<ClipboardWrite>? onClipboardWrite;
+
   /// Called when the terminal title changes. Read [title] for the value.
   VoidCallback? onTitleChanged;
 

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -994,6 +994,7 @@ class TerminalControllerImpl extends TerminalController
   void _wireTerminalCallbacks() {
     terminal.onWritePty = _emitOutput;
     terminal.onBell = () => onBell?.call();
+    terminal.onClipboardWrite = (value) => onClipboardWrite?.call(value);
     terminal.onTitleChanged = () => onTitleChanged?.call();
     terminal.onPwdChanged = _handlePwdChanged;
     terminal.onColorScheme = () => _brightness == .light ? .light : .dark;

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -600,6 +600,18 @@ void main() {
       });
     });
 
+    group('clipboard writes', () {
+      test('forwards OSC 52 writes', () {
+        ClipboardWrite? received;
+        controller.onClipboardWrite = (value) => received = value;
+
+        writeTerminalUtf8(controller.terminal, '\x1b]52;c;aGVsbG8=\x1b\\');
+
+        expect(received?.selector, 'c'.codeUnitAt(0));
+        expect(String.fromCharCodes(received!.payload), 'aGVsbG8=');
+      });
+    });
+
     group('pwd', () {
       test('updates via OSC 7 escape sequence', () {
         writeTerminalUtf8(controller.terminal, '\x1b]7;file:///tmp\x07');

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -14,8 +14,6 @@
   output library so source or ABI changes cannot reuse a stale binary.
 - **Source patch isolation**: downloaded Ghostty sources are patched in their
   own Git boundary and marked before cache reuse.
-- **Concurrent source builds**: native-asset hooks serialize shared Ghostty
-  source cache population across isolates and processes.
 - **Embedded tagged builds**: source compilation passes Ghostty's own version
   explicitly instead of inheriting Git tags from an embedding repository.
 

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -14,6 +14,8 @@
   output library so source or ABI changes cannot reuse a stale binary.
 - **Source patch isolation**: downloaded Ghostty sources are patched in their
   own Git boundary and marked before cache reuse.
+- **Concurrent source builds**: native-asset hooks serialize shared Ghostty
+  source cache population across isolates and processes.
 - **Embedded tagged builds**: source compilation passes Ghostty's own version
   explicitly instead of inheriting Git tags from an embedding repository.
 

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -16,6 +16,8 @@
   own Git boundary and marked before cache reuse.
 - **Embedded tagged builds**: source compilation passes Ghostty's own version
   explicitly instead of inheriting Git tags from an embedding repository.
+- **Windows source builds**: each native-asset output uses an isolated local
+  Zig cache and retries the transient generated-helper scanner race.
 
 ## 0.0.11
 

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Native asset refreshes**: rerunning the build hook replaces an existing
+  output library so source or ABI changes cannot reuse a stale binary.
+- **Source patch isolation**: downloaded Ghostty sources are patched in their
+  own Git boundary and marked before cache reuse.
+- **Embedded tagged builds**: source compilation passes Ghostty's own version
+  explicitly instead of inheriting Git tags from an embedding repository.
+
 ## 0.0.11
 
 ### Added

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- **OSC 52 clipboard writes**: `Terminal.onClipboardWrite` exposes write-only
+  clipboard requests with their raw selector and base64 payload. Clipboard read
+  queries remain disabled.
+
 ### Fixed
 
 - **Native asset refreshes**: rerunning the build hook replaces an existing

--- a/packages/libghostty/hook/build.dart
+++ b/packages/libghostty/hook/build.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:libghostty/src/hook/fix_ios_page_alignment.dart';
+import 'package:libghostty/src/hook/ghostty_source.dart';
 import 'package:libghostty/src/hook/library_provider.dart';
 
 void main(List<String> args) async {
@@ -13,16 +14,18 @@ Future<void> _build(BuildInput input, BuildOutputBuilder output) async {
   if (!input.config.buildCodeAssets) return;
 
   output.dependencies.add(input.packageRoot.resolve('ghostty.version'));
+  for (final patch in ghosttyPatchFiles(input.packageRoot)) {
+    output.dependencies.add(patch.uri);
+  }
 
   final targetOS = input.config.code.targetOS;
   final libFileName = targetOS.dylibFileName('ghostty');
   final installDir = input.outputDirectory;
   final libFile = File.fromUri(installDir.resolve('lib/$libFileName'));
 
-  if (!libFile.existsSync()) {
-    final provider = LibraryProvider.resolve(input);
-    await provider.provide(libFile);
-  }
+  if (libFile.existsSync()) libFile.deleteSync();
+  final provider = LibraryProvider.resolve(input);
+  await provider.provide(libFile);
 
   if (!libFile.existsSync()) {
     throw Exception(

--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -7,7 +7,12 @@ library;
 
 export 'src/bindings/bindings.dart' show initializeForWeb;
 export 'src/bindings/types/aliases.dart'
-    show DecodedImage, PngDecoder, TerminalGeometry, X11ColorName;
+    show
+        ClipboardWrite,
+        DecodedImage,
+        PngDecoder,
+        TerminalGeometry,
+        X11ColorName;
 export 'src/bindings/types/types.dart'
     show
         CellColor,

--- a/packages/libghostty/lib/src/bindings/interface.dart
+++ b/packages/libghostty/lib/src/bindings/interface.dart
@@ -180,6 +180,10 @@ abstract interface class GhosttyBindings {
 
   void terminalSetOnWritePty(int handle, ValueSetter<Uint8List>? callback);
   void terminalSetOnBell(int handle, VoidCallback? callback);
+  void terminalSetOnClipboardWrite(
+    int handle,
+    ValueSetter<ClipboardWrite>? callback,
+  );
   void terminalSetOnTitleChanged(int handle, VoidCallback? callback);
   void terminalSetOnPwdChanged(int handle, VoidCallback? callback);
   void terminalSetOnEnquiry(int handle, ValueGetter<Uint8List>? callback);

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -3481,6 +3481,46 @@ class NativeBindings implements GhosttyBindings {
   }
 
   @override
+  void terminalSetOnClipboardWrite(
+    int handle,
+    ValueSetter<ClipboardWrite>? callback,
+  ) {
+    final map = _callables.putIfAbsent(handle, () => {});
+    const option = TerminalOption.clipboardWrite;
+    map[option]?.close();
+
+    if (callback == null) {
+      map.remove(option);
+      ghostty_terminal_set(Pointer.fromAddress(handle), option, nullptr);
+      return;
+    }
+
+    final callable =
+        NativeCallable<
+          Void Function(Terminal, Pointer<Void>, Uint8, Pointer<Uint8>, Size)
+        >.isolateLocal((
+          Terminal terminal,
+          Pointer<Void> userdata,
+          int selector,
+          Pointer<Uint8> data,
+          int len,
+        ) {
+          try {
+            callback((
+              selector: selector,
+              payload: Uint8List.fromList(data.asTypedList(len)),
+            ));
+          } on Object catch (_) {}
+        });
+    map[option] = callable;
+    ghostty_terminal_set(
+      Pointer.fromAddress(handle),
+      option,
+      callable.nativeFunction.cast(),
+    );
+  }
+
+  @override
   void terminalSetOnTitleChanged(int handle, VoidCallback? callback) {
     final map = _callables.putIfAbsent(handle, () => {});
     map[TerminalOption.titleChanged]?.close();

--- a/packages/libghostty/lib/src/bindings/types/aliases.dart
+++ b/packages/libghostty/lib/src/bindings/types/aliases.dart
@@ -33,6 +33,12 @@ typedef ValueGetter<T> = T Function();
 typedef ValueSetter<T> = void Function(T value);
 typedef VoidCallback = void Function();
 
+/// An OSC 52 clipboard write request.
+///
+/// [selector] is the raw one-byte clipboard selector and [payload] is the raw
+/// base64 data. Clipboard read queries are never emitted.
+typedef ClipboardWrite = ({int selector, Uint8List payload});
+
 /// An untracked grid reference value.
 ///
 /// The value follows libghostty's untracked grid-reference lifetime rules and

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -1540,6 +1540,38 @@ class WasmBindings implements GhosttyBindings {
   }
 
   @override
+  void terminalSetOnClipboardWrite(
+    int handle,
+    ValueSetter<ClipboardWrite>? callback,
+  ) {
+    final map = _callbacks.putIfAbsent(handle, () => {});
+    const option = TerminalOption.clipboardWrite;
+
+    if (callback == null) {
+      final existing = map.remove(option);
+      if (existing != null) _table.set(existing.$1);
+      _exports.ghostty_terminal_set(handle, option.value, 0);
+      return;
+    }
+
+    final reuseIndex = map[option]?.$1;
+    final index = _registerCallback(
+      ((int terminal, int userdata, int selector, int dataPtr, int len) {
+        try {
+          callback((
+            selector: selector,
+            payload: Uint8List.fromList(_mem.readBytes(dataPtr, len)),
+          ));
+        } on Object catch (_) {}
+      }).toJS,
+      ['i32', 'i32', 'i32', 'i32', 'i32'],
+      reuseIndex: reuseIndex,
+    );
+    map[option] = (index, callback);
+    _exports.ghostty_terminal_set(handle, option.value, index);
+  }
+
+  @override
   void terminalSetOnTitleChanged(int handle, VoidCallback? callback) {
     final map = _callbacks.putIfAbsent(handle, () => {});
     const option = TerminalOption.titleChanged;

--- a/packages/libghostty/lib/src/ffi/libghostty.g.dart
+++ b/packages/libghostty/lib/src/ffi/libghostty.g.dart
@@ -6102,6 +6102,33 @@ typedef TerminalBellFn =
       >
     >;
 
+/// Callback function type for OSC 52 clipboard writes.
+///
+/// The payload is the raw base64 data from the OSC sequence. An empty payload
+/// requests clearing the selected clipboard. Clipboard read queries are
+/// ignored and do not invoke this callback. The payload pointer is valid only
+/// for the duration of the callback.
+///
+/// @param terminal The terminal handle
+/// @param userdata The userdata pointer set via GHOSTTY_TERMINAL_OPT_USERDATA
+/// @param kind OSC 52 clipboard selector (for example 'c' or 'p')
+/// @param data Pointer to the raw base64 payload
+/// @param len Length of the payload in bytes
+///
+/// @ingroup terminal
+typedef TerminalClipboardWriteFn =
+    ffi.Pointer<
+      ffi.NativeFunction<
+        ffi.Void Function(
+          Terminal terminal,
+          ffi.Pointer<ffi.Void> userdata,
+          ffi.Uint8 kind,
+          ffi.Pointer<ffi.Uint8> data,
+          ffi.Size len,
+        )
+      >
+    >;
+
 /// Callback function type for color scheme queries (CSI ? 996 n).
 ///
 /// Called when the terminal receives a color scheme device status report

--- a/packages/libghostty/lib/src/ffi/libghostty_enums.g.dart
+++ b/packages/libghostty/lib/src/ffi/libghostty_enums.g.dart
@@ -2891,7 +2891,13 @@ enum TerminalOption {
   /// to ignore pwd change events.
   ///
   /// Input type: TerminalPwdChangedFn
-  pwdChanged(25);
+  pwdChanged(25),
+
+  /// Callback invoked for OSC 52 clipboard writes. Clipboard read queries are
+  /// ignored. Set to NULL to ignore clipboard writes.
+  ///
+  /// Input type: TerminalClipboardWriteFn
+  clipboardWrite(26);
 
   final int value;
   const TerminalOption(this.value);
@@ -2923,6 +2929,7 @@ enum TerminalOption {
     23 => defaultCursorBlink,
     24 => glyphProtocol,
     25 => pwdChanged,
+    26 => clipboardWrite,
     _ => throw ArgumentError('Unknown value for TerminalOption: $value'),
   };
 }

--- a/packages/libghostty/lib/src/hook/ghostty_source.dart
+++ b/packages/libghostty/lib/src/hook/ghostty_source.dart
@@ -1,9 +1,94 @@
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
+
 /// Environment variable that overrides source resolution with a local checkout.
 const ghosttySrcEnvKey = 'GHOSTTY_SRC';
 
 const _defaultTarballBase = 'https://github.com/ghostty-org/ghostty/archive';
+const _patchMarkerName = '.libghostty-patch-key';
+final _semanticVersion = RegExp(
+  r'^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$',
+);
+
+/// Reads the Ghostty application version without consulting Git metadata.
+String ghosttySourceVersion(Directory source) {
+  final versionFile = File.fromUri(source.uri.resolve('VERSION'));
+  final String? version;
+  if (versionFile.existsSync()) {
+    version = versionFile.readAsStringSync().trim();
+  } else {
+    final zonFile = File.fromUri(source.uri.resolve('build.zig.zon'));
+    final zon = zonFile.existsSync() ? zonFile.readAsStringSync() : '';
+    version = RegExp(
+      r'^\s*\.version\s*=\s*"([^"]+)"\s*,',
+      multiLine: true,
+    ).firstMatch(zon)?.group(1);
+  }
+  if (version == null || !_semanticVersion.hasMatch(version)) {
+    throw StateError('Cannot determine Ghostty version from ${source.path}');
+  }
+  return version;
+}
+
+/// Source patches applied to downloaded and cloned Ghostty checkouts.
+List<File> ghosttyPatchFiles(Uri packageRoot) {
+  final directory = Directory.fromUri(packageRoot.resolve('patches/'));
+  if (!directory.existsSync()) return const [];
+  return directory
+      .listSync()
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.patch'))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+}
+
+/// Returns a cache key that changes when the Ghostty pin or patches change.
+String ghosttySourceCacheKey(Uri packageRoot) {
+  final commit = pinnedCommit(packageRoot);
+  final patches = ghosttyPatchFiles(packageRoot);
+  if (patches.isEmpty) return '${commit.substring(0, 12)}-none';
+  final bytes = <int>[];
+  for (final patch in patches) {
+    bytes.addAll(patch.readAsBytesSync());
+  }
+  final patchHash = sha256.convert(bytes).toString().substring(0, 12);
+  return '${commit.substring(0, 12)}-$patchHash';
+}
+
+/// Applies all packaged patches to a freshly acquired Ghostty checkout.
+void applyGhosttyPatches(Directory source, Uri packageRoot) {
+  final gitDirectory = Directory.fromUri(source.uri.resolve('.git/'));
+  final isolated = !gitDirectory.existsSync();
+  if (isolated) {
+    final result = Process.runSync('git', [
+      'init',
+      '--quiet',
+    ], workingDirectory: source.path);
+    if (result.exitCode != 0) {
+      throw Exception('Failed to isolate Ghostty source: ${result.stderr}');
+    }
+  }
+  try {
+    for (final patch in ghosttyPatchFiles(packageRoot)) {
+      final result = Process.runSync('git', [
+        'apply',
+        '--unidiff-zero',
+        patch.path,
+      ], workingDirectory: source.path);
+      if (result.exitCode != 0) {
+        throw Exception(
+          'Failed to apply Ghostty patch ${patch.path}: ${result.stderr}',
+        );
+      }
+    }
+  } finally {
+    if (isolated) {
+      gitDirectory.deleteSync(recursive: true);
+      gitDirectory.createSync();
+    }
+  }
+}
 
 /// Downloads a source tarball, extracts it, and caches the result.
 ///
@@ -15,11 +100,18 @@ Future<Directory> downloadSource(
   String? tarballUrl,
 }) async {
   final commit = pinnedCommit(packageRoot);
-  final cacheKey = commit.substring(0, 12);
+  final cacheKey = ghosttySourceCacheKey(packageRoot);
   final cacheDir = Directory.fromUri(
     cacheBase.resolve('ghostty-source-$cacheKey/'),
   );
-  if (cacheDir.existsSync()) return cacheDir;
+  final patchMarker = File.fromUri(cacheDir.uri.resolve(_patchMarkerName));
+  if (cacheDir.existsSync()) {
+    if (patchMarker.existsSync() &&
+        patchMarker.readAsStringSync() == cacheKey) {
+      return cacheDir;
+    }
+    cacheDir.deleteSync(recursive: true);
+  }
 
   tarballUrl ??= '$_defaultTarballBase/$commit.tar.gz';
 
@@ -53,9 +145,19 @@ Future<Directory> downloadSource(
   ]);
   if (extractResult.exitCode != 0) {
     cacheDir.deleteSync(recursive: true);
+    tarball.deleteSync();
     throw Exception(
       'Failed to extract Ghostty source: ${extractResult.stderr}',
     );
+  }
+
+  try {
+    applyGhosttyPatches(cacheDir, packageRoot);
+    patchMarker.writeAsStringSync(cacheKey);
+  } on Object {
+    cacheDir.deleteSync(recursive: true);
+    tarball.deleteSync();
+    rethrow;
   }
 
   tarball.deleteSync();

--- a/packages/libghostty/lib/src/hook/ghostty_source.dart
+++ b/packages/libghostty/lib/src/hook/ghostty_source.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
@@ -10,6 +11,44 @@ const _patchMarkerName = '.libghostty-patch-key';
 final _semanticVersion = RegExp(
   r'^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$',
 );
+final _sourceCacheLocks = <String, Future<void>>{};
+
+/// Runs [action] while holding the lock for a shared Ghostty source cache.
+Future<T> withGhosttySourceCacheLock<T>(
+  Uri cacheBase,
+  String cacheKey,
+  Future<T> Function() action,
+) async {
+  final lockFile = File.fromUri(
+    cacheBase.resolve('.ghostty-source-$cacheKey.lock'),
+  );
+  lockFile.parent.createSync(recursive: true);
+
+  final previous = _sourceCacheLocks[lockFile.path];
+  final completer = Completer<void>();
+  final current = completer.future;
+  _sourceCacheLocks[lockFile.path] = current;
+  if (previous != null) await previous;
+
+  RandomAccessFile? handle;
+  var locked = false;
+  try {
+    handle = await lockFile.open(mode: FileMode.append);
+    await handle.lock(FileLock.blockingExclusive);
+    locked = true;
+    return await action();
+  } finally {
+    try {
+      if (locked) await handle!.unlock();
+      await handle?.close();
+    } finally {
+      if (identical(_sourceCacheLocks[lockFile.path], current)) {
+        unawaited(_sourceCacheLocks.remove(lockFile.path));
+      }
+      completer.complete();
+    }
+  }
+}
 
 /// Reads the Ghostty application version without consulting Git metadata.
 String ghosttySourceVersion(Directory source) {
@@ -101,68 +140,76 @@ Future<Directory> downloadSource(
 }) async {
   final commit = pinnedCommit(packageRoot);
   final cacheKey = ghosttySourceCacheKey(packageRoot);
+  final resolvedTarballUrl =
+      tarballUrl ?? '$_defaultTarballBase/$commit.tar.gz';
   final cacheDir = Directory.fromUri(
     cacheBase.resolve('ghostty-source-$cacheKey/'),
   );
   final patchMarker = File.fromUri(cacheDir.uri.resolve(_patchMarkerName));
-  if (cacheDir.existsSync()) {
-    if (patchMarker.existsSync() &&
-        patchMarker.readAsStringSync() == cacheKey) {
-      return cacheDir;
-    }
-    cacheDir.deleteSync(recursive: true);
+  if (cacheDir.existsSync() &&
+      patchMarker.existsSync() &&
+      patchMarker.readAsStringSync() == cacheKey) {
+    return cacheDir;
   }
 
-  tarballUrl ??= '$_defaultTarballBase/$commit.tar.gz';
+  return withGhosttySourceCacheLock(cacheBase, cacheKey, () async {
+    if (cacheDir.existsSync()) {
+      if (patchMarker.existsSync() &&
+          patchMarker.readAsStringSync() == cacheKey) {
+        return cacheDir;
+      }
+      cacheDir.deleteSync(recursive: true);
+    }
 
-  final tarball = File.fromUri(cacheBase.resolve('$commit.tar.gz'));
-  tarball.parent.createSync(recursive: true);
+    final tarball = File.fromUri(cacheBase.resolve('$cacheKey.tar.gz'));
+    tarball.parent.createSync(recursive: true);
 
-  final httpClient = HttpClient();
-  try {
-    final request = await httpClient.getUrl(Uri.parse(tarballUrl));
-    final response = await request.close();
-    if (response.statusCode != 200) {
+    final httpClient = HttpClient();
+    try {
+      final request = await httpClient.getUrl(Uri.parse(resolvedTarballUrl));
+      final response = await request.close();
+      if (response.statusCode != 200) {
+        throw Exception(
+          'Failed to download Ghostty source: HTTP ${response.statusCode}. '
+          'Check your network connection or set '
+          '$ghosttySrcEnvKey to a local checkout.',
+        );
+      }
+      final sink = tarball.openWrite();
+      await response.pipe(sink);
+    } finally {
+      httpClient.close();
+    }
+
+    cacheDir.createSync(recursive: true);
+    final extractResult = Process.runSync('tar', [
+      'xzf',
+      tarball.path,
+      '-C',
+      cacheDir.path,
+      '--strip-components=1',
+    ]);
+    if (extractResult.exitCode != 0) {
+      cacheDir.deleteSync(recursive: true);
+      tarball.deleteSync();
       throw Exception(
-        'Failed to download Ghostty source: HTTP ${response.statusCode}. '
-        'Check your network connection or set '
-        '$ghosttySrcEnvKey to a local checkout.',
+        'Failed to extract Ghostty source: ${extractResult.stderr}',
       );
     }
-    final sink = tarball.openWrite();
-    await response.pipe(sink);
-  } finally {
-    httpClient.close();
-  }
 
-  cacheDir.createSync(recursive: true);
-  final extractResult = Process.runSync('tar', [
-    'xzf',
-    tarball.path,
-    '-C',
-    cacheDir.path,
-    '--strip-components=1',
-  ]);
-  if (extractResult.exitCode != 0) {
-    cacheDir.deleteSync(recursive: true);
+    try {
+      applyGhosttyPatches(cacheDir, packageRoot);
+      patchMarker.writeAsStringSync(cacheKey);
+    } on Object {
+      cacheDir.deleteSync(recursive: true);
+      tarball.deleteSync();
+      rethrow;
+    }
+
     tarball.deleteSync();
-    throw Exception(
-      'Failed to extract Ghostty source: ${extractResult.stderr}',
-    );
-  }
 
-  try {
-    applyGhosttyPatches(cacheDir, packageRoot);
-    patchMarker.writeAsStringSync(cacheKey);
-  } on Object {
-    cacheDir.deleteSync(recursive: true);
-    tarball.deleteSync();
-    rethrow;
-  }
-
-  tarball.deleteSync();
-
-  return cacheDir;
+    return cacheDir;
+  });
 }
 
 /// Reads the pinned Ghostty commit from `ghostty.version` at [packageRoot].

--- a/packages/libghostty/lib/src/hook/ghostty_source.dart
+++ b/packages/libghostty/lib/src/hook/ghostty_source.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
@@ -11,44 +10,6 @@ const _patchMarkerName = '.libghostty-patch-key';
 final _semanticVersion = RegExp(
   r'^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$',
 );
-final _sourceCacheLocks = <String, Future<void>>{};
-
-/// Runs [action] while holding the lock for a shared Ghostty source cache.
-Future<T> withGhosttySourceCacheLock<T>(
-  Uri cacheBase,
-  String cacheKey,
-  Future<T> Function() action,
-) async {
-  final lockFile = File.fromUri(
-    cacheBase.resolve('.ghostty-source-$cacheKey.lock'),
-  );
-  lockFile.parent.createSync(recursive: true);
-
-  final previous = _sourceCacheLocks[lockFile.path];
-  final completer = Completer<void>();
-  final current = completer.future;
-  _sourceCacheLocks[lockFile.path] = current;
-  if (previous != null) await previous;
-
-  RandomAccessFile? handle;
-  var locked = false;
-  try {
-    handle = await lockFile.open(mode: FileMode.append);
-    await handle.lock(FileLock.blockingExclusive);
-    locked = true;
-    return await action();
-  } finally {
-    try {
-      if (locked) await handle!.unlock();
-      await handle?.close();
-    } finally {
-      if (identical(_sourceCacheLocks[lockFile.path], current)) {
-        unawaited(_sourceCacheLocks.remove(lockFile.path));
-      }
-      completer.complete();
-    }
-  }
-}
 
 /// Reads the Ghostty application version without consulting Git metadata.
 String ghosttySourceVersion(Directory source) {
@@ -140,76 +101,68 @@ Future<Directory> downloadSource(
 }) async {
   final commit = pinnedCommit(packageRoot);
   final cacheKey = ghosttySourceCacheKey(packageRoot);
-  final resolvedTarballUrl =
-      tarballUrl ?? '$_defaultTarballBase/$commit.tar.gz';
   final cacheDir = Directory.fromUri(
     cacheBase.resolve('ghostty-source-$cacheKey/'),
   );
   final patchMarker = File.fromUri(cacheDir.uri.resolve(_patchMarkerName));
-  if (cacheDir.existsSync() &&
-      patchMarker.existsSync() &&
-      patchMarker.readAsStringSync() == cacheKey) {
-    return cacheDir;
+  if (cacheDir.existsSync()) {
+    if (patchMarker.existsSync() &&
+        patchMarker.readAsStringSync() == cacheKey) {
+      return cacheDir;
+    }
+    cacheDir.deleteSync(recursive: true);
   }
 
-  return withGhosttySourceCacheLock(cacheBase, cacheKey, () async {
-    if (cacheDir.existsSync()) {
-      if (patchMarker.existsSync() &&
-          patchMarker.readAsStringSync() == cacheKey) {
-        return cacheDir;
-      }
-      cacheDir.deleteSync(recursive: true);
-    }
+  tarballUrl ??= '$_defaultTarballBase/$commit.tar.gz';
 
-    final tarball = File.fromUri(cacheBase.resolve('$cacheKey.tar.gz'));
-    tarball.parent.createSync(recursive: true);
+  final tarball = File.fromUri(cacheBase.resolve('$commit.tar.gz'));
+  tarball.parent.createSync(recursive: true);
 
-    final httpClient = HttpClient();
-    try {
-      final request = await httpClient.getUrl(Uri.parse(resolvedTarballUrl));
-      final response = await request.close();
-      if (response.statusCode != 200) {
-        throw Exception(
-          'Failed to download Ghostty source: HTTP ${response.statusCode}. '
-          'Check your network connection or set '
-          '$ghosttySrcEnvKey to a local checkout.',
-        );
-      }
-      final sink = tarball.openWrite();
-      await response.pipe(sink);
-    } finally {
-      httpClient.close();
-    }
-
-    cacheDir.createSync(recursive: true);
-    final extractResult = Process.runSync('tar', [
-      'xzf',
-      tarball.path,
-      '-C',
-      cacheDir.path,
-      '--strip-components=1',
-    ]);
-    if (extractResult.exitCode != 0) {
-      cacheDir.deleteSync(recursive: true);
-      tarball.deleteSync();
+  final httpClient = HttpClient();
+  try {
+    final request = await httpClient.getUrl(Uri.parse(tarballUrl));
+    final response = await request.close();
+    if (response.statusCode != 200) {
       throw Exception(
-        'Failed to extract Ghostty source: ${extractResult.stderr}',
+        'Failed to download Ghostty source: HTTP ${response.statusCode}. '
+        'Check your network connection or set '
+        '$ghosttySrcEnvKey to a local checkout.',
       );
     }
+    final sink = tarball.openWrite();
+    await response.pipe(sink);
+  } finally {
+    httpClient.close();
+  }
 
-    try {
-      applyGhosttyPatches(cacheDir, packageRoot);
-      patchMarker.writeAsStringSync(cacheKey);
-    } on Object {
-      cacheDir.deleteSync(recursive: true);
-      tarball.deleteSync();
-      rethrow;
-    }
-
+  cacheDir.createSync(recursive: true);
+  final extractResult = Process.runSync('tar', [
+    'xzf',
+    tarball.path,
+    '-C',
+    cacheDir.path,
+    '--strip-components=1',
+  ]);
+  if (extractResult.exitCode != 0) {
+    cacheDir.deleteSync(recursive: true);
     tarball.deleteSync();
+    throw Exception(
+      'Failed to extract Ghostty source: ${extractResult.stderr}',
+    );
+  }
 
-    return cacheDir;
-  });
+  try {
+    applyGhosttyPatches(cacheDir, packageRoot);
+    patchMarker.writeAsStringSync(cacheKey);
+  } on Object {
+    cacheDir.deleteSync(recursive: true);
+    tarball.deleteSync();
+    rethrow;
+  }
+
+  tarball.deleteSync();
+
+  return cacheDir;
 }
 
 /// Reads the pinned Ghostty commit from `ghostty.version` at [packageRoot].

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -15,6 +15,10 @@ String libraryExtension(OS os) => switch (os) {
   _ => 'so',
 };
 
+/// Whether Zig hit the transient Windows scanner race for a generated helper.
+bool isTransientWindowsZigFailure(String stderr) =>
+    stderr.contains('uucode_build_tables') && stderr.contains('FileNotFound');
+
 /// Environment variable for local Ghostty source path.
 const ghosttySrcEnvKey = 'GHOSTTY_SRC';
 
@@ -98,6 +102,7 @@ final class CompileFromSource extends LibraryProvider {
     final ios = os == OS.iOS ? input.config.code.iOS.targetSdk : null;
 
     final installDir = target.parent.parent.uri;
+    final localCacheDir = Directory.fromUri(installDir.resolve('.zig-cache/'));
     final zig = zigTarget(os, arch, iOSSdk: ios);
 
     final zigArgs = [
@@ -107,24 +112,32 @@ final class CompileFromSource extends LibraryProvider {
       Directory.fromUri(installDir).path,
       '--release=fast',
       '-Dversion-string=${ghosttySourceVersion(sourceDir)}',
+      '--cache-dir',
+      localCacheDir.path,
       '--global-cache-dir',
       _zigCacheDir(sourceDir),
       if (os != .current || arch != .current) '-Dtarget=$zig',
       if (ios == .iPhoneSimulator && arch == .arm64) '-Dcpu=apple_a17',
     ];
 
-    final result = Process.runSync(
-      'zig',
-      zigArgs,
-      workingDirectory: sourceDir.path,
-    );
-
-    if (result.exitCode != 0) {
-      throw Exception(
-        'Zig compilation failed (exit code ${result.exitCode}):\n'
-        'stdout: ${result.stdout}\n'
-        'stderr: ${result.stderr}',
+    late ProcessResult result;
+    for (var attempt = 1; attempt <= 3; attempt++) {
+      result = Process.runSync(
+        'zig',
+        zigArgs,
+        workingDirectory: sourceDir.path,
       );
+      if (result.exitCode == 0) break;
+      if (os != .windows ||
+          !isTransientWindowsZigFailure(result.stderr.toString()) ||
+          attempt == 3) {
+        throw Exception(
+          'Zig compilation failed (exit code ${result.exitCode}):\n'
+          'stdout: ${result.stdout}\n'
+          'stderr: ${result.stderr}',
+        );
+      }
+      sleep(Duration(seconds: attempt * 2));
     }
 
     final srcDir = os == .windows ? 'bin' : 'lib';

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -161,49 +161,36 @@ final class CompileFromSource extends LibraryProvider {
       cacheDir.uri.resolve('.libghostty-patch-key'),
     );
 
-    if (cacheDir.existsSync() &&
-        patchMarker.existsSync() &&
-        patchMarker.readAsStringSync() == cacheKey) {
-      return cacheDir;
+    if (!cacheDir.existsSync() ||
+        !patchMarker.existsSync() ||
+        patchMarker.readAsStringSync() != cacheKey) {
+      if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+      cacheDir.createSync(recursive: true);
+
+      final result = Process.runSync('git', [
+        'clone',
+        '--depth',
+        '1',
+        '--branch',
+        commit,
+        'https://github.com/ghostty-org/ghostty.git',
+        '.',
+      ], workingDirectory: cacheDir.path);
+
+      if (result.exitCode != 0) {
+        cacheDir.deleteSync(recursive: true);
+        throw Exception('Git clone failed: ${result.stderr}');
+      }
+      try {
+        applyGhosttyPatches(cacheDir, input.packageRoot);
+        patchMarker.writeAsStringSync(cacheKey);
+      } on Object {
+        cacheDir.deleteSync(recursive: true);
+        rethrow;
+      }
     }
 
-    return withGhosttySourceCacheLock(
-      input.outputDirectoryShared,
-      'git-$cacheKey',
-      () async {
-        if (cacheDir.existsSync() &&
-            patchMarker.existsSync() &&
-            patchMarker.readAsStringSync() == cacheKey) {
-          return cacheDir;
-        }
-        if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
-        cacheDir.createSync(recursive: true);
-
-        final result = Process.runSync('git', [
-          'clone',
-          '--depth',
-          '1',
-          '--branch',
-          commit,
-          'https://github.com/ghostty-org/ghostty.git',
-          '.',
-        ], workingDirectory: cacheDir.path);
-
-        if (result.exitCode != 0) {
-          cacheDir.deleteSync(recursive: true);
-          throw Exception('Git clone failed: ${result.stderr}');
-        }
-        try {
-          applyGhosttyPatches(cacheDir, input.packageRoot);
-          patchMarker.writeAsStringSync(cacheKey);
-        } on Object {
-          cacheDir.deleteSync(recursive: true);
-          rethrow;
-        }
-
-        return cacheDir;
-      },
-    );
+    return cacheDir;
   }
 
   Future<Directory> _resolveSource() async {

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -106,7 +106,9 @@ final class CompileFromSource extends LibraryProvider {
       '-p',
       Directory.fromUri(installDir).path,
       '--release=fast',
-      if (os == .windows) ...['--global-cache-dir', _zigCacheDir(sourceDir)],
+      '-Dversion-string=${ghosttySourceVersion(sourceDir)}',
+      '--global-cache-dir',
+      _zigCacheDir(sourceDir),
       if (os != .current || arch != .current) '-Dtarget=$zig',
       if (ios == .iPhoneSimulator && arch == .arm64) '-Dcpu=apple_a17',
     ];
@@ -134,7 +136,7 @@ final class CompileFromSource extends LibraryProvider {
   String _zigCacheDir(Directory sourceDir) {
     final envDir = Platform.environment['ZIG_GLOBAL_CACHE_DIR'];
     if (envDir != null && envDir.isNotEmpty) return envDir;
-    return '${sourceDir.path}${Platform.pathSeparator}.zig-cache';
+    return '${sourceDir.path}${Platform.pathSeparator}.zig-global-cache';
   }
 
   Future<Directory> _downloadTarball() async {
@@ -151,11 +153,18 @@ final class CompileFromSource extends LibraryProvider {
 
   Future<Directory> _gitClone() async {
     final commit = pinnedCommit(input.packageRoot);
+    final cacheKey = ghosttySourceCacheKey(input.packageRoot);
     final cacheDir = Directory.fromUri(
-      input.outputDirectoryShared.resolve('ghostty-git-$commit/'),
+      input.outputDirectoryShared.resolve('ghostty-git-$cacheKey/'),
+    );
+    final patchMarker = File.fromUri(
+      cacheDir.uri.resolve('.libghostty-patch-key'),
     );
 
-    if (!cacheDir.existsSync()) {
+    if (!cacheDir.existsSync() ||
+        !patchMarker.existsSync() ||
+        patchMarker.readAsStringSync() != cacheKey) {
+      if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
       cacheDir.createSync(recursive: true);
 
       final result = Process.runSync('git', [
@@ -171,6 +180,13 @@ final class CompileFromSource extends LibraryProvider {
       if (result.exitCode != 0) {
         cacheDir.deleteSync(recursive: true);
         throw Exception('Git clone failed: ${result.stderr}');
+      }
+      try {
+        applyGhosttyPatches(cacheDir, input.packageRoot);
+        patchMarker.writeAsStringSync(cacheKey);
+      } on Object {
+        cacheDir.deleteSync(recursive: true);
+        rethrow;
       }
     }
 

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -161,36 +161,49 @@ final class CompileFromSource extends LibraryProvider {
       cacheDir.uri.resolve('.libghostty-patch-key'),
     );
 
-    if (!cacheDir.existsSync() ||
-        !patchMarker.existsSync() ||
-        patchMarker.readAsStringSync() != cacheKey) {
-      if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
-      cacheDir.createSync(recursive: true);
-
-      final result = Process.runSync('git', [
-        'clone',
-        '--depth',
-        '1',
-        '--branch',
-        commit,
-        'https://github.com/ghostty-org/ghostty.git',
-        '.',
-      ], workingDirectory: cacheDir.path);
-
-      if (result.exitCode != 0) {
-        cacheDir.deleteSync(recursive: true);
-        throw Exception('Git clone failed: ${result.stderr}');
-      }
-      try {
-        applyGhosttyPatches(cacheDir, input.packageRoot);
-        patchMarker.writeAsStringSync(cacheKey);
-      } on Object {
-        cacheDir.deleteSync(recursive: true);
-        rethrow;
-      }
+    if (cacheDir.existsSync() &&
+        patchMarker.existsSync() &&
+        patchMarker.readAsStringSync() == cacheKey) {
+      return cacheDir;
     }
 
-    return cacheDir;
+    return withGhosttySourceCacheLock(
+      input.outputDirectoryShared,
+      'git-$cacheKey',
+      () async {
+        if (cacheDir.existsSync() &&
+            patchMarker.existsSync() &&
+            patchMarker.readAsStringSync() == cacheKey) {
+          return cacheDir;
+        }
+        if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+        cacheDir.createSync(recursive: true);
+
+        final result = Process.runSync('git', [
+          'clone',
+          '--depth',
+          '1',
+          '--branch',
+          commit,
+          'https://github.com/ghostty-org/ghostty.git',
+          '.',
+        ], workingDirectory: cacheDir.path);
+
+        if (result.exitCode != 0) {
+          cacheDir.deleteSync(recursive: true);
+          throw Exception('Git clone failed: ${result.stderr}');
+        }
+        try {
+          applyGhosttyPatches(cacheDir, input.packageRoot);
+          patchMarker.writeAsStringSync(cacheKey);
+        } on Object {
+          cacheDir.deleteSync(recursive: true);
+          rethrow;
+        }
+
+        return cacheDir;
+      },
+    );
   }
 
   Future<Directory> _resolveSource() async {

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -276,6 +276,14 @@ final class Terminal with Listenable {
   /// Fires synchronously during [write]. Set to null to ignore bell events.
   set onBell(VoidCallback? value) => bindings.terminalSetOnBell(_handle, value);
 
+  /// Registers a callback for OSC 52 clipboard writes.
+  ///
+  /// The callback receives the raw clipboard selector and base64 payload.
+  /// Clipboard read queries are ignored. Fires synchronously during [write].
+  set onClipboardWrite(ValueSetter<ClipboardWrite>? value) {
+    bindings.terminalSetOnClipboardWrite(_handle, value);
+  }
+
   /// Registers a callback for color scheme queries (CSI ? 996 n).
   ///
   /// Return the current [ColorScheme], or null to silently ignore the query.

--- a/packages/libghostty/patches/osc52-clipboard-write.patch
+++ b/packages/libghostty/patches/osc52-clipboard-write.patch
@@ -1,0 +1,192 @@
+diff --git a/include/ghostty/vt/terminal.h b/include/ghostty/vt/terminal.h
+index b03653129..6a0f0f704 100644
+--- a/include/ghostty/vt/terminal.h
++++ b/include/ghostty/vt/terminal.h
+@@ -77,0 +78 @@ extern "C" {
++ * | `GHOSTTY_TERMINAL_OPT_CLIPBOARD_WRITE`  | `GhosttyTerminalClipboardWriteFn` | Clipboard write via OSC 52                |
+@@ -304,0 +306,22 @@ typedef void (*GhosttyTerminalBellFn)(GhosttyTerminal terminal,
++/**
++ * Callback function type for OSC 52 clipboard writes.
++ *
++ * The payload is the raw base64 data from the OSC sequence. An empty payload
++ * requests clearing the selected clipboard. Clipboard read queries are
++ * ignored and do not invoke this callback. The payload pointer is valid only
++ * for the duration of the callback.
++ *
++ * @param terminal The terminal handle
++ * @param userdata The userdata pointer set via GHOSTTY_TERMINAL_OPT_USERDATA
++ * @param kind OSC 52 clipboard selector (for example 'c' or 'p')
++ * @param data Pointer to the raw base64 payload
++ * @param len Length of the payload in bytes
++ *
++ * @ingroup terminal
++ */
++typedef void (*GhosttyTerminalClipboardWriteFn)(GhosttyTerminal terminal,
++                                                 void* userdata,
++                                                 uint8_t kind,
++                                                 const uint8_t* data,
++                                                 size_t len);
++
+@@ -713,0 +737,8 @@ typedef enum GHOSTTY_ENUM_TYPED {
++
++  /**
++   * Callback invoked for OSC 52 clipboard writes. Clipboard read queries are
++   * ignored. Set to NULL to ignore clipboard writes.
++   *
++   * Input type: GhosttyTerminalClipboardWriteFn
++   */
++  GHOSTTY_TERMINAL_OPT_CLIPBOARD_WRITE = 26,
+diff --git a/src/terminal/c/terminal.zig b/src/terminal/c/terminal.zig
+index a2a75147f..d5124f2a4 100644
+--- a/src/terminal/c/terminal.zig
++++ b/src/terminal/c/terminal.zig
+@@ -49,0 +50 @@ const Effects = struct {
++    clipboard_write: ?ClipboardWriteFn = null,
+@@ -70,0 +72,4 @@ const Effects = struct {
++    /// C function pointer type for OSC 52 clipboard writes. The data is the
++    /// raw base64 payload and is only valid for the duration of the callback.
++    pub const ClipboardWriteFn = *const fn (Terminal, ?*anyopaque, u8, [*]const u8, usize) callconv(lib.calling_conv) void;
++
+@@ -140,0 +146,7 @@ const Effects = struct {
++    fn clipboardWriteTrampoline(handler: *Handler, kind: u8, data: []const u8) void {
++        const stream_ptr: *Stream = @fieldParentPtr("handler", handler);
++        const wrapper: *TerminalWrapper = @fieldParentPtr("stream", stream_ptr);
++        const func = wrapper.effects.clipboard_write orelse return;
++        func(@ptrCast(wrapper), wrapper.effects.userdata, kind, data.ptr, data.len);
++    }
++
+@@ -291,0 +304 @@ fn new_(
++        .clipboard_write = &Effects.clipboardWriteTrampoline,
+@@ -345,0 +359 @@ pub const Option = enum(c_int) {
++    clipboard_write = 26,
+@@ -352,0 +367 @@ pub const Option = enum(c_int) {
++            .clipboard_write => ?Effects.ClipboardWriteFn,
+@@ -408,0 +424 @@ fn setTyped(
++        .clipboard_write => wrapper.effects.clipboard_write = value,
+@@ -2324,0 +2341,60 @@ test "bell without callback is silent" {
++test "set clipboard_write callback" {
++    var t: Terminal = null;
++    try testing.expectEqual(Result.success, new(
++        &lib.alloc.test_allocator,
++        &t,
++        .{
++            .cols = 80,
++            .rows = 24,
++            .max_scrollback = 0,
++        },
++    ));
++    defer free(t);
++
++    const S = struct {
++        var count: usize = 0;
++        var kind: u8 = 0;
++        var data: []u8 = &.{};
++        var last_userdata: ?*anyopaque = null;
++
++        fn deinit() void {
++            if (data.len > 0) testing.allocator.free(data);
++            data = &.{};
++        }
++
++        fn clipboardWrite(
++            _: Terminal,
++            userdata: ?*anyopaque,
++            value_kind: u8,
++            ptr: [*]const u8,
++            len: usize,
++        ) callconv(lib.calling_conv) void {
++            if (data.len > 0) testing.allocator.free(data);
++            data = testing.allocator.dupe(u8, ptr[0..len]) catch @panic("OOM");
++            count += 1;
++            kind = value_kind;
++            last_userdata = userdata;
++        }
++    };
++    S.count = 0;
++    S.kind = 0;
++    S.data = &.{};
++    S.last_userdata = null;
++    defer S.deinit();
++
++    var sentinel: u8 = 42;
++    try testing.expectEqual(Result.success, set(t, .userdata, @ptrCast(&sentinel)));
++    try testing.expectEqual(Result.success, set(t, .clipboard_write, @ptrCast(&S.clipboardWrite)));
++
++    const write = "\x1b]52;c;aGVsbG8=\x1b\\";
++    vt_write(t, write, write.len);
++    try testing.expectEqual(@as(usize, 1), S.count);
++    try testing.expectEqual(@as(u8, 'c'), S.kind);
++    try testing.expectEqualStrings("aGVsbG8=", S.data);
++    try testing.expectEqual(@as(?*anyopaque, @ptrCast(&sentinel)), S.last_userdata);
++
++    const query = "\x1b]52;c;?\x1b\\";
++    vt_write(t, query, query.len);
++    try testing.expectEqual(@as(usize, 1), S.count);
++}
++
+diff --git a/src/terminal/stream_terminal.zig b/src/terminal/stream_terminal.zig
+index 38d59bcd2..66d94daa9 100644
+--- a/src/terminal/stream_terminal.zig
++++ b/src/terminal/stream_terminal.zig
+@@ -62,0 +63,5 @@ pub const Handler = struct {
++        /// Called when OSC 52 requests a clipboard write. The data is the raw
++        /// base64 payload and is only valid for the duration of the callback.
++        /// Clipboard read queries are ignored and never reach this callback.
++        clipboard_write: ?*const fn (*Handler, u8, []const u8) void,
++
+@@ -103,0 +109 @@ pub const Handler = struct {
++            .clipboard_write = null,
+@@ -280,0 +287 @@ pub const Handler = struct {
++            .clipboard_contents => self.clipboardWrite(value),
+@@ -293 +299,0 @@ pub const Handler = struct {
+-            .clipboard_contents,
+@@ -309,0 +316,9 @@ pub const Handler = struct {
++    fn clipboardWrite(
++        self: *Handler,
++        value: Action.ClipboardContents,
++    ) void {
++        if (std.mem.eql(u8, value.data, "?")) return;
++        const func = self.effects.clipboard_write orelse return;
++        func(self, value.kind, value.data);
++    }
++
+@@ -1596,0 +1612,39 @@ test "bell effect callback" {
++test "OSC 52 clipboard write effect" {
++    var t: Terminal = try .init(testing.allocator, .{ .cols = 80, .rows = 24 });
++    defer t.deinit(testing.allocator);
++
++    const S = struct {
++        var count: usize = 0;
++        var kind: u8 = 0;
++        var data: []const u8 = "";
++
++        fn clipboardWrite(_: *Handler, value_kind: u8, value_data: []const u8) void {
++            count += 1;
++            kind = value_kind;
++            data = value_data;
++        }
++    };
++    S.count = 0;
++    S.kind = 0;
++    S.data = "";
++
++    var handler: Handler = .init(&t);
++    handler.effects.clipboard_write = &S.clipboardWrite;
++
++    var s: Stream = .initAlloc(testing.allocator, handler);
++    defer s.deinit();
++
++    s.nextSlice("\x1b]52;c;aGVsbG8=\x1b\\");
++    try testing.expectEqual(@as(usize, 1), S.count);
++    try testing.expectEqual(@as(u8, 'c'), S.kind);
++    try testing.expectEqualStrings("aGVsbG8=", S.data);
++
++    s.nextSlice("\x1b]52;c;?\x1b\\");
++    try testing.expectEqual(@as(usize, 1), S.count);
++
++    s.nextSlice("\x1b]52;p;\x07");
++    try testing.expectEqual(@as(usize, 2), S.count);
++    try testing.expectEqual(@as(u8, 'p'), S.kind);
++    try testing.expectEqualStrings("", S.data);
++}
++

--- a/packages/libghostty/test/hook/ghostty_source_test.dart
+++ b/packages/libghostty/test/hook/ghostty_source_test.dart
@@ -253,39 +253,6 @@ void main() {
       );
     });
 
-    test('serializes concurrent cache population', () async {
-      final contentDir = Directory('${tmpDir.path}/content')..createSync();
-      File('${contentDir.path}/marker.txt').writeAsStringSync('ready');
-
-      final tarball = File('${tmpDir.path}/test.tar.gz');
-      Process.runSync('tar', ['czf', tarball.path, '-C', contentDir.path, '.']);
-
-      final serverDir = Directory('${tmpDir.path}/server')..createSync();
-      tarball.copySync('${serverDir.path}/source.tar.gz');
-
-      final server = await TestServer.start(serverDir);
-      addTearDown(server.close);
-
-      final cacheBase = Uri.directory('${tmpDir.path}/cache/');
-      final tarballUrl = '${server.baseUrl}/source.tar.gz';
-      final results = await Future.wait([
-        downloadSource(
-          cacheBase,
-          packageRoot: packageRoot,
-          tarballUrl: tarballUrl,
-        ),
-        downloadSource(
-          cacheBase,
-          packageRoot: packageRoot,
-          tarballUrl: tarballUrl,
-        ),
-      ]);
-
-      expect(results[1].path, results[0].path);
-      expect(File('${results[0].path}/marker.txt').readAsStringSync(), 'ready');
-      expect(server.requestCount, 1);
-    });
-
     test('throws on HTTP error with actionable message', () async {
       final serverDir = Directory('${tmpDir.path}/empty_server')..createSync();
       final server = await TestServer.start(serverDir);
@@ -355,9 +322,7 @@ void main() {
       );
 
       final commit = pinnedCommit(packageRoot);
-      final tarballInCache = File.fromUri(
-        cacheBase.resolve('${commit.substring(0, 12)}-none.tar.gz'),
-      );
+      final tarballInCache = File.fromUri(cacheBase.resolve('$commit.tar.gz'));
       expect(tarballInCache.existsSync(), isFalse);
     });
   });

--- a/packages/libghostty/test/hook/ghostty_source_test.dart
+++ b/packages/libghostty/test/hook/ghostty_source_test.dart
@@ -253,6 +253,39 @@ void main() {
       );
     });
 
+    test('serializes concurrent cache population', () async {
+      final contentDir = Directory('${tmpDir.path}/content')..createSync();
+      File('${contentDir.path}/marker.txt').writeAsStringSync('ready');
+
+      final tarball = File('${tmpDir.path}/test.tar.gz');
+      Process.runSync('tar', ['czf', tarball.path, '-C', contentDir.path, '.']);
+
+      final serverDir = Directory('${tmpDir.path}/server')..createSync();
+      tarball.copySync('${serverDir.path}/source.tar.gz');
+
+      final server = await TestServer.start(serverDir);
+      addTearDown(server.close);
+
+      final cacheBase = Uri.directory('${tmpDir.path}/cache/');
+      final tarballUrl = '${server.baseUrl}/source.tar.gz';
+      final results = await Future.wait([
+        downloadSource(
+          cacheBase,
+          packageRoot: packageRoot,
+          tarballUrl: tarballUrl,
+        ),
+        downloadSource(
+          cacheBase,
+          packageRoot: packageRoot,
+          tarballUrl: tarballUrl,
+        ),
+      ]);
+
+      expect(results[1].path, results[0].path);
+      expect(File('${results[0].path}/marker.txt').readAsStringSync(), 'ready');
+      expect(server.requestCount, 1);
+    });
+
     test('throws on HTTP error with actionable message', () async {
       final serverDir = Directory('${tmpDir.path}/empty_server')..createSync();
       final server = await TestServer.start(serverDir);
@@ -322,7 +355,9 @@ void main() {
       );
 
       final commit = pinnedCommit(packageRoot);
-      final tarballInCache = File.fromUri(cacheBase.resolve('$commit.tar.gz'));
+      final tarballInCache = File.fromUri(
+        cacheBase.resolve('${commit.substring(0, 12)}-none.tar.gz'),
+      );
       expect(tarballInCache.existsSync(), isFalse);
     });
   });

--- a/packages/libghostty/test/hook/ghostty_source_test.dart
+++ b/packages/libghostty/test/hook/ghostty_source_test.dart
@@ -9,6 +9,39 @@ import 'package:test/test.dart';
 import 'helpers/test_server.dart';
 
 void main() {
+  group('ghosttySourceVersion', () {
+    late Directory tmpDir;
+
+    setUp(() {
+      tmpDir = Directory.systemTemp.createTempSync('ghostty_version_test_');
+    });
+
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    test('reads the source archive VERSION file', () {
+      File('${tmpDir.path}/VERSION').writeAsStringSync('1.2.3-dev\n');
+
+      expect(ghosttySourceVersion(tmpDir), '1.2.3-dev');
+    });
+
+    test('falls back to build.zig.zon', () {
+      File('${tmpDir.path}/build.zig.zon').writeAsStringSync('''
+.{
+    .name = .ghostty,
+    .version = "1.3.2-dev",
+}
+''');
+
+      expect(ghosttySourceVersion(tmpDir), '1.3.2-dev');
+    });
+
+    test('rejects missing or invalid versions', () {
+      expect(() => ghosttySourceVersion(tmpDir), throwsStateError);
+      File('${tmpDir.path}/VERSION').writeAsStringSync('not-semver');
+      expect(() => ghosttySourceVersion(tmpDir), throwsStateError);
+    });
+  });
+
   group('pinnedCommit', () {
     test('is a 40-character hex string', () {
       final tmpDir = Directory.systemTemp.createTempSync('pinnedCommit_test_');
@@ -27,6 +60,55 @@ void main() {
       addTearDown(() => tmpDir.deleteSync(recursive: true));
 
       expect(() => pinnedCommit(tmpDir.uri), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('Ghostty patches', () {
+    late Directory tmpDir;
+    late Uri packageRoot;
+
+    setUp(() {
+      tmpDir = Directory.systemTemp.createTempSync('ghostty_patch_test_');
+      packageRoot = Uri.directory('${tmpDir.path}/pkg/');
+      Directory.fromUri(
+        packageRoot.resolve('patches/'),
+      ).createSync(recursive: true);
+      File.fromUri(
+        packageRoot.resolve('ghostty.version'),
+      ).writeAsStringSync('861a9cf537a58a380bc6a0784573b3de3a70415e\n');
+    });
+
+    tearDown(() => tmpDir.deleteSync(recursive: true));
+
+    test('cache key changes with patch content', () {
+      final patch = File.fromUri(packageRoot.resolve('patches/test.patch'));
+      patch.writeAsStringSync('first');
+      final first = ghosttySourceCacheKey(packageRoot);
+
+      patch.writeAsStringSync('second');
+
+      expect(ghosttySourceCacheKey(packageRoot), isNot(first));
+    });
+
+    test('applies packaged patches outside a Git checkout', () {
+      Process.runSync('git', [
+        'init',
+        '--quiet',
+      ], workingDirectory: tmpDir.path);
+      final source = Directory('${tmpDir.path}/source')..createSync();
+      File('${source.path}/value.txt').writeAsStringSync('before\n');
+      File.fromUri(packageRoot.resolve('patches/test.patch')).writeAsStringSync(
+        'diff --git a/value.txt b/value.txt\n'
+        '--- a/value.txt\n'
+        '+++ b/value.txt\n'
+        '@@ -1 +1 @@\n'
+        '-before\n'
+        '+after\n',
+      );
+
+      applyGhosttyPatches(source, packageRoot);
+
+      expect(File('${source.path}/value.txt').readAsStringSync(), 'after\n');
     });
   });
 

--- a/packages/libghostty/test/hook/helpers/test_server.dart
+++ b/packages/libghostty/test/hook/helpers/test_server.dart
@@ -6,16 +6,27 @@ import 'package:shelf_static/shelf_static.dart';
 class TestServer {
   final Uri baseUrl;
   final HttpServer _server;
+  final List<void> _requests;
   Future<void>? _closeFuture;
 
-  TestServer._(this._server, this.baseUrl);
+  TestServer._(this._server, this.baseUrl, this._requests);
+
+  int get requestCount => _requests.length;
 
   Future<void> close() => _closeFuture ??= _server.close();
 
   static Future<TestServer> start(Directory directory) async {
-    final handler = createStaticHandler(directory.path);
-    final server = await io.serve(handler, 'localhost', 0);
+    final staticHandler = createStaticHandler(directory.path);
+    final requests = <void>[];
+    final server = await io.serve(
+      (request) {
+        requests.add(null);
+        return staticHandler(request);
+      },
+      'localhost',
+      0,
+    );
     final baseUrl = Uri.parse('http://localhost:${server.port}');
-    return TestServer._(server, baseUrl);
+    return TestServer._(server, baseUrl, requests);
   }
 }

--- a/packages/libghostty/test/hook/helpers/test_server.dart
+++ b/packages/libghostty/test/hook/helpers/test_server.dart
@@ -6,27 +6,16 @@ import 'package:shelf_static/shelf_static.dart';
 class TestServer {
   final Uri baseUrl;
   final HttpServer _server;
-  final List<void> _requests;
   Future<void>? _closeFuture;
 
-  TestServer._(this._server, this.baseUrl, this._requests);
-
-  int get requestCount => _requests.length;
+  TestServer._(this._server, this.baseUrl);
 
   Future<void> close() => _closeFuture ??= _server.close();
 
   static Future<TestServer> start(Directory directory) async {
-    final staticHandler = createStaticHandler(directory.path);
-    final requests = <void>[];
-    final server = await io.serve(
-      (request) {
-        requests.add(null);
-        return staticHandler(request);
-      },
-      'localhost',
-      0,
-    );
+    final handler = createStaticHandler(directory.path);
+    final server = await io.serve(handler, 'localhost', 0);
     final baseUrl = Uri.parse('http://localhost:${server.port}');
-    return TestServer._(server, baseUrl, requests);
+    return TestServer._(server, baseUrl);
   }
 }

--- a/packages/libghostty/test/hook/library_provider_test.dart
+++ b/packages/libghostty/test/hook/library_provider_test.dart
@@ -41,6 +41,24 @@ void main() {
         expect(libraryExtension(OS.android), 'so');
       });
     });
+
+    group('isTransientWindowsZigFailure', () {
+      test('recognizes the generated helper scanner race', () {
+        expect(
+          isTransientWindowsZigFailure(
+            'failed to spawn uucode_build_tables.exe: FileNotFound',
+          ),
+          isTrue,
+        );
+      });
+
+      test('rejects unrelated Zig failures', () {
+        expect(
+          isTransientWindowsZigFailure('src/main.zig:1:1: error: invalid'),
+          isFalse,
+        );
+      });
+    });
   });
 }
 

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -294,6 +294,29 @@ void main() {
       });
     });
 
+    group('onClipboardWrite', () {
+      test('fires for OSC 52 writes with the raw selector and payload', () {
+        ClipboardWrite? received;
+        terminal.onClipboardWrite = (value) => received = value;
+
+        terminal.write(
+          Uint8List.fromList('\x1b]52;c;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(received?.selector, 'c'.codeUnitAt(0));
+        expect(String.fromCharCodes(received!.payload), 'aGVsbG8=');
+      });
+
+      test('ignores OSC 52 clipboard read queries', () {
+        var count = 0;
+        terminal.onClipboardWrite = (_) => count++;
+
+        terminal.write(Uint8List.fromList('\x1b]52;c;?\x07'.codeUnits));
+
+        expect(count, 0);
+      });
+    });
+
     group('renderState dirty', () {
       test('writing content makes renderState dirty', () {
         renderState.update(terminal);

--- a/packages/libghostty/test/wasm/terminal/terminal_test.dart
+++ b/packages/libghostty/test/wasm/terminal/terminal_test.dart
@@ -276,6 +276,29 @@ void main() {
       });
     });
 
+    group('onClipboardWrite', () {
+      test('fires for OSC 52 writes with the raw selector and payload', () {
+        ClipboardWrite? received;
+        terminal.onClipboardWrite = (value) => received = value;
+
+        terminal.write(
+          Uint8List.fromList('\x1b]52;c;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(received?.selector, 'c'.codeUnitAt(0));
+        expect(String.fromCharCodes(received!.payload), 'aGVsbG8=');
+      });
+
+      test('ignores OSC 52 clipboard read queries', () {
+        var count = 0;
+        terminal.onClipboardWrite = (_) => count++;
+
+        terminal.write(Uint8List.fromList('\x1b]52;c;?\x07'.codeUnits));
+
+        expect(count, 0);
+      });
+    });
+
     group('renderState dirty', () {
       test('writing content makes renderState dirty', () {
         renderState.update(terminal);

--- a/packages/libghostty/tool/build_wasm.dart
+++ b/packages/libghostty/tool/build_wasm.dart
@@ -31,7 +31,10 @@ void main() async {
 void _compileWithZig(Directory sourceDir) {
   final result = Process.runSync('zig', [
     'build',
+    '--global-cache-dir',
+    '${sourceDir.path}/.zig-global-cache',
     '-Demit-lib-vt=true',
+    '-Dversion-string=${ghosttySourceVersion(sourceDir)}',
     '-Dtarget=wasm32-freestanding',
     '-Doptimize=ReleaseSmall',
   ], workingDirectory: sourceDir.path);


### PR DESCRIPTION
## Summary

- expose write-only OSC 52 requests as typed `libghostty` and `flterm` callbacks on native and WASM targets
- keep clipboard read queries disabled and leave decoding, limits, foreground checks, and clipboard access to the embedder
- package the pinned Ghostty C/Zig patch and include patch content in deterministic source-cache keys
- serialize source-cache publication, preserve patch line endings, refresh native outputs, and retry the Windows Zig helper race

## Why

The callback is a trust boundary: libghostty reports the raw selector and base64 payload but receives no clipboard capability. Embedders retain the policy and platform effect.

The source-hook changes are included because they are what apply and reproducibly cache the packaged OSC patch; splitting them would leave this feature uncompilable. This self-contained PR replaces those portions of #101.

## Verification

- `dart test test/hook/ghostty_source_test.dart`: **15 passed**
- native `test/impl/terminal/terminal_test.dart`: **71 passed**
- flterm `test/widgets/terminal_controller_test.dart`: **59 passed**
- `dart format --output=none --set-exit-if-changed packages/flterm packages/libghostty`: clean
- `dart analyze packages/flterm`: only the 3 existing info-level collection-style lints
- CI covers native Linux/macOS/Windows, patched WASM/Chrome, generated desktop consumers, and package contents
