### PR TITLE
fix(flterm): bind text input to owning view

### DIFF
--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -193,12 +193,18 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
-  void attach(FocusNode focusNode, ScrollController scrollController) {
+  void attach(
+    FocusNode focusNode,
+    ScrollController scrollController, {
+    required int viewId,
+  }) {
     _focusNode?.removeListener(_onFocusChanged);
     _focusNode = focusNode;
     _wasFocused = focusNode.hasFocus;
     _focusNode!.addListener(_onFocusChanged);
-    _textInput.keyboardAppearance = _brightness;
+    _textInput
+      ..viewId = viewId
+      ..keyboardAppearance = _brightness;
     if (_wasFocused && _keyboardState != .disabled) {
       if (_keyboardState == .showing) {
         _textInput.show();

--- a/packages/flterm/lib/src/widgets/terminal_input_client.dart
+++ b/packages/flterm/lib/src/widgets/terminal_input_client.dart
@@ -19,6 +19,7 @@ final class TerminalInputClient with DeltaTextInputClient {
     text: ' ',
   );
 
+  int? _viewId;
   TextInputConnection? _connection;
   TextEditingValue _value = _sentinel;
   Brightness _keyboardAppearance = .dark;
@@ -63,8 +64,24 @@ final class TerminalInputClient with DeltaTextInputClient {
     _onTextCommitted = callback;
   }
 
+  /// Replaces an active connection because platform text input is view-bound.
+  set viewId(int value) {
+    if (_viewId == value) return;
+    final wasAttached = _connection != null;
+    if (wasAttached) _closeConnection();
+    _viewId = value;
+    if (wasAttached) _openConnection();
+  }
+
   TextInputConfiguration get _configuration {
+    final viewId = _viewId;
+    if (viewId == null) {
+      throw StateError(
+        'Text input requires an owning Flutter view before attachment.',
+      );
+    }
     return TextInputConfiguration(
+      viewId: viewId,
       autocorrect: false,
       inputType: .multiline,
       inputAction: .newline,

--- a/packages/flterm/lib/src/widgets/terminal_view.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view.dart
@@ -148,6 +148,7 @@ class _TerminalViewState extends State<TerminalView> {
   var _devicePixelRatio = 1.0;
   Timer? _blinkTimer;
   var _blinkVisible = true;
+  int? _viewId;
 
   TerminalController get _controller => widget.controller;
 
@@ -179,6 +180,12 @@ class _TerminalViewState extends State<TerminalView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    final viewId = View.of(context).viewId;
+    if (_viewId != viewId) {
+      _viewId = viewId;
+      _binding.attach(_focusNode, _scrollController, viewId: viewId);
+    }
+
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
     if (_devicePixelRatio == devicePixelRatio) return;
 
@@ -197,7 +204,7 @@ class _TerminalViewState extends State<TerminalView> {
       _binding.detach();
       _binding = _asBinding(_controller);
       _binding.brightness = _themeBrightness;
-      _binding.attach(_focusNode, _scrollController);
+      _binding.attach(_focusNode, _scrollController, viewId: _viewId!);
       _controller.addListener(_onControllerChanged);
       _links.invalidateContent();
     }
@@ -206,7 +213,7 @@ class _TerminalViewState extends State<TerminalView> {
       if (_ownsFocusNode) _focusNode.dispose();
       _focusNode = widget.focusNode ?? FocusNode();
       _ownsFocusNode = widget.focusNode == null;
-      _binding.attach(_focusNode, _scrollController);
+      _binding.attach(_focusNode, _scrollController, viewId: _viewId!);
     }
 
     if (widget.scrollController != oldWidget.scrollController) {
@@ -216,7 +223,7 @@ class _TerminalViewState extends State<TerminalView> {
       _ownsScrollController = widget.scrollController == null;
       _scrollController.activeScreen = _controller.activeScreen;
       _scrollController.addListener(_onScrollChanged);
-      _binding.attach(_focusNode, _scrollController);
+      _binding.attach(_focusNode, _scrollController, viewId: _viewId!);
     }
 
     if (widget.theme != oldWidget.theme) {
@@ -281,7 +288,6 @@ class _TerminalViewState extends State<TerminalView> {
     _scrollController.addListener(_onScrollChanged);
 
     _binding.brightness = _themeBrightness;
-    _binding.attach(_focusNode, _scrollController);
     _controller.addListener(_onControllerChanged);
     _syncLinkInteraction();
   }

--- a/packages/flterm/lib/src/widgets/terminal_view_binding.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view_binding.dart
@@ -32,9 +32,12 @@ abstract interface class TerminalViewBinding {
   /// Active virtual modifier keys.
   Mods get virtualMods;
 
-  /// Subscribes to [focusNode] and [scrollController] for focus and
-  /// scroll handling.
-  void attach(FocusNode focusNode, ScrollController scrollController);
+  /// Subscribes to focus and scroll changes in the owning Flutter view.
+  void attach(
+    FocusNode focusNode,
+    ScrollController scrollController, {
+    required int viewId,
+  });
 
   /// Cancels the active selection gesture.
   void cancelSelectionGesture();

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -334,7 +334,7 @@ void main() {
         );
         addTearDown(focusNode.dispose);
         addTearDown(scrollController.dispose);
-        controller.attach(focusNode, scrollController);
+        controller.attach(focusNode, scrollController, viewId: 0);
         return scrollController;
       }
 
@@ -468,7 +468,7 @@ void main() {
           addTearDown(focusNode.dispose);
           addTearDown(scrollController.dispose);
 
-          controller.attach(focusNode, scrollController);
+          controller.attach(focusNode, scrollController, viewId: 0);
           async.elapse(const Duration(milliseconds: 250));
 
           expect(idle.length, 1);

--- a/packages/flterm/test/widgets/terminal_input_client_test.dart
+++ b/packages/flterm/test/widgets/terminal_input_client_test.dart
@@ -52,7 +52,7 @@ void main() {
     }
 
     setUp(() {
-      handler = TerminalInputClient();
+      handler = TerminalInputClient()..viewId = 0;
       commits = [];
       deletes = [];
       newlines = [];
@@ -812,6 +812,42 @@ void main() {
       });
     });
 
+    group('viewId', () {
+      test('keeps the active connection when the view is unchanged', () {
+        final calls = recordTextInputCalls();
+        handler.attach();
+        calls.clear();
+
+        handler.viewId = 0;
+
+        expect(calls, isEmpty);
+      });
+
+      test('replaces the active connection when the view changes', () {
+        final calls = recordTextInputCalls();
+        handler.attach();
+        calls.clear();
+
+        handler.viewId = 1;
+
+        expect(calls.map((call) => call.method), [
+          'TextInput.clearClient',
+          'TextInput.setClient',
+          'TextInput.setEditingState',
+        ]);
+      });
+
+      test('uses the new view for the replacement connection', () {
+        final calls = recordTextInputCalls();
+        handler.attach();
+        calls.clear();
+
+        handler.viewId = 1;
+
+        expect(textInputConfig(calls)['viewId'], 1);
+      });
+    });
+
     group('keyboardAppearance', () {
       test('updates the active config', () {
         final calls = recordTextInputCalls();
@@ -874,6 +910,22 @@ void main() {
     });
 
     group('attach', () {
+      test('throws when no Flutter view is set', () {
+        final client = TerminalInputClient();
+        addTearDown(client.detach);
+
+        expect(
+          client.attach,
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Text input requires an owning Flutter view before attachment.',
+            ),
+          ),
+        );
+      });
+
       test('replaces an existing connection', () {
         handler.attach();
         expect(handler.isAttached, isTrue);

--- a/packages/flterm/test/widgets/terminal_view_binding_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_binding_test.dart
@@ -42,7 +42,7 @@ void main() {
         addTearDown(focusNode.dispose);
         addTearDown(scrollController.dispose);
 
-        binding.attach(focusNode, scrollController);
+        binding.attach(focusNode, scrollController, viewId: 0);
 
         expect(binding.detach, returnsNormally);
       });
@@ -57,9 +57,12 @@ void main() {
         addTearDown(scrollController1.dispose);
         addTearDown(scrollController2.dispose);
 
-        binding.attach(node1, scrollController1);
+        binding.attach(node1, scrollController1, viewId: 0);
 
-        expect(() => binding.attach(node2, scrollController2), returnsNormally);
+        expect(
+          () => binding.attach(node2, scrollController2, viewId: 0),
+          returnsNormally,
+        );
       });
     });
 
@@ -216,7 +219,7 @@ void main() {
         addTearDown(focusNode.dispose);
         addTearDown(sc.dispose);
         final customBinding = custom as TerminalViewBinding;
-        customBinding.attach(focusNode, sc);
+        customBinding.attach(focusNode, sc, viewId: 0);
 
         writeNumberedLines(custom, 10);
         custom.terminal.scrollViewport(-5);
@@ -356,7 +359,7 @@ void main() {
         final sc = ScrollController();
         addTearDown(focusNode.dispose);
         addTearDown(sc.dispose);
-        binding.attach(focusNode, sc);
+        binding.attach(focusNode, sc, viewId: 0);
 
         expect(binding.cursorBlinks, isFalse);
       });
@@ -379,7 +382,7 @@ void main() {
             child: Focus(focusNode: focusNode, child: const SizedBox()),
           ),
         );
-        binding.attach(focusNode, sc);
+        binding.attach(focusNode, sc, viewId: 0);
         focusNode.requestFocus();
         await tester.pump();
 
@@ -410,7 +413,7 @@ void main() {
             child: Focus(focusNode: focusNode, child: const SizedBox()),
           ),
         );
-        binding.attach(focusNode, sc);
+        binding.attach(focusNode, sc, viewId: 0);
         focusNode.requestFocus();
         await tester.pump();
 
@@ -446,7 +449,7 @@ void main() {
         final sc = ScrollController();
         addTearDown(focusNode.dispose);
         addTearDown(sc.dispose);
-        binding.attach(focusNode, sc);
+        binding.attach(focusNode, sc, viewId: 0);
 
         writeUtf8(controller.terminal, '\x1b[?1049h');
         writeUtf8(controller.terminal, '\x1b[?12l');

--- a/packages/flterm/test/widgets/terminal_view_test.dart
+++ b/packages/flterm/test/widgets/terminal_view_test.dart
@@ -1054,6 +1054,56 @@ void main() {
       expect(calls.where((call) => call.method == 'TextInput.show'), isEmpty);
     });
 
+    group('text input connection', () {
+      List<MethodCall> lifecycleCalls(List<MethodCall> calls) {
+        return calls
+            .where(
+              (call) => const {
+                'TextInput.setClient',
+                'TextInput.clearClient',
+                'TextInput.show',
+                'TextInput.hide',
+                'TextInput.updateConfig',
+              }.contains(call.method),
+            )
+            .toList();
+      }
+
+      testWidgets('uses the containing Flutter view', (tester) async {
+        final calls = recordTextInputCalls();
+
+        await tester.pumpWidget(
+          wrapInApp(controller: controller, autofocus: true),
+        );
+        await tester.pump();
+        final setClient = calls.singleWhere(
+          (call) => call.method == 'TextInput.setClient',
+        );
+        final arguments = setClient.arguments! as List<Object?>;
+        final configuration = arguments[1]! as Map<String, Object?>;
+
+        expect(configuration['viewId'], tester.view.viewId);
+      });
+
+      testWidgets('keeps the connection across same-view dependency changes', (
+        tester,
+      ) async {
+        final calls = recordTextInputCalls();
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          wrapInApp(controller: controller, autofocus: true),
+        );
+        await tester.pump();
+        calls.clear();
+
+        tester.view.devicePixelRatio = tester.view.devicePixelRatio + 1;
+        await tester.pump();
+
+        expect(lifecycleCalls(calls), isEmpty);
+      });
+    });
+
     testWidgets('touch drag does not create selection', (tester) async {
       writeUtf8(controller, 'hello world');
       await tester.pumpWidget(


### PR DESCRIPTION
Replaces #115. Bind flterm's text input configuration to the TerminalView's owning Flutter view so Windows can attach the platform text input client, and cover view changes and connection reuse across the widget lifecycle.

Fixes #114.