### PR TITLE
fix(libghostty): rethrow terminal callback errors

### DIFF
--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -187,12 +187,13 @@ void main() {
         expect(count, 0);
       });
 
-      test('contains callback exceptions', () {
-        controller.onClipboardWrite = (_) => throw StateError('failure');
+      test('rethrows callback exceptions', () {
+        final error = StateError('clipboard failed');
+        controller.onClipboardWrite = (_) => throw error;
 
         expect(
           () => writeControllerUtf8(controller, '\x1b]52;c;aGVsbG8=\x07'),
-          returnsNormally,
+          throwsA(same(error)),
         );
       });
     });

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Terminal callback errors**: `Terminal.write()` and callback-emitting
+  `Terminal.resize()` rethrow the first effect error after processing completes.
+
 ## 0.0.11
 
 ### Added

--- a/packages/libghostty/README.md
+++ b/packages/libghostty/README.md
@@ -33,6 +33,11 @@ Terminal emulator with screen state, scrollback, cursor, styles, modes, and
 VT stream processing. Register effect callbacks for PTY writes, bell, title
 changes, and more.
 
+Effects run synchronously during `write` and callback-emitting `resize` calls.
+If one or more effects throw, that call finishes processing, notifies its
+listeners, and then rethrows its first failure with the original stack. Catch
+the initiating call when the host needs to recover.
+
 ```dart
 import 'dart:typed_data';
 import 'package:libghostty/libghostty.dart';

--- a/packages/libghostty/lib/src/bindings/native/native.dart
+++ b/packages/libghostty/lib/src/bindings/native/native.dart
@@ -139,10 +139,32 @@ const _renderStateSummaryKeys = <RenderStateData>[.cols, .rows, .dirty];
 class NativeBindings implements GhosttyBindings {
   final _utf8Ptrs = <int, Pointer<Char>>{};
   final _callables = <int, Map<TerminalOption, NativeCallable>>{};
+  ({Object error, StackTrace stackTrace})? _callbackError;
   final _stringBuffers = <int, Map<TerminalOption, _StringBuffer>>{};
 
   NativeCallable? _sysLogCallable;
   NativeCallable? _sysDecodePngCallable;
+
+  void _captureCallbackError(Object error, StackTrace stackTrace) {
+    _callbackError ??= (error: error, stackTrace: stackTrace);
+  }
+
+  T _runNestedCallbackOperation<T>(T Function() operation) {
+    final previousFailure = _callbackError!;
+    _callbackError = null;
+    late final T result;
+    late final ({Object error, StackTrace stackTrace})? failure;
+    try {
+      result = operation();
+    } finally {
+      failure = _callbackError;
+      _callbackError = previousFailure;
+    }
+    if (failure != null) {
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+    return result;
+  }
 
   final _outU8 = calloc<Uint8>();
   final _outU16 = calloc<Uint16>();
@@ -915,11 +937,42 @@ class NativeBindings implements GhosttyBindings {
   @override
   void terminalVtWrite(int handle, Uint8List data) {
     if (data.isEmpty) return;
+    if (_callables.isEmpty) {
+      using((arena) {
+        final ptr = arena<Uint8>(data.length);
+        ptr.asTypedList(data.length).setAll(0, data);
+        ghostty_terminal_vt_write(
+          Pointer.fromAddress(handle),
+          ptr,
+          data.length,
+        );
+      });
+      return;
+    }
+    if (_callbackError != null) {
+      _runNestedCallbackOperation<void>(() {
+        using((arena) {
+          final ptr = arena<Uint8>(data.length);
+          ptr.asTypedList(data.length).setAll(0, data);
+          ghostty_terminal_vt_write(
+            Pointer.fromAddress(handle),
+            ptr,
+            data.length,
+          );
+        });
+      });
+      return;
+    }
     using((arena) {
       final ptr = arena<Uint8>(data.length);
       ptr.asTypedList(data.length).setAll(0, data);
       ghostty_terminal_vt_write(Pointer.fromAddress(handle), ptr, data.length);
     });
+    final failure = _callbackError;
+    if (failure != null) {
+      _callbackError = null;
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
   }
 
   @override
@@ -930,13 +983,39 @@ class NativeBindings implements GhosttyBindings {
     int cellWidthPx,
     int cellHeightPx,
   ) {
-    return ghostty_terminal_resize(
+    if (_callables.isEmpty) {
+      return ghostty_terminal_resize(
+        Pointer.fromAddress(handle),
+        cols,
+        rows,
+        cellWidthPx,
+        cellHeightPx,
+      );
+    }
+    if (_callbackError != null) {
+      return _runNestedCallbackOperation(
+        () => ghostty_terminal_resize(
+          Pointer.fromAddress(handle),
+          cols,
+          rows,
+          cellWidthPx,
+          cellHeightPx,
+        ),
+      );
+    }
+    final result = ghostty_terminal_resize(
       Pointer.fromAddress(handle),
       cols,
       rows,
       cellWidthPx,
       cellHeightPx,
     );
+    final failure = _callbackError;
+    if (failure != null) {
+      _callbackError = null;
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+    return result;
   }
 
   @override
@@ -3471,7 +3550,9 @@ class NativeBindings implements GhosttyBindings {
         ) {
           try {
             callback(Uint8List.fromList(data.asTypedList(len)));
-          } on Object catch (_) {}
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
+          }
         });
     map[TerminalOption.writePty] = callable;
     ghostty_terminal_set(
@@ -3503,7 +3584,9 @@ class NativeBindings implements GhosttyBindings {
         ) {
           try {
             callback();
-          } on Object catch (_) {}
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
+          }
         });
     map[TerminalOption.bell] = callable;
     ghostty_terminal_set(
@@ -3561,7 +3644,8 @@ class NativeBindings implements GhosttyBindings {
               location: request.location,
               contents: List.unmodifiable(contents),
             )).value;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             return ClipboardWriteResult.ioError.value;
           }
         }, exceptionalReturn: _clipboardWriteExceptionResult);
@@ -3595,7 +3679,9 @@ class NativeBindings implements GhosttyBindings {
         ) {
           try {
             callback();
-          } on Object catch (_) {}
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
+          }
         });
     map[TerminalOption.titleChanged] = callable;
     ghostty_terminal_set(
@@ -3627,7 +3713,9 @@ class NativeBindings implements GhosttyBindings {
         ) {
           try {
             callback();
-          } on Object catch (_) {}
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
+          }
         });
     map[TerminalOption.pwdChanged] = callable;
     ghostty_terminal_set(
@@ -3674,7 +3762,8 @@ class NativeBindings implements GhosttyBindings {
             strPtr.ref.ptr = dataPtr;
             strPtr.ref.len = bytes.length;
             return strPtr.ref;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             strPtr.ref.ptr = nullptr;
             strPtr.ref.len = 0;
             return strPtr.ref;
@@ -3726,7 +3815,8 @@ class NativeBindings implements GhosttyBindings {
             strPtr.ref.ptr = dataPtr;
             strPtr.ref.len = bytes.length;
             return strPtr.ref;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             strPtr.ref.ptr = nullptr;
             strPtr.ref.len = 0;
             return strPtr.ref;
@@ -3771,7 +3861,8 @@ class NativeBindings implements GhosttyBindings {
             if (result == null) return false;
             outScheme.value = result.value;
             return true;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             return false;
           }
         }, exceptionalReturn: false);
@@ -3814,7 +3905,8 @@ class NativeBindings implements GhosttyBindings {
             outSize.ref.cell_width = result.cellWidth;
             outSize.ref.cell_height = result.cellHeight;
             return true;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             return false;
           }
         }, exceptionalReturn: false);
@@ -3871,7 +3963,8 @@ class NativeBindings implements GhosttyBindings {
                 result.secondary.romCartridge;
             outAttrs.ref.tertiary.unit_id = result.tertiary.unitId;
             return true;
-          } on Object catch (_) {
+          } on Object catch (error, stackTrace) {
+            _captureCallbackError(error, stackTrace);
             return false;
           }
         }, exceptionalReturn: false);

--- a/packages/libghostty/lib/src/bindings/wasm/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/wasm.dart
@@ -177,6 +177,7 @@ class WasmBindings implements GhosttyBindings {
   final GhosttyExports _exports;
   final _utf8Ptrs = <int, (int ptr, int len)>{};
   final _callbacks = <int, Map<TerminalOption, (int index, Function fn)>>{};
+  ({Object error, StackTrace stackTrace})? _callbackError;
   final _stringBufs = <int, Map<TerminalOption, (int ptr, int len)>>{};
   final _cellGetMultiArguments = List<JSAny?>.filled(5, null);
   final _rowGetMultiArguments = List<JSAny?>.filled(5, null);
@@ -199,6 +200,27 @@ class WasmBindings implements GhosttyBindings {
   late final int _cellMultiOut;
   late int _formatBuffer;
   late int _formatBufferCapacity;
+
+  void _captureCallbackError(Object error, StackTrace stackTrace) {
+    _callbackError ??= (error: error, stackTrace: stackTrace);
+  }
+
+  T _runNestedCallbackOperation<T>(T Function() operation) {
+    final previousFailure = _callbackError!;
+    _callbackError = null;
+    late final T result;
+    late final ({Object error, StackTrace stackTrace})? failure;
+    try {
+      result = operation();
+    } finally {
+      failure = _callbackError;
+      _callbackError = previousFailure;
+    }
+    if (failure != null) {
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+    return result;
+  }
 
   WasmBindings._(JSObject exports)
     : _exports = GhosttyExports(exports),
@@ -1090,8 +1112,25 @@ class WasmBindings implements GhosttyBindings {
     if (data.isEmpty) return;
     final ptr = _exports.ghostty_wasm_alloc_u8_array(data.length);
     _mem.writeBytes(ptr, data);
+    if (_callbacks.isEmpty) {
+      _exports.ghostty_terminal_vt_write(handle, ptr, data.length);
+      _exports.ghostty_wasm_free_u8_array(ptr, data.length);
+      return;
+    }
+    if (_callbackError != null) {
+      _runNestedCallbackOperation<void>(() {
+        _exports.ghostty_terminal_vt_write(handle, ptr, data.length);
+        _exports.ghostty_wasm_free_u8_array(ptr, data.length);
+      });
+      return;
+    }
     _exports.ghostty_terminal_vt_write(handle, ptr, data.length);
     _exports.ghostty_wasm_free_u8_array(ptr, data.length);
+    final failure = _callbackError;
+    if (failure != null) {
+      _callbackError = null;
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
   }
 
   @override
@@ -1102,7 +1141,31 @@ class WasmBindings implements GhosttyBindings {
     int cellWidthPx,
     int cellHeightPx,
   ) {
-    return .fromValue(
+    if (_callbacks.isEmpty) {
+      return .fromValue(
+        _exports.ghostty_terminal_resize(
+          handle,
+          cols,
+          rows,
+          cellWidthPx,
+          cellHeightPx,
+        ),
+      );
+    }
+    if (_callbackError != null) {
+      return _runNestedCallbackOperation(
+        () => Result.fromValue(
+          _exports.ghostty_terminal_resize(
+            handle,
+            cols,
+            rows,
+            cellWidthPx,
+            cellHeightPx,
+          ),
+        ),
+      );
+    }
+    final result = Result.fromValue(
       _exports.ghostty_terminal_resize(
         handle,
         cols,
@@ -1111,6 +1174,12 @@ class WasmBindings implements GhosttyBindings {
         cellHeightPx,
       ),
     );
+    final failure = _callbackError;
+    if (failure != null) {
+      _callbackError = null;
+      Error.throwWithStackTrace(failure.error, failure.stackTrace);
+    }
+    return result;
   }
 
   @override
@@ -1536,7 +1605,9 @@ class WasmBindings implements GhosttyBindings {
       ((int terminal, int userdata, int dataPtr, int len) {
         try {
           callback(Uint8List.fromList(_mem.readBytes(dataPtr, len)));
-        } on Object catch (_) {}
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
+        }
       }).toJS,
       ['i32', 'i32', 'i32', 'i32'],
       reuseIndex: reuseIndex,
@@ -1562,7 +1633,9 @@ class WasmBindings implements GhosttyBindings {
       ((int terminal, int userdata) {
         try {
           callback();
-        } on Object catch (_) {}
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
+        }
       }).toJS,
       ['i32', 'i32'],
       reuseIndex: reuseIndex,
@@ -1608,7 +1681,8 @@ class WasmBindings implements GhosttyBindings {
             ),
             contents: List.unmodifiable(contents),
           )).value;
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           return ClipboardWriteResult.ioError.value;
         }
       }).toJS,
@@ -1637,7 +1711,9 @@ class WasmBindings implements GhosttyBindings {
       ((int terminal, int userdata) {
         try {
           callback();
-        } on Object catch (_) {}
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
+        }
       }).toJS,
       ['i32', 'i32'],
       reuseIndex: reuseIndex,
@@ -1663,7 +1739,9 @@ class WasmBindings implements GhosttyBindings {
       ((int terminal, int userdata) {
         try {
           callback();
-        } on Object catch (_) {}
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
+        }
       }).toJS,
       ['i32', 'i32'],
       reuseIndex: reuseIndex,
@@ -1700,7 +1778,8 @@ class WasmBindings implements GhosttyBindings {
           bufMap[option] = (ptr, data.length);
           _mem.writeU32(sretPtr, ptr);
           _mem.writeU32(sretPtr + _layout.stringLen, data.length);
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           _mem.writeU32(sretPtr, 0);
           _mem.writeU32(sretPtr + _layout.stringLen, 0);
         }
@@ -1741,7 +1820,8 @@ class WasmBindings implements GhosttyBindings {
           bufMap[option] = (ptr, bytes.length);
           _mem.writeU32(sretPtr, ptr);
           _mem.writeU32(sretPtr + _layout.stringLen, bytes.length);
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           _mem.writeU32(sretPtr, 0);
           _mem.writeU32(sretPtr + _layout.stringLen, 0);
         }
@@ -1776,7 +1856,8 @@ class WasmBindings implements GhosttyBindings {
           if (result == null) return 0;
           _mem.writeU32(outPtr, result.value);
           return 1;
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           return 0;
         }
       }).toJS,
@@ -1814,7 +1895,8 @@ class WasmBindings implements GhosttyBindings {
             result.cellHeight,
           );
           return 1;
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           return 0;
         }
       }).toJS,
@@ -1875,7 +1957,8 @@ class WasmBindings implements GhosttyBindings {
             result.tertiary.unitId,
           );
           return 1;
-        } on Object catch (_) {
+        } on Object catch (error, stackTrace) {
+          _captureCallbackError(error, stackTrace);
           return 0;
         }
       }).toJS,

--- a/packages/libghostty/lib/src/impl/terminal/terminal.dart
+++ b/packages/libghostty/lib/src/impl/terminal/terminal.dart
@@ -47,13 +47,17 @@ part 'tracked_grid_ref.dart';
 ///
 /// ## Effects
 ///
-/// Effects are callbacks invoked synchronously during [write] in response to
-/// VT sequences. Register them by assigning the callback setters ([onWritePty],
-/// [onBell], [onTitleChanged], etc.). Set to null to disable.
+/// Effects are callbacks invoked synchronously by terminal operations. Most
+/// respond to VT sequences during [write], while [onWritePty] can also fire
+/// during a callback-emitting [resize]. Register them by assigning the callback
+/// setters ([onWritePty], [onBell], [onTitleChanged], etc.). Set to null to
+/// disable.
 ///
-/// All callbacks fire synchronously during [write]. Callers **must not** call
-/// [write] from within a callback (no reentrancy), and callbacks should avoid
-/// blocking or expensive operations since they block further I/O processing.
+/// Callbacks run synchronously. Callers **must not** call [write] from within a
+/// callback (no reentrancy), and callbacks should avoid blocking or expensive
+/// operations since they block further I/O processing. Callback exceptions do
+/// not interrupt terminal processing. After the initiating operation finishes,
+/// the first exception is rethrown with its original stack trace.
 ///
 /// ## Color Theme
 ///
@@ -361,9 +365,9 @@ final class Terminal with Listenable {
   /// Registers a callback for PTY write-back data.
   ///
   /// Invoked when the terminal needs to send data back to the PTY, for
-  /// example in response to device status reports or mode queries. The data
-  /// is only valid for the duration of the callback; copy it if needed.
-  /// Fires synchronously during [write].
+  /// example in response to device status reports or mode queries. The data is
+  /// owned by Dart and remains valid after the callback returns. Fires
+  /// synchronously during [write].
   set onWritePty(ValueSetter<Uint8List>? value) {
     bindings.terminalSetOnWritePty(_handle, value);
   }
@@ -555,15 +559,31 @@ final class Terminal with Listenable {
   ///
   /// Throws [InvalidValueException] if [cols] or [rows] is zero.
   /// Throws [OutOfMemoryException] if reflow allocation fails.
+  /// If an effect callback throws, the resize completes and listeners are
+  /// notified before the exception is rethrown.
   void resize({
     required int cols,
     required int rows,
     int cellWidthPx = 0,
     int cellHeightPx = 0,
   }) {
-    checkCode(
-      bindings.terminalResize(_handle, cols, rows, cellWidthPx, cellHeightPx),
-    );
+    late final Result result;
+    try {
+      result = bindings.terminalResize(
+        _handle,
+        cols,
+        rows,
+        cellWidthPx,
+        cellHeightPx,
+      );
+    } on Object catch (error, stackTrace) {
+      try {
+        notifyListeners();
+      } finally {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+    }
+    checkCode(result);
     notifyListeners();
   }
 
@@ -720,10 +740,11 @@ final class Terminal with Listenable {
 
   /// Feeds raw VT-encoded bytes into the terminal for processing.
   ///
-  /// Never fails: malformed input is logged internally but does not corrupt
-  /// state or throw. All registered callbacks fire synchronously during this
-  /// call. Callers **must not** call [write] from within a callback (no
-  /// reentrancy).
+  /// Malformed input is logged internally but does not corrupt state or throw.
+  /// All registered callbacks fire synchronously during this call. Callers
+  /// **must not** call [write] from within a callback (no reentrancy). If one
+  /// or more callbacks throw, processing finishes and listeners are notified
+  /// before the first exception is rethrown with its original stack trace.
   ///
   /// Sequences requiring output (device status reports, mode queries) are
   /// silently ignored unless [onWritePty] is registered. Notifies listeners
@@ -733,7 +754,15 @@ final class Terminal with Listenable {
   /// terminal.write(Uint8List.fromList(utf8.encode('Hello\r\n')));
   /// ```
   void write(Uint8List data) {
-    bindings.terminalVtWrite(_handle, data);
+    try {
+      bindings.terminalVtWrite(_handle, data);
+    } on Object catch (error, stackTrace) {
+      try {
+        notifyListeners();
+      } finally {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+    }
     notifyListeners();
   }
 

--- a/packages/libghostty/test/bindings/bindings_native_test.dart
+++ b/packages/libghostty/test/bindings/bindings_native_test.dart
@@ -47,6 +47,40 @@ void main() {
     });
 
     group('terminalVtWrite', () {
+      StackTrace captureStackTrace(void Function() operation) {
+        try {
+          operation();
+        } on Object catch (_, stackTrace) {
+          return stackTrace;
+        }
+        fail('Expected operation to throw');
+      }
+
+      test('rethrows callback errors', () {
+        final error = StateError('bell failed');
+        bindings.terminalSetOnBell(terminal, () => throw error);
+
+        expect(
+          () => bindings.terminalVtWrite(terminal, Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+      });
+
+      test('preserves callback error stack traces', () {
+        final error = StateError('bell failed');
+        final callbackStackTrace = StackTrace.current;
+        bindings.terminalSetOnBell(
+          terminal,
+          () => Error.throwWithStackTrace(error, callbackStackTrace),
+        );
+
+        final stackTrace = captureStackTrace(
+          () => bindings.terminalVtWrite(terminal, Uint8List.fromList([0x07])),
+        );
+
+        expect(stackTrace.toString(), callbackStackTrace.toString());
+      });
+
       test('updates row iterator cells', () {
         bindings.terminalVtWrite(
           terminal,

--- a/packages/libghostty/test/impl/terminal/terminal_test.dart
+++ b/packages/libghostty/test/impl/terminal/terminal_test.dart
@@ -35,6 +35,19 @@ void main() {
       });
     });
 
+    group('dispose', () {
+      test('succeeds after a callback error', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        expect(terminal.dispose, returnsNormally);
+      });
+    });
+
     group('geometry', () {
       test('returns cell and pixel dimensions', () {
         terminal.resize(cols: 40, rows: 10, cellWidthPx: 8, cellHeightPx: 16);
@@ -46,6 +59,205 @@ void main() {
     });
 
     group('write', () {
+      Object captureError(void Function() operation) {
+        try {
+          operation();
+        } on Object catch (error) {
+          return error;
+        }
+        fail('Expected operation to throw');
+      }
+
+      test('notifies listeners before rethrowing callback errors', () {
+        final error = StateError('bell failed');
+        var notifications = 0;
+        terminal.onBell = () => throw error;
+        terminal.addListener(() => notifications++);
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        expect(notifications, 1);
+      });
+
+      test('rethrows PTY output callback errors', () {
+        final error = StateError('output failed');
+        terminal.onWritePty = (_) => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[5n'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows title change callback errors', () {
+        final error = StateError('title failed');
+        terminal.onTitleChanged = () => throw error;
+
+        expect(
+          () =>
+              terminal.write(Uint8List.fromList('\x1b]0;Title\x07'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows working directory callback errors', () {
+        final error = StateError('pwd failed');
+        terminal.onPwdChanged = () => throw error;
+
+        expect(
+          () => terminal.write(
+            Uint8List.fromList('\x1b]7;file:///tmp\x07'.codeUnits),
+          ),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows enquiry callback errors', () {
+        final error = StateError('enquiry failed');
+        terminal.onEnquiry = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x05])),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows version query callback errors', () {
+        final error = StateError('version failed');
+        terminal.onXtversion = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[>q'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows color scheme callback errors', () {
+        final error = StateError('color scheme failed');
+        terminal.onColorScheme = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[?996n'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows size query callback errors', () {
+        final error = StateError('size failed');
+        terminal.onSize = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[18t'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows device attributes callback errors', () {
+        final error = StateError('device attributes failed');
+        terminal.onDeviceAttributes = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[c'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows failures for each operation across terminals', () {
+        final inner = Terminal(cols: 80, rows: 24);
+        addTearDown(inner.dispose);
+        final outerError = StateError('outer failure');
+        final innerError = StateError('inner failure');
+        Object? nestedError;
+        terminal.onBell = () => throw outerError;
+        terminal.onTitleChanged = () {
+          nestedError = captureError(() => inner.resize(cols: 100, rows: 40));
+        };
+        inner.onWritePty = (_) => throw innerError;
+        inner.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        final outerThrown = captureError(
+          () => terminal.write(
+            Uint8List.fromList('\x07\x1b]0;nested\x1b\\'.codeUnits),
+          ),
+        );
+
+        expect(
+          (outer: outerThrown, inner: nestedError),
+          (outer: outerError, inner: innerError),
+        );
+      });
+
+      test('rethrows failures for each operation on the same terminal', () {
+        final outerError = StateError('outer failure');
+        final innerError = StateError('inner failure');
+        Object? nestedError;
+        terminal.onBell = () => throw outerError;
+        terminal.onTitleChanged = () {
+          nestedError = captureError(
+            () => terminal.resize(cols: 100, rows: 40),
+          );
+        };
+        terminal.onWritePty = (_) => throw innerError;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        final outerThrown = captureError(
+          () => terminal.write(
+            Uint8List.fromList('\x07\x1b]0;nested\x1b\\'.codeUnits),
+          ),
+        );
+
+        expect(
+          (outer: outerThrown, inner: nestedError),
+          (outer: outerError, inner: innerError),
+        );
+      });
+
+      test('rethrows the first of multiple callback errors', () {
+        final first = StateError('first failure');
+        final second = StateError('second failure');
+        final errors = [first, second].iterator;
+        terminal.onBell = () {
+          errors.moveNext();
+          throw errors.current;
+        };
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07, 0x07])),
+          throwsA(same(first)),
+        );
+
+        expect(errors.moveNext(), isFalse);
+      });
+
+      test('finishes terminal mutation before rethrowing', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('A\x07B'.codeUnits)),
+          throwsA(same(error)),
+        );
+
+        expect(readRowText(terminal, 0), startsWith('AB'));
+      });
+
+      test('keeps the terminal usable after a callback error', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        terminal.onBell = null;
+        terminal.write(Uint8List.fromList('ready'.codeUnits));
+
+        expect(readRowText(terminal, 0), startsWith('ready'));
+      });
+
       test('updates screen cells', () {
         terminal.write(Uint8List.fromList('Hello'.codeUnits));
         final h = readCellAt(terminal, 0, 0);
@@ -425,14 +637,15 @@ void main() {
         expect(count, 0);
       });
 
-      test('contains callback exceptions', () {
-        terminal.onClipboardWrite = (_) => throw StateError('failure');
+      test('rethrows callback exceptions', () {
+        final error = StateError('clipboard failed');
+        terminal.onClipboardWrite = (_) => throw error;
 
         expect(
           () => terminal.write(
             Uint8List.fromList('\x1b]52;c;aGVsbG8=\x07'.codeUnits),
           ),
-          returnsNormally,
+          throwsA(same(error)),
         );
       });
     });
@@ -478,6 +691,35 @@ void main() {
         renderState.update(terminal);
         expect(renderState.cols, 120);
         expect(renderState.rows, 40);
+      });
+
+      test('rethrows output callback errors', () {
+        final error = StateError('resize output failed');
+        terminal.onWritePty = (_) => throw error;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        expect(
+          () => terminal.resize(cols: 100, rows: 40),
+          throwsA(same(error)),
+        );
+      });
+
+      test('updates dimensions before rethrowing output callback errors', () {
+        final error = StateError('resize output failed');
+        terminal.onWritePty = (_) => throw error;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        expect(
+          () => terminal.resize(cols: 100, rows: 40),
+          throwsA(same(error)),
+        );
+
+        expect(terminal.geometry, (
+          cols: 100,
+          rows: 40,
+          widthPx: 0,
+          heightPx: 0,
+        ));
       });
 
       test('emits in-band size report when mode 2048 is enabled', () {
@@ -736,6 +978,18 @@ void main() {
         terminal.write(Uint8List.fromList('\x1b[H'.codeUnits));
         renderState.update(terminal);
         expect(isRowDirty(renderState, 0), isFalse);
+      });
+    });
+
+    group('onWritePty', () {
+      test('retains response bytes after terminal disposal', () {
+        Uint8List? output;
+        terminal.onWritePty = (data) => output = data;
+        terminal.write(Uint8List.fromList('\x1b[5n'.codeUnits));
+
+        terminal.dispose();
+
+        expect(output, [0x1b, 0x5b, 0x30, 0x6e]);
       });
     });
 

--- a/packages/libghostty/test/wasm/bindings_wasm_test.dart
+++ b/packages/libghostty/test/wasm/bindings_wasm_test.dart
@@ -184,6 +184,40 @@ void main() {
     });
 
     group('terminalVtWrite', () {
+      StackTrace captureStackTrace(void Function() operation) {
+        try {
+          operation();
+        } on Object catch (_, stackTrace) {
+          return stackTrace;
+        }
+        fail('Expected operation to throw');
+      }
+
+      test('rethrows callback errors', () {
+        final error = StateError('bell failed');
+        bindings.terminalSetOnBell(terminal, () => throw error);
+
+        expect(
+          () => bindings.terminalVtWrite(terminal, Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+      });
+
+      test('preserves callback error stack traces', () {
+        final error = StateError('bell failed');
+        final callbackStackTrace = StackTrace.current;
+        bindings.terminalSetOnBell(
+          terminal,
+          () => Error.throwWithStackTrace(error, callbackStackTrace),
+        );
+
+        final stackTrace = captureStackTrace(
+          () => bindings.terminalVtWrite(terminal, Uint8List.fromList([0x07])),
+        );
+
+        expect(stackTrace.toString(), callbackStackTrace.toString());
+      });
+
       test('updates row iterator cells', () {
         bindings.terminalVtWrite(
           terminal,

--- a/packages/libghostty/test/wasm/terminal/terminal_test.dart
+++ b/packages/libghostty/test/wasm/terminal/terminal_test.dart
@@ -38,7 +38,219 @@ void main() {
       });
     });
 
+    group('dispose', () {
+      test('succeeds after a callback error', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        expect(terminal.dispose, returnsNormally);
+      });
+    });
+
     group('write', () {
+      Object captureError(void Function() operation) {
+        try {
+          operation();
+        } on Object catch (error) {
+          return error;
+        }
+        fail('Expected operation to throw');
+      }
+
+      test('notifies listeners before rethrowing callback errors', () {
+        final error = StateError('bell failed');
+        var notifications = 0;
+        terminal.onBell = () => throw error;
+        terminal.addListener(() => notifications++);
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        expect(notifications, 1);
+      });
+
+      test('rethrows PTY output callback errors', () {
+        final error = StateError('output failed');
+        terminal.onWritePty = (_) => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[5n'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows title change callback errors', () {
+        final error = StateError('title failed');
+        terminal.onTitleChanged = () => throw error;
+
+        expect(
+          () =>
+              terminal.write(Uint8List.fromList('\x1b]0;Title\x07'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows working directory callback errors', () {
+        final error = StateError('pwd failed');
+        terminal.onPwdChanged = () => throw error;
+
+        expect(
+          () => terminal.write(
+            Uint8List.fromList('\x1b]7;file:///tmp\x07'.codeUnits),
+          ),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows enquiry callback errors', () {
+        final error = StateError('enquiry failed');
+        terminal.onEnquiry = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x05])),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows version query callback errors', () {
+        final error = StateError('version failed');
+        terminal.onXtversion = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[>q'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows color scheme callback errors', () {
+        final error = StateError('color scheme failed');
+        terminal.onColorScheme = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[?996n'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows size query callback errors', () {
+        final error = StateError('size failed');
+        terminal.onSize = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[18t'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows device attributes callback errors', () {
+        final error = StateError('device attributes failed');
+        terminal.onDeviceAttributes = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('\x1b[c'.codeUnits)),
+          throwsA(same(error)),
+        );
+      });
+
+      test('rethrows failures for each operation across terminals', () {
+        final inner = Terminal(cols: 80, rows: 24);
+        addTearDown(inner.dispose);
+        final outerError = StateError('outer failure');
+        final innerError = StateError('inner failure');
+        Object? nestedError;
+        terminal.onBell = () => throw outerError;
+        terminal.onTitleChanged = () {
+          nestedError = captureError(() => inner.resize(cols: 100, rows: 40));
+        };
+        inner.onWritePty = (_) => throw innerError;
+        inner.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        final outerThrown = captureError(
+          () => terminal.write(
+            Uint8List.fromList('\x07\x1b]0;nested\x1b\\'.codeUnits),
+          ),
+        );
+
+        expect(
+          (outer: outerThrown, inner: nestedError),
+          (outer: outerError, inner: innerError),
+        );
+      });
+
+      test('rethrows failures for each operation on the same terminal', () {
+        final outerError = StateError('outer failure');
+        final innerError = StateError('inner failure');
+        Object? nestedError;
+        terminal.onBell = () => throw outerError;
+        terminal.onTitleChanged = () {
+          nestedError = captureError(
+            () => terminal.resize(cols: 100, rows: 40),
+          );
+        };
+        terminal.onWritePty = (_) => throw innerError;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        final outerThrown = captureError(
+          () => terminal.write(
+            Uint8List.fromList('\x07\x1b]0;nested\x1b\\'.codeUnits),
+          ),
+        );
+
+        expect(
+          (outer: outerThrown, inner: nestedError),
+          (outer: outerError, inner: innerError),
+        );
+      });
+
+      test('rethrows the first of multiple callback errors', () {
+        final first = StateError('first failure');
+        final second = StateError('second failure');
+        final errors = [first, second].iterator;
+        terminal.onBell = () {
+          errors.moveNext();
+          throw errors.current;
+        };
+
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07, 0x07])),
+          throwsA(same(first)),
+        );
+
+        expect(errors.moveNext(), isFalse);
+      });
+
+      test('finishes terminal mutation before rethrowing', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+
+        expect(
+          () => terminal.write(Uint8List.fromList('A\x07B'.codeUnits)),
+          throwsA(same(error)),
+        );
+
+        expect(readRowText(terminal, 0), startsWith('AB'));
+      });
+
+      test('keeps the terminal usable after a callback error', () {
+        final error = StateError('bell failed');
+        terminal.onBell = () => throw error;
+        expect(
+          () => terminal.write(Uint8List.fromList([0x07])),
+          throwsA(same(error)),
+        );
+
+        terminal.onBell = null;
+        terminal.write(Uint8List.fromList('ready'.codeUnits));
+
+        expect(readRowText(terminal, 0), startsWith('ready'));
+      });
+
       test('updates screen cells', () {
         terminal.write(Uint8List.fromList('Hello'.codeUnits));
         final h = readCellAt(terminal, 0, 0);
@@ -371,14 +583,15 @@ void main() {
         expect(count, 0);
       });
 
-      test('contains callback exceptions', () {
-        terminal.onClipboardWrite = (_) => throw StateError('failure');
+      test('rethrows callback exceptions', () {
+        final error = StateError('clipboard failed');
+        terminal.onClipboardWrite = (_) => throw error;
 
         expect(
           () => terminal.write(
             Uint8List.fromList('\x1b]52;c;aGVsbG8=\x07'.codeUnits),
           ),
-          returnsNormally,
+          throwsA(same(error)),
         );
       });
     });
@@ -424,6 +637,35 @@ void main() {
         renderState.update(terminal);
         expect(renderState.cols, 120);
         expect(renderState.rows, 40);
+      });
+
+      test('rethrows output callback errors', () {
+        final error = StateError('resize output failed');
+        terminal.onWritePty = (_) => throw error;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        expect(
+          () => terminal.resize(cols: 100, rows: 40),
+          throwsA(same(error)),
+        );
+      });
+
+      test('updates dimensions before rethrowing output callback errors', () {
+        final error = StateError('resize output failed');
+        terminal.onWritePty = (_) => throw error;
+        terminal.modeSet(const TerminalMode.inBandResize(), value: true);
+
+        expect(
+          () => terminal.resize(cols: 100, rows: 40),
+          throwsA(same(error)),
+        );
+
+        expect(terminal.geometry, (
+          cols: 100,
+          rows: 40,
+          widthPx: 0,
+          heightPx: 0,
+        ));
       });
 
       test('clamps cursor', () {
@@ -679,6 +921,16 @@ void main() {
     });
 
     group('onWritePty', () {
+      test('retains response bytes after terminal disposal', () {
+        Uint8List? output;
+        terminal.onWritePty = (data) => output = data;
+        terminal.write(Uint8List.fromList('\x1b[5n'.codeUnits));
+
+        terminal.dispose();
+
+        expect(output, [0x1b, 0x5b, 0x30, 0x6e]);
+      });
+
       test('receives terminal responses', () {
         Uint8List? received;
         terminal.onWritePty = (data) => received = data;


### PR DESCRIPTION
Capture terminal effect callback exceptions across native and WASM, finish the initiating write or resize, notify listeners, then rethrow the first failure with its original stack. Nested operations keep their errors isolated, and the terminal remains usable afterward.