### PR TITLE
chore(flterm): prepare v0.0.5 release

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.0.5
+
+### Added
+
+- **Clipboard writes**: `TerminalController.onClipboardWrite` forwards atomic,
+  binary-safe OSC 52 and iTerm2 clipboard requests so applications can apply
+  their own platform and security policies. If the callback throws, the
+  initiating write finishes terminal processing before rethrowing the error.
+- **Idle scrollback compression**: attached terminal views schedule bounded
+  compression after terminal and viewport activity settles, reducing retained
+  scrollback memory without competing with rendering.
+
+### Changed
+
+- **Kitty graphics caching**: unchanged placement snapshots are reused across
+  frames, while image generations invalidate cached images and stale pending
+  decodes. This avoids repeated traversal, sorting, and eviction work without
+  displaying stale image data.
+- **Color behavior**: `ColorPalette.generated()` uses libghostty palette
+  generation, and terminal color-scheme reports use perceived background
+  luminance.
+- **Published package contents**: tests, benchmark tooling, generated API
+  documentation, build outputs, and coverage data are excluded.
+
+### Fixed
+
+- **IME preedit layout**: ZWJ emoji, skin-tone emoji sequences, combining
+  marks, and variation selectors are measured as grapheme clusters using
+  libghostty's terminal width rules.
+- **Viewport scrolling**: scroll-controller pixel offsets map to absolute
+  terminal rows regardless of the current viewport position.
+- **Windows text input**: platform text input binds to the `TerminalView`'s
+  owning Flutter view and reconnects when that view changes.
+
 ## 0.0.4
 
 ### Breaking

--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -37,7 +37,7 @@ libghostty-vt engine.
 
 ```yaml
 dependencies:
-  flterm: ^0.0.4
+  flterm: ^0.0.5
 ```
 
 On web, initialize the wasm module once before mounting any terminal:

--- a/packages/flterm/pubspec.yaml
+++ b/packages/flterm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flterm
 description: Flutter terminal widget on top of Ghostty's libghostty-vt engine.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/elias8/libghostty
 repository: https://github.com/elias8/libghostty/tree/main/packages/flterm
 issue_tracker: https://github.com/elias8/libghostty/issues
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   image: ^4.8.0
-  libghostty: ^0.0.11
+  libghostty: ^0.0.12
   meta: ^1.18.0
 
 dev_dependencies:


### PR DESCRIPTION
Prepare flterm v0.0.5 with clipboard writes, idle scrollback compression, lower overhead Kitty graphics caching, improved color behavior, and fixes for IME layout, viewport scrolling, and Windows text input. This also trims published package contents and updates the libghostty dependency to v0.0.12.