### PR TITLE
fix(flterm): reattach IME when the global text input is stolen

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Dead keys / IME stop working after focus churn**: the text input client
+  tracked attachment by connection non-nullness, but Flutter's `TextInput` is a
+  process-wide singleton — another pane, text field, or the composer stealing
+  the global connection silently orphaned this client without a
+  `connectionClosed` callback. Composition keys were then forwarded to a dead
+  connection and accents (dead key + vowel) stopped reaching the IME. The
+  client now consults `TextInputConnection.attached` and reopens an orphaned
+  connection on the next attach.
+
 ## 0.0.4
 
 ### Breaking

--- a/packages/flterm/lib/src/widgets/terminal_input_client.dart
+++ b/packages/flterm/lib/src/widgets/terminal_input_client.dart
@@ -44,12 +44,24 @@ final class TerminalInputClient with DeltaTextInputClient {
   /// preedit text should be rendered.
   bool get hasActiveComposition => _value.hasTerminalComposingRange;
 
-  bool get isAttached => _connection != null;
+  /// Whether this client still owns the global platform text input.
+  ///
+  /// [TextInput] is a process-wide singleton: when any other client (another
+  /// terminal pane, an app text field, the composer) calls [TextInput.attach],
+  /// the global connection switches to it and this client is *not* told via
+  /// [connectionClosed] — that only reaches the current client. Our
+  /// [_connection] therefore stays non-null while silently orphaned, so we must
+  /// consult [TextInputConnection.attached] (the authoritative
+  /// `_currentConnection == this`) rather than mere non-nullness.
+  bool get isAttached => _connection?.attached ?? false;
 
   set keyboardAppearance(Brightness value) {
     if (_keyboardAppearance == value) return;
     _keyboardAppearance = value;
-    _connection?.updateConfig(_configuration);
+    final connection = _connection;
+    if (connection != null && connection.attached) {
+      connection.updateConfig(_configuration);
+    }
   }
 
   set onDelete(ValueChanged<int>? callback) => _onDelete = callback;
@@ -124,7 +136,9 @@ final class TerminalInputClient with DeltaTextInputClient {
   void ensureAttached({Brightness keyboardAppearance = Brightness.dark}) {
     _keyboardAppearance = keyboardAppearance;
     final connection = _connection;
-    if (connection == null) return _openConnection();
+    // Reopen when the connection is gone *or* orphaned by another client's
+    // attach; updating a detached connection is a no-op (and asserts in debug).
+    if (connection == null || !connection.attached) return _openConnection();
     connection.updateConfig(_configuration);
   }
 
@@ -209,7 +223,7 @@ final class TerminalInputClient with DeltaTextInputClient {
     required Rect composingRect,
   }) {
     final connection = _connection;
-    if (connection == null) return;
+    if (connection == null || !connection.attached) return;
     connection
       ..setEditableSizeAndTransform(editableSize, transform)
       ..setCaretRect(caretRect)
@@ -359,7 +373,10 @@ final class TerminalInputClient with DeltaTextInputClient {
 
   void _resetBuffer() {
     _value = _sentinel;
-    _connection?.setEditingState(_value);
+    final connection = _connection;
+    if (connection != null && connection.attached) {
+      connection.setEditingState(_value);
+    }
   }
 
   void _resetInputState() {

--- a/packages/flterm/test/widgets/terminal_input_client_test.dart
+++ b/packages/flterm/test/widgets/terminal_input_client_test.dart
@@ -810,6 +810,25 @@ void main() {
 
         expect(textInputSetClientCalls(calls), hasLength(1));
       });
+
+      test('reopens a connection orphaned by another client', () {
+        handler.attach();
+        expect(handler.isAttached, isTrue);
+
+        // Another client stealing the global TextInput singleton orphans us
+        // without a connectionClosed() callback.
+        final other = TerminalInputClient()..viewId = 0;
+        addTearDown(other.detach);
+        other.attach();
+
+        expect(handler.isAttached, isFalse);
+
+        final calls = recordTextInputCalls();
+        handler.ensureAttached();
+
+        expect(textInputSetClientCalls(calls), hasLength(1));
+        expect(handler.isAttached, isTrue);
+      });
     });
 
     group('viewId', () {


### PR DESCRIPTION
## Summary

After some focus churn, a terminal pane permanently stops accepting **dead
keys / accents** (e.g. `´` + vowel) on macOS, while plain keys keep working.
Accents only travel through the platform IME, so once the IME path breaks the
pane can no longer compose.

## Root cause

Flutter's `TextInput` is a **process-wide singleton**. When any other client
(another terminal pane, an app `TextField`, the agent composer) calls
`TextInput.attach`, the global connection switches to it and this client is
**not** notified — `connectionClosed()` is only delivered to the *current*
client (`text_input.dart`). Our `_connection` therefore stays non-null while
silently orphaned; `TextInputConnection.attached` (`_currentConnection == this`)
flips to false but was never consulted.

Because `isAttached` was `_connection != null`, it lied `true` for an orphaned
connection:

- `_shouldForwardCompositionKeyToTextInput` kept forwarding composition keys to
  the dead IME, so the dead key never reached a live connection.
- `ensureAttached()` saw non-null and only ran `updateConfig` on the dead
  connection — a no-op (and an `assert(attached)` failure in debug) — instead of
  reopening.

Net effect: the pane never reattaches and accents vanish permanently there.

## Fix

Consult `TextInputConnection.attached` instead of mere non-nullness:

- `isAttached => _connection?.attached ?? false`
- `ensureAttached()` reopens when the connection is `null` **or** detached
- `keyboardAppearance`, `updateGeometry`, and `_resetBuffer` skip a detached
  connection instead of asserting on it

Reattachment then happens naturally through the existing `ensureAttached` calls
on focus/keyboard-state changes.

## Repro

Type `´a` in a Ghostty pane (works), click another pane or an app text field,
come back and try `´a` again — fails from then on without the fix.

## Tests

Adds a regression test: a second client attaching orphans the first, after
which `isAttached` is `false` and `ensureAttached()` reopens the connection.
`flutter analyze` clean; full flterm suite passes (648 tests).
