### PR TITLE
perf(flterm): add terminal benchmarks

### DIFF
--- a/.github/workflows/benchmark-flterm.yml
+++ b/.github/workflows/benchmark-flterm.yml
@@ -1,0 +1,67 @@
+name: benchmark flterm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/flterm/**'
+      - '!packages/flterm/**/*.md'
+      - 'packages/libghostty/**'
+      - '!packages/libghostty/**/*.md'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - '.github/workflows/benchmark-flterm.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-flterm-main
+  cancel-in-progress: false
+
+env:
+  ZIG_VERSION: "0.16.0"
+
+jobs:
+  benchmark:
+    name: benchmark-flterm-macos
+    runs-on: macos-15
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: stable
+          cache: true
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pub-cache
+          key: pub-benchmark-flterm-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: pub-benchmark-flterm-
+
+      - name: run benchmark
+        id: benchmark
+        run: |
+          flutter pub get
+          dart run packages/flterm/tool/benchmarks/run.dart \
+            --output "$RUNNER_TEMP/flterm-benchmark-results" \
+            --revision "$GITHUB_SHA"
+
+      - name: publish benchmark summary
+        if: steps.benchmark.outcome == 'success'
+        run: cat "$RUNNER_TEMP/flterm-benchmark-results/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() && steps.benchmark.outcome != 'skipped' }}
+        with:
+          name: flterm-benchmark-${{ github.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/flterm-benchmark-results
+          retention-days: 90
+          if-no-files-found: warn

--- a/packages/flterm/.pubignore
+++ b/packages/flterm/.pubignore
@@ -10,3 +10,5 @@
 /dart_test.yaml
 /test/
 /tool/
+/example/integration_test/flterm_benchmark.dart
+/example/test_driver/flterm_benchmark_driver.dart

--- a/packages/flterm/example/integration_test/flterm_benchmark.dart
+++ b/packages/flterm/example/integration_test/flterm_benchmark.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../tool/benchmarks/frame/suite.dart' as benchmark;
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+  benchmark.FltermBenchmarkSuite(binding).register();
+}

--- a/packages/flterm/example/pubspec.yaml
+++ b/packages/flterm/example/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/packages/flterm/example/test_driver/flterm_benchmark_driver.dart
+++ b/packages/flterm/example/test_driver/flterm_benchmark_driver.dart
@@ -1,0 +1,12 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() {
+  return integrationDriver(
+    responseDataCallback: (data) {
+      if (data == null) {
+        throw const FormatException('Benchmark returned no report data.');
+      }
+      return writeResponseData(data, testOutputFilename: 'flterm_benchmarks');
+    },
+  );
+}

--- a/packages/flterm/pubspec.yaml
+++ b/packages/flterm/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   meta: ^1.18.0
 
 dev_dependencies:
+  crypto: ^3.0.7
   fake_async: ^1.3.3
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter

--- a/packages/flterm/test/tool/benchmarks/commands_test.dart
+++ b/packages/flterm/test/tool/benchmarks/commands_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io' show Directory, File;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tool/benchmarks/protocol.dart' show BenchmarkWorkload;
+import '../../../tool/benchmarks/report/model.dart'
+    show BenchmarkEnvironment, BenchmarkWorkloadResult;
+import '../../../tool/benchmarks/run.dart'
+    as run
+    show
+        BenchmarkArtifacts,
+        benchmarkDriveArguments,
+        benchmarkReportFromFlutterResponse;
+
+void main() {
+  group('benchmark commands', () {
+    group('drive arguments', () {
+      test('disable DDS for integration performance tracing', () {
+        expect(run.benchmarkDriveArguments, contains('--no-dds'));
+      });
+    });
+
+    group('BenchmarkArtifacts', () {
+      group('prepare', () {
+        test('removes only artifacts from a prior run', () {
+          final directory = Directory.systemTemp.createTempSync(
+            'flterm-benchmark-artifacts-',
+          );
+          addTearDown(() => directory.deleteSync(recursive: true));
+          File.fromUri(
+            directory.uri.resolve('results.json'),
+          ).writeAsStringSync('old results');
+          File.fromUri(
+            directory.uri.resolve('report.md'),
+          ).writeAsStringSync('old report');
+          File.fromUri(
+            directory.uri.resolve('raw-flutter.json'),
+          ).writeAsStringSync('old raw data');
+          File.fromUri(
+            directory.uri.resolve('flutter.stdout.log'),
+          ).writeAsStringSync('old stdout');
+          File.fromUri(
+            directory.uri.resolve('flutter.stderr.log'),
+          ).writeAsStringSync('old stderr');
+          final unrelated = File.fromUri(directory.uri.resolve('keep.txt'))
+            ..writeAsStringSync('keep');
+          final artifacts = run.BenchmarkArtifacts(directory);
+
+          artifacts.prepare();
+
+          expect(
+            directory.listSync().map((entry) => entry.uri.pathSegments.last),
+            ['keep.txt'],
+          );
+          expect(unrelated.readAsStringSync(), 'keep');
+        });
+      });
+    });
+
+    group('benchmarkReportFromFlutterResponse', () {
+      Map<String, Object?> response() => {
+        'font_digest': 'sha256:fonts',
+        'workloads': <Object?>[
+          for (final workload in BenchmarkWorkload.values)
+            BenchmarkWorkloadResult(
+              id: workload.id,
+              label: workload.label,
+              metrics: const [],
+            ).toJson(),
+        ],
+      };
+
+      const environment = BenchmarkEnvironment(
+        operatingSystem: 'macos',
+        operatingSystemVersion: '15.5',
+        architecture: 'arm64',
+        dartVersion: '3.12.0',
+        flutterVersion: '3.44.0',
+      );
+
+      test('creates a report from every workload', () {
+        final result = run.benchmarkReportFromFlutterResponse(
+          response(),
+          revision: 'abc123',
+          environment: environment,
+        );
+
+        expect(
+          result.workloads.map((workload) => workload.id),
+          BenchmarkWorkload.values.map((workload) => workload.id),
+        );
+      });
+
+      test('rejects a missing workload', () {
+        final incompleteResponse = response();
+        (incompleteResponse['workloads']! as List<Object?>).removeLast();
+
+        expect(
+          () => run.benchmarkReportFromFlutterResponse(
+            incompleteResponse,
+            revision: 'abc123',
+            environment: environment,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('every protocol workload'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/packages/flterm/test/tool/benchmarks/fixture/terminal_test.dart
+++ b/packages/flterm/test/tool/benchmarks/fixture/terminal_test.dart
@@ -1,0 +1,122 @@
+import 'dart:convert' show utf8;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../tool/benchmarks/fixture/terminal.dart'
+    show TerminalBenchmarkFixture;
+
+void main() {
+  group('TerminalBenchmarkFixture', () {
+    group('streamingOutput', () {
+      test('provides the streaming benchmark corpus', () {
+        final bytes = TerminalBenchmarkFixture.streamingOutput;
+        final text = utf8.decode(bytes);
+
+        expect(bytes, hasLength(4 * 1024 * 1024));
+        expect(() => bytes[0] = bytes[0], throwsUnsupportedError);
+        expect(text, contains('\x1b[38;5;39m'));
+        expect(text, contains('\x1b[38;2;'));
+        expect(text, contains('\x1b[32m'));
+        expect(text, contains('界'));
+        expect(text, contains('e\u0301'));
+      });
+    });
+
+    group('interactiveTuiOutput', () {
+      test('provides the interactive TUI benchmark corpus', () {
+        final bytes = TerminalBenchmarkFixture.interactiveTuiOutput;
+        final text = utf8.decode(bytes);
+
+        expect(bytes, hasLength(4 * 1024 * 1024));
+        expect(() => bytes[0] = bytes[0], throwsUnsupportedError);
+        expect(text, contains('\x1b[?1049h'));
+        expect(text, contains('\x1b[?2026h'));
+      });
+    });
+
+    group('chunks', () {
+      test('creates fixed-size views over every input byte', () {
+        final input = Uint8List.fromList([1, 2, 3, 4]);
+
+        final result = TerminalBenchmarkFixture.chunks(input, 2);
+
+        expect(result.map((chunk) => chunk.length), [2, 2]);
+        expect(result.expand((chunk) => chunk), orderedEquals(input));
+      });
+
+      test('rejects a partial final chunk', () {
+        expect(
+          () => TerminalBenchmarkFixture.chunks(Uint8List(3), 2),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.message,
+              'message',
+              contains('divisible by chunkSize'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('partialFrames', () {
+      test('creates the requested three-row updates', () {
+        final result = TerminalBenchmarkFixture.partialFrames(count: 12);
+        final addresses = RegExp(
+          r'\x1b\[\d+;1H',
+        ).allMatches(utf8.decode(result.first));
+
+        expect(result, hasLength(12));
+        expect(addresses, hasLength(3));
+      });
+    });
+
+    group('fullFrames', () {
+      test('addresses every terminal row', () {
+        final result = TerminalBenchmarkFixture.fullFrames(count: 1);
+
+        final addresses = RegExp(
+          r'\x1b\[\d+;1H',
+        ).allMatches(utf8.decode(result.single));
+
+        expect(addresses, hasLength(80));
+      });
+
+      test('rejects a non-positive frame count', () {
+        expect(
+          () => TerminalBenchmarkFixture.fullFrames(count: 0),
+          throwsRangeError,
+        );
+      });
+    });
+
+    group('glyphMissFrames', () {
+      test('creates distinct frames covering uncached glyph classes', () {
+        final result = TerminalBenchmarkFixture.glyphMissFrames(count: 120);
+        final text = utf8.decode(result.expand((frame) => frame).toList());
+
+        expect(result.toSet(), hasLength(120));
+        expect(text, contains('一'));
+        expect(text, contains('😀'));
+      });
+    });
+
+    group('inputDigest', () {
+      const fixtureDigest =
+          'sha256:2ab7fcf523ee15f013dea8481916414a'
+          '851b357db62e08603ff2d104ceba50cf';
+
+      test('captures fixture and font identity', () {
+        final first = TerminalBenchmarkFixture.benchmarkDigest(
+          'sha256:font-one',
+        );
+        final second = TerminalBenchmarkFixture.benchmarkDigest(
+          'sha256:font-two',
+        );
+
+        expect(TerminalBenchmarkFixture.inputDigest, fixtureDigest);
+        expect(first, isNot(second));
+      });
+    });
+  });
+}

--- a/packages/flterm/test/tool/benchmarks/frame/render_environment_test.dart
+++ b/packages/flterm/test/tool/benchmarks/frame/render_environment_test.dart
@@ -1,0 +1,37 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../tool/benchmarks/frame/render_environment.dart'
+    show benchmarkFontDigest;
+
+void main() {
+  group('benchmarkFontDigest', () {
+    ByteData data(List<int> bytes) {
+      return Uint8List.fromList(bytes).buffer.asByteData();
+    }
+
+    String digest({
+      List<int> regular = const [1],
+      List<int> bold = const [2],
+      List<int> textFallback = const [3],
+      List<int> emojiFallback = const [4],
+    }) {
+      return benchmarkFontDigest(
+        jetBrainsMonoRegular: data(regular),
+        jetBrainsMonoBold: data(bold),
+        notoSansJp: data(textFallback),
+        notoEmoji: data(emojiFallback),
+      );
+    }
+
+    test('captures every bundled font', () {
+      final baseline = digest();
+
+      expect(digest(regular: [5]), isNot(baseline));
+      expect(digest(bold: [5]), isNot(baseline));
+      expect(digest(textFallback: [5]), isNot(baseline));
+      expect(digest(emojiFallback: [5]), isNot(baseline));
+    });
+  });
+}

--- a/packages/flterm/test/tool/benchmarks/frame/result_test.dart
+++ b/packages/flterm/test/tool/benchmarks/frame/result_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../tool/benchmarks/frame/result.dart'
+    show framePerformanceResult;
+
+void main() {
+  group('framePerformanceResult', () {
+    Map<String, Object?> summary({
+      List<int> buildTimes = const [500, 800, 1200],
+      List<int> rasterTimes = const [700, 1000, 1500],
+    }) => {
+      'average_frame_build_time_millis': 0.5,
+      '90th_percentile_frame_build_time_millis': 0.8,
+      '99th_percentile_frame_build_time_millis': 1.2,
+      'worst_frame_build_time_millis': 2.0,
+      'missed_frame_build_budget_count': 1,
+      'average_frame_rasterizer_time_millis': 0.7,
+      '90th_percentile_frame_rasterizer_time_millis': 1.0,
+      '99th_percentile_frame_rasterizer_time_millis': 1.5,
+      'worst_frame_rasterizer_time_millis': 2.5,
+      'missed_frame_rasterizer_budget_count': 2,
+      'frame_count': 300,
+      'frame_build_times': buildTimes,
+      'frame_rasterizer_times': rasterTimes,
+    };
+
+    group('conversion', () {
+      test('preserves the Flutter frame summary', () {
+        final result = framePerformanceResult(
+          workload: .fullOutput,
+          summary: summary(),
+        );
+
+        expect(result.metric('ui_p99').value, 1.2);
+        expect(result.metric('raster_p99').value, 1.5);
+        expect(result.metric('raster_missed_budget').value, 2);
+        expect(result.details['frame_build_times'], [500, 800, 1200]);
+      });
+    });
+
+    group('validation', () {
+      test('rejects a summary without required metrics', () {
+        expect(
+          () =>
+              framePerformanceResult(workload: .fullOutput, summary: const {}),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('average_frame_build_time_millis'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects an input workload', () {
+        expect(
+          () => framePerformanceResult(
+            workload: .streamingOutput,
+            summary: summary(),
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.message,
+              'message',
+              contains('frame workload'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/packages/flterm/test/tool/benchmarks/input_benchmark_test.dart
+++ b/packages/flterm/test/tool/benchmarks/input_benchmark_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tool/benchmarks/input_benchmark.dart' show measureBenchmark;
+import '../../../tool/benchmarks/report/model.dart'
+    show BenchmarkMetric, BenchmarkWorkloadResult;
+
+void main() {
+  group('measureBenchmark', () {
+    BenchmarkWorkloadResult measure(List<int> samples) {
+      final clock = _FakeClock(samples);
+      return measureBenchmark(
+        workload: .streamingOutput,
+        warmupIterations: 0,
+        minimumSamples: samples.length,
+        minimumDuration: .zero,
+        clock: clock.read,
+        step: clock.step,
+      );
+    }
+
+    BenchmarkMetric metric(BenchmarkWorkloadResult result, String id) {
+      return result.metrics.singleWhere((metric) => metric.id == id);
+    }
+
+    group('statistics', () {
+      test('computes timing distribution statistics', () {
+        final result = measure([1000, 2000, 3000, 4000]);
+
+        expect(metric(result, 'mean').value, 2.5);
+        expect(
+          metric(result, 'standard_deviation').value,
+          closeTo(1.291, 0.001),
+        );
+        expect(
+          (
+            p50: metric(result, 'p50').value,
+            p95: metric(result, 'p95').value,
+            p99: metric(result, 'p99').value,
+          ),
+          (p50: 2.0, p95: 4.0, p99: 4.0),
+        );
+      });
+
+      test('computes aggregate throughput', () {
+        final clock = _FakeClock([2000, 3000]);
+
+        final result = measureBenchmark(
+          workload: .streamingOutput,
+          warmupIterations: 0,
+          minimumSamples: 2,
+          minimumDuration: .zero,
+          bytesPerIteration: 1024 * 1024,
+          clock: clock.read,
+          step: clock.step,
+        );
+
+        expect(metric(result, 'throughput').value, 400);
+      });
+    });
+
+    group('sampling', () {
+      test('preserves raw samples as diagnostic details', () {
+        final result = measure([2000, 3000]);
+
+        expect(result.details['samples_microseconds'], [2000, 3000]);
+      });
+
+      test('excludes preparation from measured samples', () {
+        final clock = _FakeClock([10, 10]);
+
+        final result = measureBenchmark(
+          workload: .streamingOutput,
+          warmupIterations: 0,
+          minimumSamples: 2,
+          minimumDuration: .zero,
+          clock: clock.read,
+          prepare: () => clock.advance(100),
+          step: clock.step,
+        );
+
+        expect(result.details['samples_microseconds'], [10, 10]);
+      });
+
+      test('runs unmeasured warmup iterations', () {
+        final clock = _FakeClock([10]);
+        var steps = 0;
+
+        measureBenchmark(
+          workload: .streamingOutput,
+          warmupIterations: 2,
+          minimumSamples: 1,
+          minimumDuration: .zero,
+          clock: clock.read,
+          step: () {
+            steps++;
+            clock.step();
+          },
+        );
+
+        expect(steps, 3);
+      });
+
+      test('meets the minimum measured duration', () {
+        final clock = _FakeClock([10, 10, 10]);
+
+        final result = measureBenchmark(
+          workload: .streamingOutput,
+          warmupIterations: 0,
+          minimumSamples: 1,
+          minimumDuration: const Duration(microseconds: 25),
+          clock: clock.read,
+          step: clock.step,
+        );
+
+        expect(result.details['samples_microseconds'], [10, 10, 10]);
+      });
+    });
+
+    group('workload', () {
+      test('rejects a frame workload', () {
+        final clock = _FakeClock([10]);
+
+        expect(
+          () => measureBenchmark(
+            workload: .cleanFrame,
+            warmupIterations: 0,
+            minimumSamples: 1,
+            minimumDuration: .zero,
+            clock: clock.read,
+            step: clock.step,
+          ),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.message,
+              'message',
+              contains('input workload'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}
+
+final class _FakeClock {
+  final List<int> samples;
+  var _microseconds = 0;
+  var _sample = 0;
+
+  _FakeClock(this.samples);
+
+  int read() => _microseconds;
+
+  void step() {
+    advance(samples[_sample]);
+    _sample = (_sample + 1) % samples.length;
+  }
+
+  void advance(int microseconds) {
+    _microseconds += microseconds;
+  }
+}

--- a/packages/flterm/test/tool/benchmarks/report/report_test.dart
+++ b/packages/flterm/test/tool/benchmarks/report/report_test.dart
@@ -1,0 +1,317 @@
+import 'dart:convert' show jsonDecode, jsonEncode;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../tool/benchmarks/frame/result.dart'
+    show framePerformanceResult;
+import '../../../../tool/benchmarks/report/markdown.dart'
+    show formatBenchmarkReport;
+import '../../../../tool/benchmarks/report/model.dart'
+    show
+        BenchmarkEnvironment,
+        BenchmarkMetric,
+        BenchmarkReport,
+        BenchmarkWorkloadResult;
+
+void main() {
+  group('benchmark reporting', () {
+    List<BenchmarkMetric> inputMetrics({required double value}) {
+      return [
+        BenchmarkMetric(
+          id: 'throughput',
+          label: 'throughput',
+          value: value,
+          unit: .mebibytesPerSecond,
+          direction: .higherIsBetter,
+        ),
+        for (final id in const [
+          'mean',
+          'standard_deviation',
+          'p50',
+          'p95',
+          'p99',
+        ])
+          BenchmarkMetric(
+            id: id,
+            label: id,
+            value: id == 'standard_deviation' ? 0.25 : 1,
+            unit: .milliseconds,
+            direction: .lowerIsBetter,
+          ),
+      ];
+    }
+
+    BenchmarkReport report({double value = 100, bool completeMetrics = true}) {
+      final metrics = inputMetrics(value: value);
+      return BenchmarkReport(
+        protocolVersion: 1,
+        fixtureDigest: 'sha256:one',
+        revision: 'abc123',
+        environment: const BenchmarkEnvironment(
+          operatingSystem: 'macos',
+          operatingSystemVersion: '15.5',
+          architecture: 'arm64',
+          dartVersion: '3.12.0',
+          flutterVersion: '3.44.0',
+          runnerImage: 'macos-15',
+        ),
+        workloads: [
+          BenchmarkWorkloadResult(
+            id: 'input.streaming_output',
+            label: 'streaming output',
+            metrics: completeMetrics ? metrics : metrics.take(1).toList(),
+            details: const {'samples': 100},
+          ),
+        ],
+      );
+    }
+
+    BenchmarkReport frameReport() {
+      return BenchmarkReport(
+        protocolVersion: 1,
+        fixtureDigest: 'sha256:one',
+        revision: 'abc123',
+        environment: const BenchmarkEnvironment(
+          operatingSystem: 'macos',
+          operatingSystemVersion: '15.5',
+          architecture: 'arm64',
+          dartVersion: '3.12.0',
+          flutterVersion: '3.44.0',
+          runnerImage: 'macos-15',
+        ),
+        workloads: [
+          framePerformanceResult(
+            workload: .fullOutput,
+            summary: const {
+              'average_frame_build_time_millis': 1,
+              '90th_percentile_frame_build_time_millis': 2,
+              '99th_percentile_frame_build_time_millis': 3,
+              'worst_frame_build_time_millis': 4,
+              'missed_frame_build_budget_count': 1,
+              'average_frame_rasterizer_time_millis': 2,
+              '90th_percentile_frame_rasterizer_time_millis': 3,
+              '99th_percentile_frame_rasterizer_time_millis': 4,
+              'worst_frame_rasterizer_time_millis': 5,
+              'missed_frame_rasterizer_budget_count': 2,
+              'frame_count': 100,
+            },
+          ),
+        ],
+      );
+    }
+
+    group('BenchmarkWorkloadResult.fromJson', () {
+      test('round trips every workload field', () {
+        final workload = report().workloads.single;
+
+        final result = BenchmarkWorkloadResult.fromJson(
+          jsonDecode(jsonEncode(workload.toJson())) as Map<String, Object?>,
+        );
+
+        expect(result.toJson(), workload.toJson());
+      });
+
+      test('rejects a metric with an unknown unit', () {
+        final json = report().workloads.single.toJson();
+        final metrics = json['metrics']! as List<Object?>;
+        final metric = metrics.first! as Map<String, Object?>;
+        metric['unit'] = 'frames_per_fortnight';
+
+        expect(
+          () => BenchmarkWorkloadResult.fromJson(json),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('frames_per_fortnight'),
+            ),
+          ),
+        );
+      });
+
+      test('reports invalid metric values as malformed data', () {
+        final json = report().workloads.single.toJson();
+        final metrics = json['metrics']! as List<Object?>;
+        final metric = metrics.first! as Map<String, Object?>;
+        metric['value'] = -1;
+
+        expect(
+          () => BenchmarkWorkloadResult.fromJson(json),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('finite and non-negative'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('model validation', () {
+      test('rejects duplicate result identities', () {
+        final original = report();
+        final workload = original.workloads.single;
+        final metric = inputMetrics(value: 100).first;
+
+        expect(
+          () => BenchmarkReport(
+            protocolVersion: original.protocolVersion,
+            fixtureDigest: original.fixtureDigest,
+            revision: original.revision,
+            environment: original.environment,
+            workloads: [workload, workload],
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('duplicate workload id'),
+            ),
+          ),
+        );
+        expect(
+          () => BenchmarkWorkloadResult(
+            id: 'input.streaming_output',
+            label: 'streaming output',
+            metrics: [metric, metric],
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('duplicate metric id'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects an empty workload identifier', () {
+        expect(
+          () => BenchmarkWorkloadResult(
+            id: ' ',
+            label: 'streaming output',
+            metrics: inputMetrics(value: 100),
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('workload id must not be empty'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects invalid metric values', () {
+        final invalidMeasurement = throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('finite and non-negative'),
+          ),
+        );
+
+        expect(
+          () => BenchmarkMetric(
+            id: 'throughput',
+            label: 'throughput',
+            value: -1,
+            unit: .mebibytesPerSecond,
+            direction: .higherIsBetter,
+          ),
+          invalidMeasurement,
+        );
+        expect(
+          () => BenchmarkMetric(
+            id: 'throughput',
+            label: 'throughput',
+            value: double.nan,
+            unit: .mebibytesPerSecond,
+            direction: .higherIsBetter,
+          ),
+          invalidMeasurement,
+        );
+      });
+
+      test('rejects a missing required metric', () {
+        final workload = BenchmarkWorkloadResult(
+          id: 'input.streaming_output',
+          label: 'streaming output',
+          metrics: inputMetrics(value: 100).take(1).toList(),
+        );
+
+        expect(
+          () => workload.metric('mean'),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('missing metric "mean"'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects a non-integer count detail', () {
+        final workload = BenchmarkWorkloadResult(
+          id: 'input.streaming_output',
+          label: 'streaming output',
+          metrics: inputMetrics(value: 100),
+          details: const {'samples': 1.5},
+        );
+
+        expect(
+          () => workload.detailCount('samples'),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('count detail "samples"'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('formatBenchmarkReport', () {
+      test('formats an input benchmark report', () {
+        final benchmarkReport = report(value: 120.25);
+
+        final result = formatBenchmarkReport(benchmarkReport);
+
+        expect(
+          result,
+          contains(
+            '| streaming output | 120.25 MiB/s | 1.00 ms ± 0.25 ms | '
+            '1.00 ms | 1.00 ms | 1.00 ms | 100 |',
+          ),
+        );
+        expect(result, contains('Runner: macos-15'));
+      });
+
+      test('formats frame misses as a count and rate', () {
+        final benchmarkReport = frameReport();
+
+        final result = formatBenchmarkReport(benchmarkReport);
+
+        expect(result, contains('| 2/100 (2.0%) | 100 |'));
+      });
+
+      test('rejects an incomplete input workload', () {
+        final benchmarkReport = report(completeMetrics: false);
+
+        expect(
+          () => formatBenchmarkReport(benchmarkReport),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('missing metric "mean"'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/packages/flterm/tool/benchmarks/README.md
+++ b/packages/flterm/tool/benchmarks/README.md
@@ -1,0 +1,132 @@
+# flterm benchmarks
+
+This suite measures the performance boundaries that directly affect terminal
+users:
+
+- processing output through `TerminalController.write`;
+- drawing unchanged, partially updated, and fully updated terminal frames;
+- rendering glyphs that are not already present in the atlas;
+- presenting the first frame of a new terminal renderer.
+
+It intentionally does not benchmark individual parsers, painters, caches, or
+other implementation details. Those measurements are useful only when
+investigating a specific subsystem and do not describe the experience of using
+flterm.
+
+## Measurement protocol
+
+Rendering follows Flutter's
+[integration performance testing](https://docs.flutter.dev/cookbook/testing/integration/profiling)
+guidance. The suite runs through `flutter drive --profile` and records Flutter's
+UI and raster frame timings. Debug widget-test timings are not performance
+results.
+
+Every workload uses:
+
+- a terminal with 120 columns and 80 rows;
+- fixed cell metrics and device pixel ratio 1;
+- the example's bundled JetBrains Mono, Noto Sans JP, and Noto Emoji fonts;
+- fixture generation and chunk preparation outside measured regions;
+- sequential execution, with no concurrent performance workloads.
+
+Input workloads perform ten unmeasured warmups, then collect at least 100
+samples and five seconds of measured work. Each sample processes exactly
+4 MiB. Rendering workloads schedule and await one real engine frame per
+iteration at the runner display's cadence.
+
+The input timer surrounds only the prepared calls to
+`TerminalController.write`. Rendering results come from Flutter frame timings.
+Terminal updates are applied before each measured frame, but their parser time
+is not added to Flutter's UI or raster duration. Flutter can omit frame timings
+at collection boundaries, so steady workloads require at least 95 percent of
+their scheduled samples.
+
+## Deterministic input
+
+The suite uses two complementary input sources:
+
+- A generated streaming-output corpus represents build logs and command output.
+  It contains plain text, wrapping, 16/256/RGB styling, paths, numbers, CR/LF
+  handling, and representative Unicode.
+- A checked-in normalized editor-session transcript represents cursor-addressed
+  TUI updates, status lines, commands, alternate-screen operation, and
+  synchronized output. It contains no host paths, timing values, locale-derived
+  content, or terminal replies.
+
+Both corpora are exactly 4 MiB and are sliced into views before timing begins.
+The report's fixture digest identifies the deterministic fixtures and bundled
+fonts used for a run.
+
+The workload mix follows established terminal benchmark practice: combine
+realistic application-shaped traffic with focused synthetic stress cases.
+Throughput alone is not treated as overall terminal performance because it
+cannot describe frame consistency or latency.
+
+## Workloads
+
+### Input throughput
+
+`streaming output, 128 KiB chunks` models batched output using the repository's
+default PTY output batch size.
+
+`interactive TUI, 4 KiB chunks` models smaller, escape-heavy interactive
+updates.
+
+Both workloads keep scrollback disabled so a sample measures terminal input
+processing rather than unbounded history growth.
+
+### Frame performance
+
+`clean frame` measures steady frames without a terminal mutation.
+
+`partial TUI update` changes exactly three rows using the editor transcript.
+
+`full-screen output` changes every row using styled streaming output.
+
+These workloads each record 300 frames after an initial warm frame.
+
+`new glyphs` records 120 frames. Every frame introduces a disjoint set of CJK
+glyphs and also exercises bold text, combining text, and emoji. The bundled
+fonts keep glyph selection stable across machines.
+
+`first terminal frame` records at least 30 independent first frames from fresh
+renderer and render-cache instances. Terminal state and fonts are prepared
+first. This measures flterm's first presentation, not Flutter process startup.
+
+## Run locally
+
+From `packages/flterm`:
+
+```sh
+dart run tool/benchmarks/run.dart
+```
+
+The command writes the following files under
+`example/build/benchmark-results/`:
+
+- `report.md`: the human-readable result;
+- `results.json`: normalized, versioned benchmark data;
+- `raw-flutter.json`: Flutter's complete integration response;
+- `flutter.stdout.log` and `flutter.stderr.log`: runner diagnostics.
+
+Use a custom output directory or revision label when needed:
+
+```sh
+dart run tool/benchmarks/run.dart \
+  --output /tmp/flterm-results \
+  --revision working-tree
+```
+
+For repeatable measurements, keep other applications idle and record the
+hardware, Flutter version, display configuration, and power state.
+
+## Continuous measurement
+
+The `benchmark flterm` workflow runs after relevant flterm or libghostty
+changes land on `main`, and it can also be started manually. It measures the
+checked-out revision once, writes its report to the job summary, and uploads
+the complete result bundle for 90 days.
+
+Preserve result data and generated Markdown elsewhere when a report must
+outlive artifact retention. Harness failures fail the benchmark workflow;
+measured values alone do not fail it.

--- a/packages/flterm/tool/benchmarks/fixture/terminal.dart
+++ b/packages/flterm/tool/benchmarks/fixture/terminal.dart
@@ -1,0 +1,202 @@
+import 'dart:convert' show utf8;
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' show sha256;
+
+import '../protocol.dart';
+
+/// Normalized content from an editor session.
+///
+/// Host paths, timing data, and terminal replies are intentionally absent.
+/// The benchmark adds cursor addressing and synchronized-update boundaries.
+const _editorTranscript = [
+  (
+    code: '  final controller = TerminalController();',
+    status: ' NORMAL   terminal_view.dart                 42,7   63%',
+    command: ':set number cursorline',
+  ),
+  (
+    code: '  controller.write(output);',
+    status: ' INSERT   terminal_view.dart                 43,29  65%',
+    command: '-- INSERT --',
+  ),
+  (
+    code: '  await tester.pump(const Duration(milliseconds: 16));',
+    status: ' NORMAL   frame_render_benchmark.dart        98,12  51%',
+    command: '/watchPerformance',
+  ),
+  (
+    code: '  expect(result, isNotEmpty);',
+    status: ' NORMAL   benchmark_report_test.dart         76,5   38%',
+    command: ':write',
+  ),
+  (
+    code: '  const symbols = "λ界é";',
+    status: ' INSERT   terminal_benchmark_fixture.dart    31,28  24%',
+    command: '-- INSERT --',
+  ),
+  (
+    code: '  return renderer.buildFrame();',
+    status: ' NORMAL   terminal_renderer.dart             211,3  72%',
+    command: ':nohlsearch',
+  ),
+];
+const _partialFrameDirtyRows = 3;
+
+/// Deterministic input prepared outside every timed benchmark region.
+abstract final class TerminalBenchmarkFixture {
+  static const corpusLength = 4 * 1024 * 1024;
+
+  static final streamingOutput = _corpus(
+    _streamingRecords(),
+  ).asUnmodifiableView();
+  static final interactiveTuiOutput = _corpus(
+    _tuiRecords(),
+  ).asUnmodifiableView();
+
+  static final inputDigest = _digest();
+
+  /// Combines deterministic input and font identities for report provenance.
+  static String benchmarkDigest(String fontDigest) {
+    final input = utf8.encode('$inputDigest:$fontDigest');
+    return 'sha256:${sha256.convert(input)}';
+  }
+
+  /// Splits [input] into views allocated before the timed write loop.
+  static List<Uint8List> chunks(Uint8List input, int chunkSize) {
+    if (chunkSize <= 0) {
+      throw RangeError.range(chunkSize, 1, null, 'chunkSize');
+    }
+    if (input.length % chunkSize != 0) {
+      throw ArgumentError.value(
+        input.length,
+        'input',
+        'length must be divisible by chunkSize',
+      );
+    }
+    return List.unmodifiable([
+      for (var offset = 0; offset < input.length; offset += chunkSize)
+        Uint8List.sublistView(input, offset, offset + chunkSize),
+    ]);
+  }
+
+  /// Produces editor updates affecting three rows of the protocol surface.
+  static List<Uint8List> partialFrames({required int count}) {
+    _validateCount(count);
+    return List.unmodifiable([
+      for (var frame = 0; frame < count; frame++) _partialFrame(frame),
+    ]);
+  }
+
+  /// Produces streaming-output updates affecting every protocol row.
+  static List<Uint8List> fullFrames({required int count}) {
+    _validateCount(count);
+    return List.unmodifiable([
+      for (var frame = 0; frame < count; frame++) _fullFrame(frame),
+    ]);
+  }
+
+  /// Creates frames whose CJK glyph set is disjoint from earlier frames.
+  static List<Uint8List> glyphMissFrames({required int count}) {
+    _validateCount(count);
+    return List.unmodifiable([
+      for (var frame = 0; frame < count; frame++) _glyphFrame(frame),
+    ]);
+  }
+
+  static List<Uint8List> _streamingRecords() => [
+    for (var line = 0; line < 64; line++)
+      Uint8List.fromList(
+        utf8.encode(
+          '\x1b[38;5;39mINFO\x1b[0m '
+          'build/module_${line.toString().padLeft(2, '0')}.dart '
+          '\x1b[38;2;120;200;80mcompleted\x1b[0m in ${17 + line} ms; '
+          '\x1b[32m${100 + line} checks passed\x1b[0m; λ界 e\u0301\r\n',
+        ),
+      ),
+  ];
+
+  static List<Uint8List> _tuiRecords() => [
+    Uint8List.fromList(utf8.encode('\x1b[?1049h\x1b[2J\x1b[H')),
+    for (var index = 0; index < _editorTranscript.length; index++)
+      _partialFrame(index),
+  ];
+
+  static Uint8List _corpus(List<Uint8List> records) {
+    final output = Uint8List(corpusLength);
+    var offset = 0;
+    var record = 0;
+    while (offset + records[record].length <= output.length) {
+      final bytes = records[record];
+      output.setRange(offset, offset + bytes.length, bytes);
+      offset += bytes.length;
+      record = (record + 1) % records.length;
+    }
+    output.fillRange(offset, output.length, 0x20);
+    return output;
+  }
+
+  static Uint8List _partialFrame(int frame) {
+    final transcript = _editorTranscript[frame % _editorTranscript.length];
+    final content = [transcript.code, transcript.status, transcript.command];
+    final buffer = StringBuffer('\x1b[?2026h');
+    for (var index = 0; index < _partialFrameDirtyRows; index++) {
+      final row = benchmarkRows - _partialFrameDirtyRows + index + 1;
+      buffer
+        ..write('\x1b[$row;1H\x1b[2K')
+        ..write(content[index % content.length])
+        ..write(' #${frame.toString().padLeft(3, '0')}');
+    }
+    buffer.write('\x1b[?2026l');
+    return Uint8List.fromList(utf8.encode(buffer.toString()));
+  }
+
+  static Uint8List _fullFrame(int frame) {
+    final buffer = StringBuffer('\x1b[?2026h');
+    for (var row = 0; row < benchmarkRows; row++) {
+      buffer.write(
+        '\x1b[${row + 1};1H\x1b[2K'
+        '\x1b[38;5;${32 + row % 96}m'
+        'worker ${row.toString().padLeft(2, '0')} '
+        'frame ${frame.toString().padLeft(3, '0')} '
+        'compile λ界 e\u0301 \x1b[0m',
+      );
+    }
+    buffer.write('\x1b[?2026l');
+    return Uint8List.fromList(utf8.encode(buffer.toString()));
+  }
+
+  static Uint8List _glyphFrame(int frame) {
+    final cjk = String.fromCharCodes([
+      for (var offset = 0; offset < 4; offset++) 0x4E00 + frame * 4 + offset,
+    ]);
+    final emoji = String.fromCharCode(0x1F600 + frame % 16);
+    final frameNumber = frame.toString().padLeft(3, '0');
+    return Uint8List.fromList(
+      utf8.encode(
+        [
+          '\x1b[?2026h',
+          '\x1b[20;1H\x1b[2K\x1b[1m$cjk\x1b[0m',
+          '\x1b[21;1H\x1b[2K$emoji grapheme e\u0301',
+          '\x1b[22;1H\x1b[2Kcache miss $frameNumber',
+          '\x1b[?2026l',
+        ].join(),
+      ),
+    );
+  }
+
+  static String _digest() {
+    final components = [
+      sha256.convert(streamingOutput),
+      sha256.convert(interactiveTuiOutput),
+      ...partialFrames(count: benchmarkSteadyFrames).map(sha256.convert),
+      ...fullFrames(count: benchmarkSteadyFrames).map(sha256.convert),
+      ...glyphMissFrames(count: benchmarkGlyphMissFrames).map(sha256.convert),
+    ].join(':');
+    return 'sha256:${sha256.convert(utf8.encode(components))}';
+  }
+
+  static void _validateCount(int count) {
+    if (count <= 0) throw RangeError.range(count, 1, null, 'count');
+  }
+}

--- a/packages/flterm/tool/benchmarks/frame/harness.dart
+++ b/packages/flterm/tool/benchmarks/frame/harness.dart
@@ -1,0 +1,159 @@
+import 'dart:typed_data';
+
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:libghostty/libghostty.dart' show Terminal;
+
+import '../fixture/terminal.dart';
+import '../protocol.dart';
+import '../report/model.dart';
+import 'render_environment.dart';
+import 'result.dart';
+
+const _firstFrameReportKey = 'pending_first_frame_report';
+const _reportKey = 'pending_frame_report';
+
+/// Drives profile-mode terminal frames and returns Flutter timing summaries.
+final class FrameBenchmarkHarness {
+  final IntegrationTestWidgetsFlutterBinding _binding;
+  final WidgetTester _tester;
+
+  const FrameBenchmarkHarness(this._binding, this._tester);
+
+  Map<String, Object?> get _reportData =>
+      _binding.reportData ??= <String, Object?>{};
+
+  Future<void> initialize() async {
+    _tester.view
+      ..devicePixelRatio = 1
+      ..physicalSize = benchmarkSurfaceSize;
+    addTearDown(_tester.view.resetDevicePixelRatio);
+    addTearDown(_tester.view.resetPhysicalSize);
+    final digest = await loadBenchmarkFonts();
+    _reportData['font_digest'] = digest;
+  }
+
+  /// Measures fresh renderer mounts while excluding old-atlas disposal.
+  Future<BenchmarkWorkloadResult> measureFirstTerminalFrames() async {
+    final states = TerminalBenchmarkFixture.fullFrames(
+      count: benchmarkFirstFrameMounts,
+    );
+    final resources = [
+      for (final state in states)
+        (
+          terminal: Terminal(cols: benchmarkColumns, rows: benchmarkRows)
+            ..write(state),
+          cache: TerminalRenderCache(),
+        ),
+    ];
+    final retainedAtlases = <TerminalAtlasHandle>[];
+    try {
+      await _tester.pumpWidget(const SizedBox.shrink());
+      await _binding.watchPerformance(() async {
+        for (var sample = 0; sample < resources.length; sample++) {
+          final resource = resources[sample];
+          _binding.attachRootWidget(
+            _binding.wrapWithDefaultView(
+              BenchmarkTerminalSurface(
+                key: ValueKey(sample),
+                terminal: resource.terminal,
+                cache: resource.cache,
+              ),
+            ),
+          );
+          _binding.scheduleFrame();
+          await _binding.endOfFrame;
+          retainedAtlases.add(retainBenchmarkAtlas(resource.cache));
+        }
+      }, reportKey: _firstFrameReportKey);
+      final summary = Map<String, Object?>.from(
+        _reportData.remove(_firstFrameReportKey)! as Map<Object?, Object?>,
+      );
+      return framePerformanceResult(
+        workload: .firstTerminalFrame,
+        summary: summary,
+      );
+    } finally {
+      await _tester.pumpWidget(const SizedBox.shrink());
+      for (final handle in retainedAtlases) {
+        handle.release();
+      }
+      for (final resource in resources) {
+        resource.cache.dispose();
+        resource.terminal.dispose();
+      }
+    }
+  }
+
+  Future<BenchmarkWorkloadResult> measureGlyphMissFrames() {
+    final updates = TerminalBenchmarkFixture.glyphMissFrames(
+      count: benchmarkGlyphMissFrames,
+    );
+    return _measureFrames(workload: .glyphMisses, updates: updates);
+  }
+
+  Future<BenchmarkWorkloadResult> measureSteadyFrames({
+    required BenchmarkWorkload workload,
+    List<Uint8List>? updates,
+  }) async {
+    final terminal = Terminal(cols: benchmarkColumns, rows: benchmarkRows);
+    final cache = TerminalRenderCache();
+    addTearDown(terminal.dispose);
+    addTearDown(cache.dispose);
+    addTearDown(() => _tester.pumpWidget(const SizedBox.shrink()));
+
+    await _tester.pumpWidget(
+      BenchmarkTerminalSurface(terminal: terminal, cache: cache),
+    );
+    terminal.write(TerminalBenchmarkFixture.fullFrames(count: 1).single);
+    await _tester.pump();
+
+    var update = 0;
+    final summary = await _capture(() async {
+      for (var frame = 0; frame < benchmarkSteadyFrames; frame++) {
+        if (updates != null) {
+          terminal.write(updates[update]);
+          update = (update + 1) % updates.length;
+        }
+        await _renderFrame();
+      }
+    });
+    return framePerformanceResult(workload: workload, summary: summary);
+  }
+
+  Future<Map<String, Object?>> _capture(Future<void> Function() action) async {
+    await _binding.watchPerformance(action, reportKey: _reportKey);
+    return Map<String, Object?>.from(
+      _reportData.remove(_reportKey)! as Map<Object?, Object?>,
+    );
+  }
+
+  Future<BenchmarkWorkloadResult> _measureFrames({
+    required BenchmarkWorkload workload,
+    required List<Uint8List> updates,
+  }) async {
+    final terminal = Terminal(cols: benchmarkColumns, rows: benchmarkRows);
+    final cache = TerminalRenderCache();
+    addTearDown(terminal.dispose);
+    addTearDown(cache.dispose);
+    addTearDown(() => _tester.pumpWidget(const SizedBox.shrink()));
+    await _tester.pumpWidget(
+      BenchmarkTerminalSurface(terminal: terminal, cache: cache),
+    );
+
+    final summary = await _capture(() async {
+      for (final update in updates) {
+        terminal.write(update);
+        await _renderFrame();
+      }
+    });
+    return framePerformanceResult(workload: workload, summary: summary);
+  }
+
+  Future<void> _renderFrame() async {
+    _binding.scheduleFrame();
+    await _binding.endOfFrame;
+  }
+}

--- a/packages/flterm/tool/benchmarks/frame/render_environment.dart
+++ b/packages/flterm/tool/benchmarks/frame/render_environment.dart
@@ -1,0 +1,124 @@
+import 'dart:convert' show utf8;
+
+import 'package:crypto/crypto.dart' show sha256;
+import 'package:flterm/src/foundation/cell_metrics.dart';
+import 'package:flterm/src/foundation/terminal_render_observer.dart';
+import 'package:flterm/src/foundation/terminal_theme.dart';
+import 'package:flterm/src/rendering/atlas/atlas_config.dart';
+import 'package:flterm/src/rendering/terminal_render_cache.dart';
+import 'package:flterm/src/rendering/terminal_renderer.dart';
+import 'package:flutter/rendering.dart' show ViewportOffset;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:libghostty/libghostty.dart' show Terminal;
+
+import '../protocol.dart';
+
+const _metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
+
+/// Logical size of the benchmark grid at device pixel ratio 1.
+final benchmarkSurfaceSize = Size(
+  benchmarkColumns * _metrics.cellWidth,
+  benchmarkRows * _metrics.cellHeight,
+);
+final _theme = TerminalTheme.dark().copyWith(
+  fontFamilyFallback: const ['Noto Sans JP', 'Noto Emoji'],
+);
+final _atlasConfig = AtlasConfig.fromTheme(
+  theme: _theme,
+  metrics: _metrics,
+  devicePixelRatio: 1,
+);
+Future<String>? _loadingFonts;
+
+/// Loads every bundled font before rendering and returns their identity.
+Future<String> loadBenchmarkFonts() => _loadingFonts ??= _loadFonts();
+
+Future<String> _loadFonts() async {
+  final assets = await Future.wait([
+    rootBundle.load('assets/fonts/JetBrainsMono-Regular.ttf'),
+    rootBundle.load('assets/fonts/JetBrainsMono-Bold.ttf'),
+    rootBundle.load('assets/fonts/NotoSansJP-Regular.ttf'),
+    rootBundle.load('assets/fonts/NotoEmoji-Regular.ttf'),
+  ]);
+  final textLoader = FontLoader('Noto Sans JP')
+    ..addFont(Future.value(assets[2]));
+  final emojiLoader = FontLoader('Noto Emoji')
+    ..addFont(Future.value(assets[3]));
+  await Future.wait([textLoader.load(), emojiLoader.load()]);
+
+  return benchmarkFontDigest(
+    jetBrainsMonoRegular: assets[0],
+    jetBrainsMonoBold: assets[1],
+    notoSansJp: assets[2],
+    notoEmoji: assets[3],
+  );
+}
+
+/// Identifies every bundled font that can affect benchmark rendering.
+String benchmarkFontDigest({
+  required ByteData jetBrainsMonoRegular,
+  required ByteData jetBrainsMonoBold,
+  required ByteData notoSansJp,
+  required ByteData notoEmoji,
+}) {
+  final componentDigests = [
+    sha256.convert(Uint8List.sublistView(jetBrainsMonoRegular)),
+    sha256.convert(Uint8List.sublistView(jetBrainsMonoBold)),
+    sha256.convert(Uint8List.sublistView(notoSansJp)),
+    sha256.convert(Uint8List.sublistView(notoEmoji)),
+  ].join(':');
+  return 'sha256:${sha256.convert(utf8.encode(componentDigests))}';
+}
+
+/// Fixed terminal surface shared by every rendering workload.
+final class BenchmarkTerminalSurface extends StatelessWidget {
+  final Terminal terminal;
+  final TerminalRenderCache cache;
+
+  const BenchmarkTerminalSurface({
+    super.key,
+    required this.terminal,
+    required this.cache,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: .ltr,
+      child: Align(
+        alignment: .topLeft,
+        child: SizedBox(
+          width: benchmarkSurfaceSize.width,
+          height: benchmarkSurfaceSize.height,
+          child: TerminalRenderer(
+            terminal: terminal,
+            theme: _theme,
+            metrics: _metrics,
+            offset: ViewportOffset.zero(),
+            renderObserver: const _FocusedRenderObserver(),
+            renderCache: cache,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Keeps an already-populated atlas alive after its renderer is detached.
+TerminalAtlasHandle retainBenchmarkAtlas(TerminalRenderCache cache) {
+  return cache.acquireAtlas(_atlasConfig);
+}
+
+final class _FocusedRenderObserver implements TerminalRenderObserver {
+  const _FocusedRenderObserver();
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+}

--- a/packages/flterm/tool/benchmarks/frame/result.dart
+++ b/packages/flterm/tool/benchmarks/frame/result.dart
@@ -1,0 +1,123 @@
+import '../protocol.dart';
+import '../report/model.dart';
+
+enum _FrameMetric {
+  /// Mean framework build duration.
+  uiAverage(
+    'ui_average',
+    'UI average',
+    'average_frame_build_time_millis',
+    .milliseconds,
+  ),
+
+  /// 90th-percentile framework build duration.
+  uiP90(
+    'ui_p90',
+    'UI p90',
+    '90th_percentile_frame_build_time_millis',
+    .milliseconds,
+  ),
+
+  /// 99th-percentile framework build duration.
+  uiP99(
+    'ui_p99',
+    'UI p99',
+    '99th_percentile_frame_build_time_millis',
+    .milliseconds,
+  ),
+
+  /// Longest framework build duration.
+  uiWorst(
+    'ui_worst',
+    'UI worst',
+    'worst_frame_build_time_millis',
+    .milliseconds,
+  ),
+
+  /// Framework builds exceeding Flutter's frame budget.
+  uiMissedBudget(
+    'ui_missed_budget',
+    'UI missed 16 ms budget',
+    'missed_frame_build_budget_count',
+    .count,
+  ),
+
+  /// Mean engine raster duration.
+  rasterAverage(
+    'raster_average',
+    'raster average',
+    'average_frame_rasterizer_time_millis',
+    .milliseconds,
+  ),
+
+  /// 90th-percentile engine raster duration.
+  rasterP90(
+    'raster_p90',
+    'raster p90',
+    '90th_percentile_frame_rasterizer_time_millis',
+    .milliseconds,
+  ),
+
+  /// 99th-percentile engine raster duration.
+  rasterP99(
+    'raster_p99',
+    'raster p99',
+    '99th_percentile_frame_rasterizer_time_millis',
+    .milliseconds,
+  ),
+
+  /// Longest engine raster duration.
+  rasterWorst(
+    'raster_worst',
+    'raster worst',
+    'worst_frame_rasterizer_time_millis',
+    .milliseconds,
+  ),
+
+  /// Raster passes exceeding Flutter's frame budget.
+  rasterMissedBudget(
+    'raster_missed_budget',
+    'raster missed 16 ms budget',
+    'missed_frame_rasterizer_budget_count',
+    .count,
+  );
+
+  const _FrameMetric(this.id, this.label, this.source, this.unit);
+
+  final String id;
+  final String label;
+  final String source;
+  final BenchmarkMetricUnit unit;
+}
+
+/// Converts Flutter's frame summary into stable benchmark metrics.
+BenchmarkWorkloadResult framePerformanceResult({
+  required BenchmarkWorkload workload,
+  required Map<String, Object?> summary,
+}) {
+  if (workload.kind != .frame) {
+    throw ArgumentError.value(workload, 'workload', 'must be a frame workload');
+  }
+  return BenchmarkWorkloadResult(
+    id: workload.id,
+    label: workload.label,
+    metrics: [
+      for (final metric in _FrameMetric.values)
+        BenchmarkMetric(
+          id: metric.id,
+          label: metric.label,
+          value: _metric(summary, metric.source).toDouble(),
+          unit: metric.unit,
+          direction: .lowerIsBetter,
+        ),
+    ],
+    details: Map.unmodifiable(summary),
+  );
+}
+
+num _metric(Map<String, Object?> summary, String name) {
+  return switch (summary[name]) {
+    final num value => value,
+    _ => throw FormatException('Frame summary metric "$name" is missing.'),
+  };
+}

--- a/packages/flterm/tool/benchmarks/frame/suite.dart
+++ b/packages/flterm/tool/benchmarks/frame/suite.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../fixture/terminal.dart';
+import '../input_benchmark.dart';
+import '../protocol.dart';
+import '../report/model.dart';
+import 'harness.dart';
+
+/// Owns workload registration and result collection for one profile run.
+///
+/// ```dart
+/// FltermBenchmarkSuite(binding).register();
+/// ```
+final class FltermBenchmarkSuite {
+  final IntegrationTestWidgetsFlutterBinding _binding;
+
+  const FltermBenchmarkSuite(this._binding);
+
+  void register() {
+    group('flterm performance', () {
+      group('input throughput', () {
+        testWidgets('records public controller workloads', (tester) async {
+          final results = runControllerWriteBenchmarks();
+
+          _record(results);
+
+          expect(results, hasLength(2));
+        });
+      });
+
+      group('frame rendering', () {
+        testWidgets('records clean frames', (tester) async {
+          final harness = await _harness(tester);
+
+          final result = await harness.measureSteadyFrames(
+            workload: .cleanFrame,
+          );
+          _record([result]);
+
+          _expectCapturedFrames(result, benchmarkSteadyFrames);
+        });
+
+        testWidgets('records partial TUI updates', (tester) async {
+          final harness = await _harness(tester);
+          final updates = TerminalBenchmarkFixture.partialFrames(
+            count: benchmarkSteadyFrames,
+          );
+
+          final result = await harness.measureSteadyFrames(
+            workload: .partialTui,
+            updates: updates,
+          );
+          _record([result]);
+
+          _expectCapturedFrames(result, benchmarkSteadyFrames);
+        });
+
+        testWidgets('records full-screen output', (tester) async {
+          final harness = await _harness(tester);
+          final updates = TerminalBenchmarkFixture.fullFrames(
+            count: benchmarkSteadyFrames,
+          );
+
+          final result = await harness.measureSteadyFrames(
+            workload: .fullOutput,
+            updates: updates,
+          );
+          _record([result]);
+
+          _expectCapturedFrames(result, benchmarkSteadyFrames);
+        });
+
+        testWidgets('records glyph cache misses', (tester) async {
+          final harness = await _harness(tester);
+
+          final result = await harness.measureGlyphMissFrames();
+          _record([result]);
+
+          _expectCapturedFrames(result, benchmarkGlyphMissFrames);
+        });
+
+        testWidgets('records first terminal frames', (tester) async {
+          final harness = await _harness(tester);
+
+          final result = await harness.measureFirstTerminalFrames();
+          _record([result]);
+
+          expect(
+            result.details['frame_count'],
+            greaterThanOrEqualTo(benchmarkFirstFrameSamples),
+          );
+        });
+      });
+    });
+  }
+
+  Future<FrameBenchmarkHarness> _harness(WidgetTester tester) async {
+    final harness = FrameBenchmarkHarness(_binding, tester);
+    await harness.initialize();
+    return harness;
+  }
+
+  void _expectCapturedFrames(
+    BenchmarkWorkloadResult result,
+    int scheduledFrames,
+  ) {
+    final minimum = (scheduledFrames * benchmarkMinimumFrameCaptureRatio)
+        .floor();
+    expect(result.details['frame_count'], greaterThanOrEqualTo(minimum));
+  }
+
+  void _record(List<BenchmarkWorkloadResult> results) {
+    final data = _binding.reportData ??= <String, Object?>{};
+    final existing = switch (data['workloads']) {
+      final List<Object?> values => values,
+      null => <Object?>[],
+      _ => throw const FormatException('Benchmark workloads must be a list.'),
+    };
+    data['workloads'] = [
+      ...existing,
+      for (final result in results) result.toJson(),
+    ];
+  }
+}

--- a/packages/flterm/tool/benchmarks/input_benchmark.dart
+++ b/packages/flterm/tool/benchmarks/input_benchmark.dart
@@ -1,0 +1,205 @@
+import 'dart:math' show sqrt;
+import 'dart:typed_data';
+
+import 'package:flterm/flterm.dart' show TerminalConfig, TerminalController;
+
+import 'fixture/terminal.dart';
+import 'protocol.dart';
+import 'report/model.dart';
+
+const _interactiveChunkSize = 4 * 1024;
+const _streamingChunkSize = 128 * 1024;
+
+/// Measures fixed work after warmup until both sample minima are met.
+BenchmarkWorkloadResult measureBenchmark({
+  required BenchmarkWorkload workload,
+  required void Function() step,
+  void Function()? prepare,
+  int warmupIterations = 10,
+  int minimumSamples = 100,
+  Duration minimumDuration = const Duration(seconds: 5),
+  int? bytesPerIteration,
+  int Function()? clock,
+}) {
+  if (workload.kind != .input) {
+    throw ArgumentError.value(
+      workload,
+      'workload',
+      'must be an input workload',
+    );
+  }
+  if (warmupIterations < 0) {
+    throw RangeError.range(warmupIterations, 0, null, 'warmupIterations');
+  }
+  if (minimumSamples <= 0) {
+    throw RangeError.range(minimumSamples, 1, null, 'minimumSamples');
+  }
+  if (minimumDuration.isNegative) {
+    throw ArgumentError.value(minimumDuration, 'minimumDuration');
+  }
+  if (bytesPerIteration != null && bytesPerIteration <= 0) {
+    throw RangeError.range(bytesPerIteration, 1, null, 'bytesPerIteration');
+  }
+  for (var iteration = 0; iteration < warmupIterations; iteration++) {
+    prepare?.call();
+    step();
+  }
+
+  final readClock = clock ?? _stopwatchClock();
+  final samples = <int>[];
+  var measuredMicroseconds = 0;
+  do {
+    prepare?.call();
+    final start = readClock();
+    step();
+    final elapsed = readClock() - start;
+    if (elapsed <= 0) {
+      throw StateError(
+        'Benchmark "${workload.id}" completed below the clock resolution.',
+      );
+    }
+    samples.add(elapsed);
+    measuredMicroseconds += elapsed;
+  } while (samples.length < minimumSamples ||
+      measuredMicroseconds < minimumDuration.inMicroseconds);
+
+  return _workloadResult(
+    workload: workload,
+    samples: samples,
+    bytesPerIteration: bytesPerIteration,
+  );
+}
+
+/// Measures the public input boundary with realistic precomputed streams.
+List<BenchmarkWorkloadResult> runControllerWriteBenchmarks() {
+  return [
+    _measureWrites(
+      workload: .streamingOutput,
+      chunks: TerminalBenchmarkFixture.chunks(
+        TerminalBenchmarkFixture.streamingOutput,
+        _streamingChunkSize,
+      ),
+    ),
+    _measureWrites(
+      workload: .interactiveTui,
+      chunks: TerminalBenchmarkFixture.chunks(
+        TerminalBenchmarkFixture.interactiveTuiOutput,
+        _interactiveChunkSize,
+      ),
+    ),
+  ];
+}
+
+BenchmarkWorkloadResult _measureWrites({
+  required BenchmarkWorkload workload,
+  required List<Uint8List> chunks,
+}) {
+  final controller = TerminalController(
+    config: const TerminalConfig(scrollbackLimit: 0),
+  );
+  try {
+    return measureBenchmark(
+      workload: workload,
+      step: () => _writeChunks(controller, chunks),
+      bytesPerIteration: TerminalBenchmarkFixture.corpusLength,
+    );
+  } finally {
+    controller.dispose();
+  }
+}
+
+int Function() _stopwatchClock() {
+  final stopwatch = Stopwatch()..start();
+  return () => stopwatch.elapsedMicroseconds;
+}
+
+BenchmarkMetric _timingMetric(String id, num microseconds) {
+  return BenchmarkMetric(
+    id: id,
+    label: id,
+    value: microseconds / Duration.microsecondsPerMillisecond,
+    unit: .milliseconds,
+    direction: .lowerIsBetter,
+  );
+}
+
+BenchmarkWorkloadResult _workloadResult({
+  required BenchmarkWorkload workload,
+  required List<int> samples,
+  required int? bytesPerIteration,
+}) {
+  final statistics = _SampleStatistics(samples);
+  final throughput = bytesPerIteration == null
+      ? null
+      : bytesPerIteration /
+            (1024 * 1024) /
+            (statistics.mean / Duration.microsecondsPerSecond);
+  return BenchmarkWorkloadResult(
+    id: workload.id,
+    label: workload.label,
+    metrics: [
+      if (throughput != null)
+        BenchmarkMetric(
+          id: 'throughput',
+          label: 'throughput',
+          value: throughput,
+          unit: .mebibytesPerSecond,
+          direction: .higherIsBetter,
+        ),
+      _timingMetric('mean', statistics.mean),
+      _timingMetric('standard_deviation', statistics.standardDeviation),
+      _timingMetric('p50', statistics.p50),
+      _timingMetric('p95', statistics.p95),
+      _timingMetric('p99', statistics.p99),
+    ],
+    details: {
+      'samples': samples.length,
+      'samples_microseconds': List<int>.unmodifiable(samples),
+      'bytes_per_iteration': ?bytesPerIteration,
+    },
+  );
+}
+
+void _writeChunks(TerminalController controller, List<Uint8List> chunks) {
+  for (var index = 0; index < chunks.length; index++) {
+    controller.write(chunks[index]);
+  }
+}
+
+final class _SampleStatistics {
+  final double mean;
+  final double standardDeviation;
+  final int p50;
+  final int p95;
+  final int p99;
+
+  factory _SampleStatistics(List<int> samples) {
+    final sorted = [...samples]..sort();
+    final mean =
+        samples.fold<int>(0, (sum, sample) => sum + sample) / samples.length;
+    final squaredDifferenceSum = samples.fold<double>(0, (sum, sample) {
+      final difference = sample - mean;
+      return sum + difference * difference;
+    });
+
+    int percentile(double value) => sorted[(sorted.length * value).ceil() - 1];
+
+    return _SampleStatistics._(
+      mean: mean,
+      standardDeviation: samples.length == 1
+          ? 0
+          : sqrt(squaredDifferenceSum / (samples.length - 1)),
+      p50: percentile(0.50),
+      p95: percentile(0.95),
+      p99: percentile(0.99),
+    );
+  }
+
+  const _SampleStatistics._({
+    required this.mean,
+    required this.standardDeviation,
+    required this.p50,
+    required this.p95,
+    required this.p99,
+  });
+}

--- a/packages/flterm/tool/benchmarks/protocol.dart
+++ b/packages/flterm/tool/benchmarks/protocol.dart
@@ -1,0 +1,67 @@
+const benchmarkProtocolVersion = 2;
+const benchmarkColumns = 120;
+const benchmarkRows = 80;
+const benchmarkSteadyFrames = 300;
+const benchmarkGlyphMissFrames = 120;
+const benchmarkFirstFrameSamples = 30;
+const benchmarkFirstFrameMounts = 36;
+const benchmarkMinimumFrameCaptureRatio = 0.95;
+
+/// The user-facing performance boundary exercised by a workload.
+enum BenchmarkWorkloadKind {
+  /// Terminal input processing measured outside Flutter frame timing.
+  input,
+
+  /// Flutter UI and raster work measured from engine frame timings.
+  frame,
+}
+
+/// Stable workload identities shared by measurement and reporting.
+enum BenchmarkWorkload {
+  /// Batched command output written in 128 KiB chunks.
+  streamingOutput(
+    'input.streaming_output',
+    'streaming output, 128 KiB chunks',
+    .input,
+  ),
+
+  /// Escape-heavy interactive output written in 4 KiB chunks.
+  interactiveTui(
+    'input.interactive_tui',
+    'interactive TUI, 4 KiB chunks',
+    .input,
+  ),
+
+  /// An unchanged terminal rendered repeatedly.
+  cleanFrame('render.clean', 'clean frame', .frame),
+
+  /// An editor-like update affecting three terminal rows.
+  partialTui('render.partial_tui', 'partial TUI update', .frame),
+
+  /// Styled output replacing every visible terminal row.
+  fullOutput('render.full_output', 'full-screen output', .frame),
+
+  /// Frames introducing glyphs not already present in the atlas.
+  glyphMisses('render.glyph_misses', 'new glyphs', .frame),
+
+  /// The first presentation of a fresh terminal renderer.
+  firstTerminalFrame(
+    'render.first_terminal_frame',
+    'first terminal frame',
+    .frame,
+  );
+
+  const BenchmarkWorkload(this.id, this.label, this.kind);
+
+  final String id;
+  final String label;
+  final BenchmarkWorkloadKind kind;
+
+  static final _byId = {for (final workload in values) workload.id: workload};
+
+  /// Resolves the workload whose stable protocol identity is [id].
+  static BenchmarkWorkload fromId(String id) {
+    return _byId[id] ??
+        (throw FormatException('Unknown benchmark workload "$id".'));
+  }
+}

--- a/packages/flterm/tool/benchmarks/report/markdown.dart
+++ b/packages/flterm/tool/benchmarks/report/markdown.dart
@@ -1,0 +1,134 @@
+import '../protocol.dart';
+import 'model.dart';
+
+enum _FramePhase {
+  /// Framework build work recorded on Flutter's UI thread.
+  ui('UI', 'ui'),
+
+  /// Engine raster work recorded after the UI phase.
+  raster('raster', 'raster');
+
+  const _FramePhase(this.label, this.metricPrefix);
+
+  final String label;
+  final String metricPrefix;
+}
+
+String formatBenchmarkReport(BenchmarkReport report) {
+  final environment = report.environment;
+  final input = _workloads(report, .input);
+  final frames = _workloads(report, .frame);
+  final platform = [
+    'Platform: ${environment.operatingSystem}',
+    environment.operatingSystemVersion,
+    '(${environment.architecture})  ',
+  ].join(' ');
+  final runner = environment.runnerImage;
+  final frameHeader = [
+    '| workload | phase | average | p90 | p99 | worst |',
+    'missed >16 ms | frames |',
+  ].join(' ');
+  final directionNote = [
+    'Throughput is higher-is-better.',
+    'Frame timings and missed budgets are lower-is-better.',
+    'Missed budgets are shown as count over captured frames and rate.',
+  ].join(' ');
+
+  return [
+    '# flterm benchmark',
+    '',
+    'Revision: `${report.revision}`  ',
+    platform,
+    if (runner != null) 'Runner: $runner  ',
+    'Flutter: ${environment.flutterVersion}  ',
+    'Dart: ${environment.dartVersion}  ',
+    'Mode: profile  ',
+    'Terminal: $benchmarkColumns×$benchmarkRows at device pixel ratio 1  ',
+    'Protocol: ${report.protocolVersion}  ',
+    'Fixture: `${report.fixtureDigest}`',
+    '',
+    '## Input throughput',
+    '',
+    '| workload | throughput | mean ± std dev | p50 | p95 | p99 | samples |',
+    '|---|---:|---:|---:|---:|---:|---:|',
+    for (final workload in input) _inputRow(workload),
+    '',
+    '## Frame performance',
+    '',
+    frameHeader,
+    '|---|---|---:|---:|---:|---:|---:|---:|',
+    for (final workload in frames) ...[
+      for (final phase in _FramePhase.values) _frameRow(workload, phase),
+    ],
+    '',
+    directionNote,
+  ].join('\n');
+}
+
+String _inputRow(BenchmarkWorkloadResult workload) {
+  final mean = _metricValue(workload, 'mean');
+  final deviation = _metricValue(workload, 'standard_deviation');
+  final values = [
+    workload.label,
+    _metricValue(workload, 'throughput'),
+    '$mean ± $deviation',
+    _metricValue(workload, 'p50'),
+    _metricValue(workload, 'p95'),
+    _metricValue(workload, 'p99'),
+    '${workload.detailCount('samples')}',
+  ];
+  return '| ${values.join(' | ')} |';
+}
+
+String _frameRow(BenchmarkWorkloadResult workload, _FramePhase phase) {
+  final prefix = phase.metricPrefix;
+  final values = [
+    workload.label,
+    phase.label,
+    _metricValue(workload, '${prefix}_average'),
+    _metricValue(workload, '${prefix}_p90'),
+    _metricValue(workload, '${prefix}_p99'),
+    _metricValue(workload, '${prefix}_worst'),
+    _missedFrames(workload, '${prefix}_missed_budget'),
+    '${workload.detailCount('frame_count')}',
+  ];
+  return '| ${values.join(' | ')} |';
+}
+
+String _metricValue(BenchmarkWorkloadResult workload, String id) {
+  return _value(workload.metric(id));
+}
+
+String _value(BenchmarkMetric metric) {
+  final digits = metric.unit == .count ? 0 : 2;
+  final suffix = metric.unit.displayName;
+  final value = metric.value.toStringAsFixed(digits);
+  return suffix.isEmpty ? value : '$value $suffix';
+}
+
+String _missedFrames(BenchmarkWorkloadResult workload, String metricId) {
+  final frames = workload.detailCount('frame_count');
+  if (frames == 0) {
+    throw FormatException(
+      'Benchmark workload "${workload.id}" contains no frame timings.',
+    );
+  }
+  final missed = workload.metric(metricId).value;
+  if (missed != missed.roundToDouble()) {
+    throw FormatException(
+      'Benchmark workload "${workload.id}" has a fractional missed count.',
+    );
+  }
+  final count = missed.toInt();
+  final rate = count / frames * 100;
+  return '$count/$frames (${rate.toStringAsFixed(1)}%)';
+}
+
+Iterable<BenchmarkWorkloadResult> _workloads(
+  BenchmarkReport report,
+  BenchmarkWorkloadKind kind,
+) {
+  return report.workloads.where(
+    (result) => BenchmarkWorkload.fromId(result.id).kind == kind,
+  );
+}

--- a/packages/flterm/tool/benchmarks/report/model.dart
+++ b/packages/flterm/tool/benchmarks/report/model.dart
@@ -1,0 +1,228 @@
+const benchmarkReportSchemaVersion = 1;
+
+/// Runtime properties recorded with a benchmark result.
+final class BenchmarkEnvironment {
+  final String operatingSystem;
+  final String operatingSystemVersion;
+  final String architecture;
+  final String dartVersion;
+  final String flutterVersion;
+  final String? runnerImage;
+
+  const BenchmarkEnvironment({
+    required this.operatingSystem,
+    required this.operatingSystemVersion,
+    required this.architecture,
+    required this.dartVersion,
+    required this.flutterVersion,
+    this.runnerImage,
+  });
+
+  Map<String, Object?> toJson() => {
+    'operating_system': operatingSystem,
+    'operating_system_version': operatingSystemVersion,
+    'architecture': architecture,
+    'dart_version': dartVersion,
+    'flutter_version': flutterVersion,
+    ...switch (runnerImage) {
+      final value? => {'runner_image': value},
+      null => const {},
+    },
+  };
+}
+
+/// One measurement produced by a benchmark workload.
+final class BenchmarkMetric {
+  final String id;
+  final String label;
+  final double value;
+  final BenchmarkMetricUnit unit;
+  final BenchmarkMetricDirection direction;
+
+  BenchmarkMetric({
+    required String id,
+    required String label,
+    required double value,
+    required this.unit,
+    required this.direction,
+  }) : id = _requiredText(id, 'metric id'),
+       label = _requiredText(label, 'metric label'),
+       value = _measurement(value);
+
+  factory BenchmarkMetric.fromJson(Map<String, Object?> json) {
+    return BenchmarkMetric(
+      id: json['id']! as String,
+      label: json['label']! as String,
+      value: (json['value']! as num).toDouble(),
+      unit: switch (json['unit']! as String) {
+        'milliseconds' => .milliseconds,
+        'mebibytes_per_second' => .mebibytesPerSecond,
+        'count' => .count,
+        final value => throw FormatException(
+          'Unknown benchmark metric unit "$value".',
+        ),
+      },
+      direction: switch (json['direction']! as String) {
+        'higher_is_better' => .higherIsBetter,
+        'lower_is_better' => .lowerIsBetter,
+        final value => throw FormatException(
+          'Unknown benchmark metric direction "$value".',
+        ),
+      },
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'label': label,
+    'value': value,
+    'unit': unit.jsonName,
+    'direction': direction.jsonName,
+  };
+}
+
+enum BenchmarkMetricDirection {
+  higherIsBetter('higher_is_better'),
+  lowerIsBetter('lower_is_better');
+
+  const BenchmarkMetricDirection(this.jsonName);
+
+  final String jsonName;
+}
+
+enum BenchmarkMetricUnit {
+  milliseconds('milliseconds', 'ms'),
+  mebibytesPerSecond('mebibytes_per_second', 'MiB/s'),
+  count('count', '');
+
+  const BenchmarkMetricUnit(this.jsonName, this.displayName);
+
+  final String jsonName;
+  final String displayName;
+}
+
+/// Versioned output from one benchmark run.
+final class BenchmarkReport {
+  final int schemaVersion = benchmarkReportSchemaVersion;
+  final int protocolVersion;
+  final String fixtureDigest;
+  final String revision;
+  final BenchmarkEnvironment environment;
+  final List<BenchmarkWorkloadResult> workloads;
+
+  BenchmarkReport({
+    required this.protocolVersion,
+    required this.fixtureDigest,
+    required this.revision,
+    required this.environment,
+    required List<BenchmarkWorkloadResult> workloads,
+  }) : workloads = _uniqueWorkloads(workloads);
+
+  Map<String, Object?> toJson() => {
+    'schema_version': schemaVersion,
+    'protocol_version': protocolVersion,
+    'fixture_digest': fixtureDigest,
+    'revision': revision,
+    'environment': environment.toJson(),
+    'workloads': [for (final workload in workloads) workload.toJson()],
+  };
+}
+
+/// Results and diagnostic details for one stable workload identity.
+final class BenchmarkWorkloadResult {
+  final String id;
+  final String label;
+  final List<BenchmarkMetric> metrics;
+  final Map<String, Object?> details;
+
+  BenchmarkWorkloadResult({
+    required String id,
+    required String label,
+    required List<BenchmarkMetric> metrics,
+    Map<String, Object?> details = const {},
+  }) : id = _requiredText(id, 'workload id'),
+       label = _requiredText(label, 'workload label'),
+       metrics = _uniqueMetrics(metrics),
+       details = Map.unmodifiable(details);
+
+  factory BenchmarkWorkloadResult.fromJson(Map<String, Object?> json) {
+    return BenchmarkWorkloadResult(
+      id: json['id']! as String,
+      label: json['label']! as String,
+      metrics: [
+        for (final value in json['metrics']! as List<Object?>)
+          BenchmarkMetric.fromJson(value! as Map<String, Object?>),
+      ],
+      details: json['details']! as Map<String, Object?>,
+    );
+  }
+
+  /// Returns the required non-negative integer detail identified by [id].
+  int detailCount(String id) {
+    return switch (details[id]) {
+      final int value when value >= 0 => value,
+      _ => throw FormatException(
+        'Benchmark workload "${this.id}" is missing count detail "$id".',
+      ),
+    };
+  }
+
+  /// Returns the required metric identified by [id].
+  BenchmarkMetric metric(String id) {
+    for (final metric in metrics) {
+      if (metric.id == id) return metric;
+    }
+    throw FormatException(
+      'Benchmark workload "${this.id}" is missing metric "$id".',
+    );
+  }
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'label': label,
+    'metrics': [for (final metric in metrics) metric.toJson()],
+    'details': details,
+  };
+}
+
+double _measurement(double value) {
+  if (!value.isFinite || value < 0) {
+    throw const FormatException(
+      'Benchmark metric "value" must be finite and non-negative.',
+    );
+  }
+  return value;
+}
+
+String _requiredText(String value, String name) {
+  if (value.trim().isEmpty) {
+    throw FormatException('Benchmark $name must not be empty.');
+  }
+  return value;
+}
+
+List<BenchmarkMetric> _uniqueMetrics(List<BenchmarkMetric> metrics) {
+  final ids = <String>{};
+  for (final metric in metrics) {
+    if (!ids.add(metric.id)) {
+      throw FormatException(
+        'Benchmark workload contains duplicate metric id "${metric.id}".',
+      );
+    }
+  }
+  return List.unmodifiable(metrics);
+}
+
+List<BenchmarkWorkloadResult> _uniqueWorkloads(
+  List<BenchmarkWorkloadResult> workloads,
+) {
+  final ids = <String>{};
+  for (final workload in workloads) {
+    if (!ids.add(workload.id)) {
+      throw FormatException(
+        'Benchmark report contains duplicate workload id "${workload.id}".',
+      );
+    }
+  }
+  return List.unmodifiable(workloads);
+}

--- a/packages/flterm/tool/benchmarks/run.dart
+++ b/packages/flterm/tool/benchmarks/run.dart
@@ -1,0 +1,316 @@
+import 'dart:convert';
+import 'dart:ffi' show Abi;
+import 'dart:io';
+
+import 'fixture/terminal.dart';
+import 'protocol.dart';
+import 'report/markdown.dart';
+import 'report/model.dart';
+
+const _usageExitCode = 64;
+
+/// Flutter drive arguments for the profile benchmark.
+const benchmarkDriveArguments = [
+  'drive',
+  '--no-dds',
+  '--driver',
+  'test_driver/flterm_benchmark_driver.dart',
+  '--target',
+  'integration_test/flterm_benchmark.dart',
+  '--profile',
+  '--dart-define=INTEGRATION_TEST_SHOULD_REPORT_RESULTS_TO_NATIVE=false',
+  '-d',
+  'macos',
+];
+
+Future<void> main(List<String> arguments) async {
+  if (!Platform.isMacOS) {
+    stderr.writeln(
+      'The flterm example currently provides only a macOS desktop runner.',
+    );
+    exitCode = _usageExitCode;
+    return;
+  }
+
+  late final ({Directory? outputDirectory, String revision}) options;
+  try {
+    options = _parseOptions(arguments);
+  } on FormatException catch (error) {
+    stderr.writeln(error.message);
+    exitCode = _usageExitCode;
+    return;
+  }
+
+  try {
+    await _BenchmarkRun(options).execute();
+  } on ProcessException catch (error) {
+    stderr.writeln(error);
+    exitCode = error.errorCode;
+  } on FileSystemException catch (error) {
+    stderr.writeln(error.message);
+    exitCode = 1;
+  } on FormatException catch (error) {
+    stderr.writeln(error.message);
+    exitCode = 1;
+  }
+}
+
+final class _BenchmarkRun {
+  final String revision;
+  final Directory exampleDirectory;
+  final BenchmarkArtifacts artifacts;
+
+  factory _BenchmarkRun(
+    ({Directory? outputDirectory, String revision}) options,
+  ) {
+    final packageDirectory = File.fromUri(Platform.script).parent.parent.parent;
+    final exampleDirectory = Directory.fromUri(
+      packageDirectory.uri.resolve('example/'),
+    );
+    return _BenchmarkRun._(
+      revision: options.revision,
+      exampleDirectory: exampleDirectory,
+      artifacts: BenchmarkArtifacts(
+        options.outputDirectory ??
+            Directory.fromUri(
+              exampleDirectory.uri.resolve('build/benchmark-results/'),
+            ),
+      ),
+    );
+  }
+
+  const _BenchmarkRun._({
+    required this.revision,
+    required this.exampleDirectory,
+    required this.artifacts,
+  });
+
+  Future<void> execute() async {
+    artifacts.prepare();
+    final rawFlutter = File.fromUri(
+      exampleDirectory.uri.resolve('build/flterm_benchmarks.json'),
+    );
+    if (rawFlutter.existsSync()) rawFlutter.deleteSync();
+
+    final flutterVersion = await _flutterVersion();
+    final processExitCode = await _runFlutter();
+    if (processExitCode != 0) {
+      exitCode = processExitCode;
+      return;
+    }
+
+    final report = benchmarkReportFromFlutterResponse(
+      _readJsonObject(rawFlutter),
+      revision: revision,
+      environment: _environment(flutterVersion),
+    );
+    final markdown = formatBenchmarkReport(report);
+    artifacts.writeResults(
+      report: report,
+      markdown: markdown,
+      rawFlutter: rawFlutter,
+    );
+    stdout.writeln(markdown);
+  }
+
+  Future<String> _flutterVersion() async {
+    final result = await Process.run('flutter', const [
+      '--version',
+      '--machine',
+    ]);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'flutter',
+        const ['--version', '--machine'],
+        result.stderr as String,
+        result.exitCode,
+      );
+    }
+    final Object? json = jsonDecode(result.stdout as String);
+    final data = _jsonObject(json, 'Flutter version');
+    return switch (data['frameworkVersion']) {
+      final String value when value.isNotEmpty => value,
+      _ => throw const FormatException(
+        'Flutter version output contains no framework version.',
+      ),
+    };
+  }
+
+  Future<int> _runFlutter() async {
+    final process = await Process.start(
+      'flutter',
+      benchmarkDriveArguments,
+      workingDirectory: exampleDirectory.path,
+    );
+    final output = _pipe(process.stdout, artifacts.stdoutLog, stdout);
+    final errors = _pipe(process.stderr, artifacts.stderrLog, stderr);
+    final (processExitCode, _, _) = await (
+      process.exitCode,
+      output,
+      errors,
+    ).wait;
+    return processExitCode;
+  }
+
+  Future<void> _pipe(
+    Stream<List<int>> input,
+    File logFile,
+    IOSink console,
+  ) async {
+    final log = logFile.openWrite();
+    try {
+      await for (final text in input.transform(utf8.decoder)) {
+        log.write(text);
+        console.write(text);
+      }
+    } finally {
+      await log.close();
+    }
+  }
+
+  BenchmarkEnvironment _environment(String flutterVersion) {
+    final runnerImage = [
+      ?Platform.environment['ImageOS'],
+      ?Platform.environment['ImageVersion'],
+    ].join(' ');
+    return BenchmarkEnvironment(
+      operatingSystem: Platform.operatingSystem,
+      operatingSystemVersion: Platform.operatingSystemVersion,
+      architecture: Abi.current().toString(),
+      dartVersion: Platform.version.split(' ').first,
+      flutterVersion: flutterVersion,
+      runnerImage: runnerImage.isEmpty ? null : runnerImage,
+    );
+  }
+}
+
+/// Validates Flutter's response and attaches host-side run metadata.
+BenchmarkReport benchmarkReportFromFlutterResponse(
+  Map<String, Object?> response, {
+  required String revision,
+  required BenchmarkEnvironment environment,
+}) {
+  final workloadData = switch (response['workloads']) {
+    final List<Object?> values => values,
+    _ => throw const FormatException(
+      'Flutter benchmark response contains no workloads.',
+    ),
+  };
+  final fontDigest = switch (response['font_digest']) {
+    final String value when value.isNotEmpty => value,
+    _ => throw const FormatException(
+      'Flutter benchmark response contains no font digest.',
+    ),
+  };
+  final report = BenchmarkReport(
+    protocolVersion: benchmarkProtocolVersion,
+    fixtureDigest: TerminalBenchmarkFixture.benchmarkDigest(fontDigest),
+    revision: revision,
+    environment: environment,
+    workloads: [
+      for (final value in workloadData)
+        BenchmarkWorkloadResult.fromJson(_jsonObject(value, 'workload')),
+    ],
+  );
+  final expected = {
+    for (final workload in BenchmarkWorkload.values) workload.id,
+  };
+  final actual = {for (final workload in report.workloads) workload.id};
+  if (report.workloads.length != expected.length ||
+      !actual.containsAll(expected)) {
+    throw const FormatException(
+      'Flutter benchmark response must contain every protocol workload.',
+    );
+  }
+  return report;
+}
+
+Map<String, Object?> _readJsonObject(File file) {
+  if (!file.existsSync()) {
+    throw FormatException('Benchmark response file is missing: ${file.path}');
+  }
+  final Object? json = jsonDecode(file.readAsStringSync());
+  return _jsonObject(json, 'benchmark response');
+}
+
+Map<String, Object?> _jsonObject(Object? value, String name) {
+  return switch (value) {
+    final Map<Object?, Object?> value => Map<String, Object?>.from(value),
+    _ => throw FormatException('$name must be a JSON object.'),
+  };
+}
+
+/// Owns the files produced by one host-side benchmark run.
+///
+/// [prepare] removes only known benchmark artifacts, leaving other entries in
+/// the output directory intact.
+///
+/// ```dart
+/// final artifacts = BenchmarkArtifacts(Directory('/tmp/flterm-results'));
+/// artifacts.prepare();
+/// ```
+final class BenchmarkArtifacts {
+  static const _names = [
+    'results.json',
+    'report.md',
+    'raw-flutter.json',
+    'flutter.stdout.log',
+    'flutter.stderr.log',
+  ];
+
+  final Directory directory;
+
+  const BenchmarkArtifacts(this.directory);
+
+  File get stdoutLog => _file('flutter.stdout.log');
+  File get stderrLog => _file('flutter.stderr.log');
+
+  void prepare() {
+    directory.createSync(recursive: true);
+    for (final name in _names) {
+      final artifact = _file(name);
+      if (artifact.existsSync()) artifact.deleteSync();
+    }
+  }
+
+  void writeResults({
+    required BenchmarkReport report,
+    required String markdown,
+    required File rawFlutter,
+  }) {
+    _writeText(
+      'results.json',
+      const JsonEncoder.withIndent('  ').convert(report.toJson()),
+    );
+    _writeText('report.md', markdown);
+    rawFlutter.copySync(_file('raw-flutter.json').path);
+  }
+
+  File _file(String name) => File.fromUri(directory.uri.resolve(name));
+
+  void _writeText(String name, String contents) {
+    _file(name).writeAsStringSync('$contents\n');
+  }
+}
+
+({Directory? outputDirectory, String revision}) _parseOptions(
+  List<String> arguments,
+) {
+  Directory? output;
+  var revision = 'working-tree';
+  for (var index = 0; index < arguments.length; index += 2) {
+    if (index + 1 >= arguments.length) {
+      throw FormatException('Missing value for ${arguments[index]}.');
+    }
+    final value = arguments[index + 1];
+    switch (arguments[index]) {
+      case '--output':
+        output = Directory(value);
+      case '--revision':
+        revision = value;
+      default:
+        throw FormatException('Unknown option ${arguments[index]}.');
+    }
+  }
+  return (outputDirectory: output, revision: revision);
+}


### PR DESCRIPTION
Add repeatable benchmarks for terminal input throughput and Flutter frame performance. The suite measures streaming and interactive input alongside clean, partial, full-screen, new-glyph, and first-frame rendering under a fixed terminal and font setup, then emits normalized results for comparison across revisions.

Note: I provided the direction and used GPT 5.5 to write the benchmark suite, including its README.