### PR TITLE
fix(flterm): reconnect displaced text input clients

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Text input recovery**: terminal clients reconnect when another input client
+  takes the platform text input connection, including while composition is
+  active.
+
 ## 0.0.5
 
 ### Added

--- a/packages/flterm/lib/src/widgets/terminal_input_client.dart
+++ b/packages/flterm/lib/src/widgets/terminal_input_client.dart
@@ -44,12 +44,20 @@ final class TerminalInputClient with DeltaTextInputClient {
   /// preedit text should be rendered.
   bool get hasActiveComposition => _value.hasTerminalComposingRange;
 
-  bool get isAttached => _connection != null;
+  /// Whether this client owns the platform text input connection.
+  ///
+  /// Text input accepts one client at a time. Another client can replace this
+  /// connection without invoking [connectionClosed], so non-nullness alone
+  /// does not prove ownership.
+  bool get isAttached => _connection?.attached ?? false;
 
   set keyboardAppearance(Brightness value) {
     if (_keyboardAppearance == value) return;
     _keyboardAppearance = value;
-    _connection?.updateConfig(_configuration);
+    final connection = _connection;
+    if (connection != null && connection.attached) {
+      connection.updateConfig(_configuration);
+    }
   }
 
   set onDelete(ValueChanged<int>? callback) => _onDelete = callback;
@@ -125,6 +133,10 @@ final class TerminalInputClient with DeltaTextInputClient {
     _keyboardAppearance = keyboardAppearance;
     final connection = _connection;
     if (connection == null) return _openConnection();
+    if (!connection.attached) {
+      _closeConnection();
+      return _openConnection();
+    }
     connection.updateConfig(_configuration);
   }
 
@@ -209,7 +221,7 @@ final class TerminalInputClient with DeltaTextInputClient {
     required Rect composingRect,
   }) {
     final connection = _connection;
-    if (connection == null) return;
+    if (connection == null || !connection.attached) return;
     connection
       ..setEditableSizeAndTransform(editableSize, transform)
       ..setCaretRect(caretRect)
@@ -359,7 +371,10 @@ final class TerminalInputClient with DeltaTextInputClient {
 
   void _resetBuffer() {
     _value = _sentinel;
-    _connection?.setEditingState(_value);
+    final connection = _connection;
+    if (connection != null && connection.attached) {
+      connection.setEditingState(_value);
+    }
   }
 
   void _resetInputState() {

--- a/packages/flterm/test/widgets/terminal_input_client_test.dart
+++ b/packages/flterm/test/widgets/terminal_input_client_test.dart
@@ -810,6 +810,40 @@ void main() {
 
         expect(textInputSetClientCalls(calls), hasLength(1));
       });
+
+      test('reopens a connection orphaned by another client', () {
+        final calls = recordTextInputCalls();
+        handler.attach();
+        final other = TerminalInputClient()..viewId = 0;
+        addTearDown(other.detach);
+        other.attach();
+        calls.clear();
+
+        handler.ensureAttached();
+
+        expect(textInputSetClientCalls(calls), hasLength(1));
+      });
+
+      test('clears visible preedit when reopening an orphaned connection', () {
+        final preedit = <String>[];
+        handler.onPreeditChanged = preedit.add;
+        handler.attach();
+        handler.updateEditingValue(
+          const TextEditingValue(
+            text: ' ni',
+            selection: TextSelection.collapsed(offset: 3),
+            composing: TextRange(start: 1, end: 3),
+          ),
+        );
+        final other = TerminalInputClient()..viewId = 0;
+        addTearDown(other.detach);
+        other.attach();
+        preedit.clear();
+
+        handler.ensureAttached();
+
+        expect(preedit, ['']);
+      });
     });
 
     group('viewId', () {


### PR DESCRIPTION
Reconnect terminal text input when another client takes ownership of the platform connection, and clear any active preedit state before reopening it. This keeps IME input recoverable without sending updates through an orphaned connection.

Replaces #124