### PR TITLE
fix(libghostty): isolate git when compiling ghostty from source

### DIFF
--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -116,12 +116,16 @@ final class CompileFromSource extends LibraryProvider {
       'zig',
       zigArgs,
       workingDirectory: sourceDir.path,
-      environment: zigCacheDir == null
-          ? null
-          : {
-              'ZIG_GLOBAL_CACHE_DIR': zigCacheDir,
-              'ZIG_LOCAL_CACHE_DIR': zigCacheDir,
-            },
+      environment: {
+        // Keep Ghostty's version detection from walking into the consuming
+        // repository. The absolute parent ceiling still allows a Ghostty
+        // checkout to use its own `.git`.
+        'GIT_CEILING_DIRECTORIES': sourceDir.parent.absolute.path,
+        if (zigCacheDir != null) ...{
+          'ZIG_GLOBAL_CACHE_DIR': zigCacheDir,
+          'ZIG_LOCAL_CACHE_DIR': zigCacheDir,
+        },
+      },
     );
 
     if (result.exitCode != 0) {


### PR DESCRIPTION
## Summary

`source: compile` panics for any consumer whose release tag isn't `vX.Y.Z`,
breaking tagged release builds on every target.

## Root cause

`CompileFromSource` extracts the ghostty source under the consuming app's
directory:

```
<app>/.dart_tool/hooks_runner/shared/libghostty/build/ghostty-source-<hash>/
```

That path is frequently **inside the app's own git repository**. Ghostty's
build (`src/build/Config.zig`) shells out to git to derive its version, and
because the extracted source has no `.git` of its own, the discovery walks up
into the app's repo and reads the **app's** tag.

When the app is checked out on a tag that isn't `vX.Y.Z` — e.g. a CI release
build tagged `myapp-v1.2.3` — `Config.zig` panics:

```
thread panic: tagged releases must be in vX.Y.Z format matching build.zig
  at src/build/Config.zig:278
```

It escapes local dev only because an *untagged* HEAD falls into the
branch/short-hash path. In CI the checkout is on the tag, so every tagged
release build fails — on all four desktop targets.

Proof (run from inside the extracted source):

```
$ git rev-parse --show-toplevel
/path/to/consuming-app            # the app's repo, not ghostty
$ git describe --exact-match --tags HEAD
myapp-v1.2.3                      # the app's tag → panic
```

## Fix

Fence git at the extracted source's parent via `GIT_CEILING_DIRECTORIES`
(which git requires to be absolute) in the environment passed to `zig build`.
The upward walk then stops before reaching the app repo, Ghostty finds no
repository, and falls back to a dev version through the **existing**
`Config.zig` `error.GitNotRepository` path — the intended fallback, not a
workaround.

## Verification

With a `cockpit-v1.15.0` tag on the consumer repo (which otherwise reproduces
the panic), a cold `zig build -Demit-lib-vt=true --release=fast` completes
(`exit 0`) and emits a dylib exporting the expected symbols. `flutter analyze`
is clean.
