### PR TITLE
fix(flterm): Windows text input + TUI wheel/trackpad scroll forwarding

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Windows keyboard input**: the text input client now reports the hosting
+  `FlutterView` id when attaching, so desktop embedders can resolve the
+  target view. This fixes typing being dead on Windows, where the attach
+  failed with `Could not set client, view ID is null.`.
+
 ## 0.0.4
 
 ### Breaking

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -101,6 +101,9 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
+  set viewId(int? value) => _textInput.viewId = value;
+
+  @override
   TerminalConfig get config => _config;
 
   @override

--- a/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
+++ b/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
@@ -70,6 +70,9 @@ class _TerminalGestureDetectorState extends State<TerminalGestureDetector> {
       // é neutralizado (`NeverScrollableScrollPhysics`) nesse modo no
       // `TerminalView`, evitando dois consumidores disputando o pointer signal.
       onPointerSignal: tracked ? _handlePointerSignal : null,
+      // macOS entrega o trackpad como pan/zoom; encaminha igual ao wheel.
+      onPointerPanZoomStart: tracked ? _handlePointerPanZoomStart : null,
+      onPointerPanZoomUpdate: tracked ? _handlePointerPanZoomUpdate : null,
       child: TerminalRawGestureDetector(
         onTapDown: _handleTapDown,
         onTapUp: _handleTapUp,
@@ -288,39 +291,69 @@ class _TerminalGestureDetectorState extends State<TerminalGestureDetector> {
   /// pequenos e frequentes; acumulamos pra não rolar rápido demais).
   double _wheelAccum = 0;
 
-  /// Encaminha o wheel pro app como reporte de mouse (botão 4 = cima,
-  /// 5 = baixo) quando o mouse tracking está ligado. Segurando Shift o app não
-  /// recebe (o terminal deixa o Shift+wheel pro scroll local), como o resto.
+  /// Pan acumulado do gesto pan/zoom em curso (o [PointerPanZoomUpdateEvent.pan]
+  /// é acumulado desde o start; derivamos o delta por update).
+  Offset _panZoomLast = Offset.zero;
+
+  /// Wheel via [PointerSignalEvent] — mouse de verdade e, no macOS, o scroll
+  /// sintetizado do trackpad. Encaminha pro app como reporte de mouse.
   void _handlePointerSignal(PointerSignalEvent event) {
     if (event is! PointerScrollEvent) return;
     if (!_isMouseTracked(HardwareKeyboard.instance.isShiftPressed)) return;
+    // Mouse = discreto (um notch por evento); trackpad = contínuo (acumula).
+    _forwardScroll(
+      event.scrollDelta.dy,
+      event.localPosition,
+      discrete: event.kind == PointerDeviceKind.mouse,
+    );
+  }
+
+  // No macOS o trackpad muitas vezes chega como gesto **pan/zoom** (não como
+  // PointerScrollEvent), então sem tratar isso o scroll de dois dedos não
+  // encaminha nada pro app. Mesmo caminho de forward do wheel, contínuo.
+  void _handlePointerPanZoomStart(PointerPanZoomStartEvent event) {
+    _panZoomLast = Offset.zero;
+    _wheelAccum = 0;
+  }
+
+  void _handlePointerPanZoomUpdate(PointerPanZoomUpdateEvent event) {
+    if (!_isMouseTracked(HardwareKeyboard.instance.isShiftPressed)) return;
+    final dy = event.pan.dy - _panZoomLast.dy;
+    _panZoomLast = event.pan;
+    // Pan tem sinal oposto ao scrollDelta (dedo pra cima = pan.dy negativo =
+    // ver conteúdo abaixo = scroll down); invertendo, reusa a convenção.
+    _forwardScroll(-dy, event.localPosition, discrete: false);
+  }
+
+  /// Converte um delta vertical (px, convenção de `scrollDelta`) em passos de
+  /// linha e encaminha ao app como wheel (botão 4 = cima, 5 = baixo).
+  /// [discrete] = mouse (≥1 linha/notch, sem acumular); contínuo = trackpad.
+  void _forwardScroll(double deltaY, Offset localPosition,
+      {required bool discrete}) {
     final cellHeight = widget.metrics.cellHeight;
     if (cellHeight <= 0) return;
-    final lines = event.scrollDelta.dy / cellHeight;
+    final lines = deltaY / cellHeight;
     if (lines == 0) return;
 
     final int steps;
-    if (event.kind == PointerDeviceKind.mouse) {
-      // Wheel de mouse é discreto (um notch por evento): garante ao menos 1
-      // linha no sentido; notches maiores rolam proporcional.
+    if (discrete) {
       final mag = lines.abs().round();
       steps = (mag < 1 ? 1 : mag) * (lines.isNegative ? -1 : 1);
     } else {
-      // Trackpad (contínuo): acumula a fração e só dispara em linhas inteiras.
       _wheelAccum += lines;
       steps = _wheelAccum.truncate();
       if (steps == 0) return;
       _wheelAccum -= steps;
     }
 
-    // scrollDelta.dy < 0 = rolar pra cima = botão 4; > 0 = baixo = botão 5.
+    // dy < 0 = rolar pra cima = botão 4; > 0 = baixo = botão 5.
     final button = steps < 0 ? MouseButton.four : MouseButton.five;
     for (var i = 0; i < steps.abs(); i++) {
       _binding.handleMouseEvent((
         action: MouseAction.press,
         button: button,
-        pixelX: event.localPosition.dx,
-        pixelY: event.localPosition.dy,
+        pixelX: localPosition.dx,
+        pixelY: localPosition.dy,
       ));
     }
   }

--- a/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
+++ b/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
@@ -4,7 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:libghostty/libghostty.dart'
-    show MouseAction, MouseTracking, Position;
+    show MouseAction, MouseButton, MouseTracking, Position;
 import 'package:meta/meta.dart';
 
 import '../foundation.dart';
@@ -63,6 +63,13 @@ class _TerminalGestureDetectorState extends State<TerminalGestureDetector> {
       onPointerDown: tracked ? _handleTrackedDown : null,
       onPointerMove: tracked ? _handleTrackedMove : null,
       onPointerUp: tracked ? _handleTrackedUp : null,
+      // Wheel com mouse tracking ligado (TUIs como claude/vim no alt-buffer) tem
+      // que virar reporte de mouse pro app, não rolar o scrollback do viewport.
+      // Sem isso o `Scrollable` filho engole o wheel (e no alt-buffer não há
+      // scrollback), então o scroll interno do app não funciona. O `Scrollable`
+      // é neutralizado (`NeverScrollableScrollPhysics`) nesse modo no
+      // `TerminalView`, evitando dois consumidores disputando o pointer signal.
+      onPointerSignal: tracked ? _handlePointerSignal : null,
       child: TerminalRawGestureDetector(
         onTapDown: _handleTapDown,
         onTapUp: _handleTapUp,
@@ -275,6 +282,47 @@ class _TerminalGestureDetectorState extends State<TerminalGestureDetector> {
       pixelX: position.dx,
       pixelY: position.dy,
     ));
+  }
+
+  /// Resíduo fracionário de linha ao encaminhar o wheel (trackpad manda deltas
+  /// pequenos e frequentes; acumulamos pra não rolar rápido demais).
+  double _wheelAccum = 0;
+
+  /// Encaminha o wheel pro app como reporte de mouse (botão 4 = cima,
+  /// 5 = baixo) quando o mouse tracking está ligado. Segurando Shift o app não
+  /// recebe (o terminal deixa o Shift+wheel pro scroll local), como o resto.
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    if (!_isMouseTracked(HardwareKeyboard.instance.isShiftPressed)) return;
+    final cellHeight = widget.metrics.cellHeight;
+    if (cellHeight <= 0) return;
+    final lines = event.scrollDelta.dy / cellHeight;
+    if (lines == 0) return;
+
+    final int steps;
+    if (event.kind == PointerDeviceKind.mouse) {
+      // Wheel de mouse é discreto (um notch por evento): garante ao menos 1
+      // linha no sentido; notches maiores rolam proporcional.
+      final mag = lines.abs().round();
+      steps = (mag < 1 ? 1 : mag) * (lines.isNegative ? -1 : 1);
+    } else {
+      // Trackpad (contínuo): acumula a fração e só dispara em linhas inteiras.
+      _wheelAccum += lines;
+      steps = _wheelAccum.truncate();
+      if (steps == 0) return;
+      _wheelAccum -= steps;
+    }
+
+    // scrollDelta.dy < 0 = rolar pra cima = botão 4; > 0 = baixo = botão 5.
+    final button = steps < 0 ? MouseButton.four : MouseButton.five;
+    for (var i = 0; i < steps.abs(); i++) {
+      _binding.handleMouseEvent((
+        action: MouseAction.press,
+        button: button,
+        pixelX: event.localPosition.dx,
+        pixelY: event.localPosition.dy,
+      ));
+    }
   }
 
   void _startAutoScroll() {

--- a/packages/flterm/lib/src/widgets/terminal_input_client.dart
+++ b/packages/flterm/lib/src/widgets/terminal_input_client.dart
@@ -22,6 +22,7 @@ final class TerminalInputClient with DeltaTextInputClient {
   TextInputConnection? _connection;
   TextEditingValue _value = _sentinel;
   Brightness _keyboardAppearance = .dark;
+  int? _viewId;
   Timer? _newlineActionDedupeTimer;
   var _suppressNextNewlineDelta = false;
   var _suppressNextNewlineAction = false;
@@ -51,6 +52,19 @@ final class TerminalInputClient with DeltaTextInputClient {
     _connection?.updateConfig(_configuration);
   }
 
+  /// The id of the [FlutterView] hosting the terminal.
+  ///
+  /// Desktop embedders route the IME to a specific view, so the platform
+  /// text input control needs this id to resolve the target view when the
+  /// client attaches. Windows rejects the attach outright when it is null
+  /// (`Could not set client, view ID is null.`); macOS and Linux fall back
+  /// to the implicit view, which is why the omission only broke Windows.
+  set viewId(int? value) {
+    if (_viewId == value) return;
+    _viewId = value;
+    _connection?.updateConfig(_configuration);
+  }
+
   set onDelete(ValueChanged<int>? callback) => _onDelete = callback;
 
   set onNewline(VoidCallback? callback) => _onNewline = callback;
@@ -76,6 +90,7 @@ final class TerminalInputClient with DeltaTextInputClient {
       enableInteractiveSelection: false,
       enableIMEPersonalizedLearning: false,
       keyboardAppearance: _keyboardAppearance,
+      viewId: _viewId,
     );
   }
 

--- a/packages/flterm/lib/src/widgets/terminal_view.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view.dart
@@ -169,6 +169,11 @@ class _TerminalViewState extends State<TerminalView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Desktop embedders route the IME to a specific FlutterView. Feed the
+    // hosting view id to the text input so the platform can resolve the
+    // target view when the client attaches; Windows fails the attach
+    // otherwise ("Could not set client, view ID is null.").
+    _binding.viewId = View.of(context).viewId;
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     if (_devicePixelRatio == devicePixelRatio) return;
 
@@ -187,6 +192,7 @@ class _TerminalViewState extends State<TerminalView> {
       _binding.detach();
       _binding = _asBinding(_controller);
       _binding.brightness = _themeBrightness;
+      _binding.viewId = View.of(context).viewId;
       _binding.attach(_focusNode, _scrollController);
       _controller.addListener(_onControllerChanged);
       _links.invalidateContent();

--- a/packages/flterm/lib/src/widgets/terminal_view.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -169,11 +171,15 @@ class _TerminalViewState extends State<TerminalView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // Desktop embedders route the IME to a specific FlutterView. Feed the
-    // hosting view id to the text input so the platform can resolve the
-    // target view when the client attaches; Windows fails the attach
-    // otherwise ("Could not set client, view ID is null.").
-    _binding.viewId = View.of(context).viewId;
+    // Só o Windows precisa do viewId no config do text input: ele rejeita o
+    // attach com viewId null ("Could not set client, view ID is null."). No
+    // macOS/Linux o embedder cai no implicit view, e passar o viewId ali muda
+    // o timing do attach/updateConfig o suficiente pra bagunçar o dedup de
+    // newline do IME (Enter chegava duplicado / não chegava). Manter null fora
+    // do Windows = comportamento idêntico ao release.
+    if (defaultTargetPlatform == TargetPlatform.windows) {
+      _binding.viewId = View.of(context).viewId;
+    }
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     if (_devicePixelRatio == devicePixelRatio) return;
 
@@ -192,7 +198,9 @@ class _TerminalViewState extends State<TerminalView> {
       _binding.detach();
       _binding = _asBinding(_controller);
       _binding.brightness = _themeBrightness;
-      _binding.viewId = View.of(context).viewId;
+      if (defaultTargetPlatform == TargetPlatform.windows) {
+        _binding.viewId = View.of(context).viewId;
+      }
       _binding.attach(_focusNode, _scrollController);
       _controller.addListener(_onControllerChanged);
       _links.invalidateContent();

--- a/packages/flterm/lib/src/widgets/terminal_view.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view.dart
@@ -320,7 +320,14 @@ class _TerminalViewState extends State<TerminalView> {
                     onLinkActivate: widget.linkSettings.onActivate,
                     child: Scrollable(
                       controller: _scrollController,
-                      physics: widget.scrollPhysics,
+                      // Com mouse tracking (TUIs como claude/vim) o wheel é
+                      // encaminhado ao app pelo gesture detector; o scroll do
+                      // viewport é desligado pra os dois não disputarem o
+                      // pointer signal (o que fazia o scroll interno do app não
+                      // funcionar). No alt-buffer não há scrollback pra rolar.
+                      physics: _controller.mouseTracking != .none
+                          ? const NeverScrollableScrollPhysics()
+                          : widget.scrollPhysics,
                       viewportBuilder: (_, offset) => TerminalRenderer(
                         key: _rendererKey,
                         theme: _theme,

--- a/packages/flterm/lib/src/widgets/terminal_view_binding.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view_binding.dart
@@ -13,6 +13,12 @@ abstract interface class TerminalViewBinding {
   /// Sets the theme brightness for color scheme queries and text input.
   set brightness(Brightness value);
 
+  /// Sets the id of the [FlutterView] hosting the terminal.
+  ///
+  /// Forwarded to the platform text input so the IME can resolve the target
+  /// view on desktop embedders. Windows requires it to attach the client.
+  set viewId(int? value);
+
   /// Whether the cursor should actively blink right now.
   ///
   /// Combines DEC mode 12, focus state, and viewport scroll position.

--- a/packages/flterm/test/widgets/terminal_input_client_test.dart
+++ b/packages/flterm/test/widgets/terminal_input_client_test.dart
@@ -915,6 +915,48 @@ void main() {
         expect(config['keyboardAppearance'], Brightness.light.toString());
         expect(config['autofill'], isNull);
       });
+
+      test('omits view id until one is provided', () {
+        final calls = recordTextInputCalls();
+
+        handler.attach();
+
+        expect(textInputConfig(calls)['viewId'], isNull);
+      });
+
+      test('includes the view id so desktop embedders resolve the view', () {
+        final calls = recordTextInputCalls();
+
+        handler.viewId = 7;
+        handler.attach();
+
+        expect(textInputConfig(calls)['viewId'], 7);
+      });
+    });
+
+    group('viewId', () {
+      test('pushes an updated view id to the live connection', () {
+        final calls = recordTextInputCalls();
+        handler.viewId = 1;
+        handler.attach();
+
+        handler.viewId = 2;
+
+        expect(textInputUpdateConfig(calls)['viewId'], 2);
+      });
+
+      test('ignores a redundant view id assignment', () {
+        final calls = recordTextInputCalls();
+        handler.viewId = 3;
+        handler.attach();
+
+        handler.viewId = 3;
+
+        expect(
+          calls.where((call) => call.method == 'TextInput.updateConfig'),
+          isEmpty,
+        );
+      });
     });
 
     group('detach', () {


### PR DESCRIPTION
## Summary

This PR bundles a set of `flterm` fixes for keyboard input and scroll handling
on desktop embedders, discovered while running TUIs (e.g. Claude Code / vim in
the alt-buffer) inside a Flutter host.

## Fixes

### 1. Windows keyboard input — report the hosting `FlutterView` id (#114)
The text input client built its `TextInputConfiguration` without a `viewId`, so
it attached with `viewId: null`. macOS/Linux fall back to the implicit view, but
Windows rejects the attach with `Could not set client, view ID is null.`,
leaving keyboard input completely dead. We now thread `View.of(context).viewId`
through the binding and controller into `TerminalInputClient` and push an
`updateConfig` when it changes.

### 2. Keep macOS/Linux input pristine — gate the viewId threading to Windows
Setting `viewId` + `updateConfig` on macOS shifted the IME newline-dedup timing
enough to break Enter in TUIs (arrived duplicated / not at all). The viewId is
now only set on Windows, so macOS/Linux keep the previous release behavior while
Windows still gets a non-null view id.

### 3. Forward the wheel to the app under mouse tracking (internal TUI scroll)
With mouse tracking enabled (alt-buffer TUIs), there was no `onPointerSignal`
handler, so the inner `Scrollable` swallowed the wheel (scrolling the frozen
scrollback) and the app never received a mouse report. When tracked, the wheel
is now forwarded to the app as mouse button 4/5 presses (proportional for mouse
notches, accumulated fractions for trackpad; Shift+wheel stays local), and the
inner `Scrollable` uses `NeverScrollableScrollPhysics` so the two don't fight
over the pointer signal.

### 4. Forward macOS trackpad (pan/zoom) scroll to the app too
Two-finger trackpad scroll on macOS often arrives as pan/zoom gestures rather
than `PointerScrollEvent`, so internal TUI scroll did nothing on the trackpad.
We now also handle `onPointerPanZoomStart/Update`, routing the pan delta through
the same wheel-forward path.

## Tests
Adds coverage in `terminal_input_client_test.dart` for the viewId config
threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
