### PR TITLE
feat(flterm): expose terminal options and callbacks

### DIFF
--- a/packages/flterm/lib/flterm.dart
+++ b/packages/flterm/lib/flterm.dart
@@ -13,6 +13,7 @@ export 'package:libghostty/libghostty.dart'
         ClipboardWriteCallback,
         ClipboardWriteResult,
         CursorShape,
+        DesktopNotification,
         DeviceAttributesResponse,
         Formatter,
         FormatterExtra,

--- a/packages/flterm/lib/flterm.dart
+++ b/packages/flterm/lib/flterm.dart
@@ -27,6 +27,8 @@ export 'package:libghostty/libghostty.dart'
         SelectionGestureBehavior,
         SelectionGestureBehaviors,
         TerminalMode,
+        TerminalProgress,
+        TerminalProgressState,
         TerminalScreen,
         UnderlineStyle,
         initializeForWeb;

--- a/packages/flterm/lib/src/foundation/terminal_config.dart
+++ b/packages/flterm/lib/src/foundation/terminal_config.dart
@@ -32,7 +32,7 @@ enum ScrollToBottom {
 /// ```dart
 /// final controller = TerminalController(
 ///   config: TerminalConfig(
-///     scrollbackLimit: 5_000_000,
+///     scrollbackMaxBytes: 5_000_000,
 ///     cursorBlink: true,
 ///     modes: {
 ///       ...TerminalConfig.defaultModes,
@@ -81,9 +81,17 @@ class TerminalConfig {
 
   /// Maximum scrollback buffer size in bytes.
   ///
-  /// Defaults to 10,000,000 bytes. Set to 0 to disable scrollback entirely.
-  /// The terminal discards the oldest lines when this limit is reached.
-  final int scrollbackLimit;
+  /// Defaults to 10,000 bytes. Set to null for no limit, or 0 to disable
+  /// scrollback. When this and [scrollbackMaxLines] are set, the oldest
+  /// complete pages are discarded when either limit is reached.
+  final int? scrollbackMaxBytes;
+
+  /// Maximum number of physical scrollback rows.
+  ///
+  /// Defaults to no limit. At least one normal page is retained. When this
+  /// and [scrollbackMaxBytes] are set, the oldest complete pages are
+  /// discarded when either limit is reached.
+  final int? scrollbackMaxLines;
 
   /// Maximum bytes of Kitty graphics image storage.
   ///
@@ -152,14 +160,22 @@ class TerminalConfig {
     this.enquiryResponse = '',
     this.modes = defaultModes,
     this.cursorStyle = .block,
-    this.scrollbackLimit = 10_000_000,
+    this.scrollbackMaxBytes = 10_000,
+    this.scrollbackMaxLines,
     this.kittyImageStorageLimit = 64 * 1024 * 1024,
     this.selectionClearOnTyping = true,
     this.scrollToBottom = .onKeystroke,
     this.deviceAttributes = const DeviceAttributesResponse(),
   }) : assert(cols > 0, 'cols must be positive'),
        assert(rows > 0, 'rows must be positive'),
-       assert(scrollbackLimit >= 0, 'scrollbackLimit must be non-negative'),
+       assert(
+         scrollbackMaxBytes == null || scrollbackMaxBytes >= 0,
+         'scrollbackMaxBytes must be non-negative',
+       ),
+       assert(
+         scrollbackMaxLines == null || scrollbackMaxLines >= 0,
+         'scrollbackMaxLines must be non-negative',
+       ),
        assert(
          kittyImageStorageLimit >= 0,
          'kittyImageStorageLimit must be non-negative',
@@ -170,7 +186,8 @@ class TerminalConfig {
   int get hashCode => Object.hash(
     cols,
     rows,
-    scrollbackLimit,
+    scrollbackMaxBytes,
+    scrollbackMaxLines,
     kittyImageStorageLimit,
     apcBufferLimit,
     glyphProtocol,
@@ -189,7 +206,8 @@ class TerminalConfig {
       other is TerminalConfig &&
           cols == other.cols &&
           rows == other.rows &&
-          scrollbackLimit == other.scrollbackLimit &&
+          scrollbackMaxBytes == other.scrollbackMaxBytes &&
+          scrollbackMaxLines == other.scrollbackMaxLines &&
           kittyImageStorageLimit == other.kittyImageStorageLimit &&
           apcBufferLimit == other.apcBufferLimit &&
           glyphProtocol == other.glyphProtocol &&
@@ -205,7 +223,8 @@ class TerminalConfig {
   TerminalConfig copyWith({
     int? cols,
     int? rows,
-    int? scrollbackLimit,
+    int? scrollbackMaxBytes,
+    int? scrollbackMaxLines,
     int? kittyImageStorageLimit,
     int? apcBufferLimit,
     bool? glyphProtocol,
@@ -220,7 +239,8 @@ class TerminalConfig {
     return TerminalConfig(
       cols: cols ?? this.cols,
       rows: rows ?? this.rows,
-      scrollbackLimit: scrollbackLimit ?? this.scrollbackLimit,
+      scrollbackMaxBytes: scrollbackMaxBytes ?? this.scrollbackMaxBytes,
+      scrollbackMaxLines: scrollbackMaxLines ?? this.scrollbackMaxLines,
       kittyImageStorageLimit:
           kittyImageStorageLimit ?? this.kittyImageStorageLimit,
       apcBufferLimit: apcBufferLimit ?? this.apcBufferLimit,
@@ -240,7 +260,8 @@ class TerminalConfig {
   String toString() =>
       'TerminalConfig('
       'cols: $cols, rows: $rows, '
-      'scrollbackLimit: $scrollbackLimit, '
+      'scrollbackMaxBytes: $scrollbackMaxBytes, '
+      'scrollbackMaxLines: $scrollbackMaxLines, '
       'modes: ${modes.length} entries)';
 
   static bool _modesEqual(

--- a/packages/flterm/lib/src/widgets/terminal_controller.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller.dart
@@ -48,6 +48,13 @@ abstract class TerminalController extends ChangeNotifier
   /// display them. Fires synchronously during [write].
   set onDesktopNotification(ValueChanged<DesktopNotification>? callback);
 
+  /// Sets the callback for program progress reported through OSC 9;4, or
+  /// clears it if null.
+  ///
+  /// The application decides how to present progress. Fires synchronously
+  /// during [write].
+  set onProgressReport(ValueChanged<TerminalProgress>? callback);
+
   /// Called when the grid dimensions change. Forward to your backend.
   OnResize? onResize;
 

--- a/packages/flterm/lib/src/widgets/terminal_controller.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller.dart
@@ -41,6 +41,13 @@ abstract class TerminalController extends ChangeNotifier
   /// Called when the working directory changes. Read [pwd] for the value.
   VoidCallback? onPwdChanged;
 
+  /// Sets the callback for desktop notifications requested through OSC 9 or
+  /// OSC 777, or clears it if null.
+  ///
+  /// Requests are untrusted. The application decides whether and how to
+  /// display them. Fires synchronously during [write].
+  set onDesktopNotification(ValueChanged<DesktopNotification>? callback);
+
   /// Called when the grid dimensions change. Forward to your backend.
   OnResize? onResize;
 

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -153,6 +153,10 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
+  set onDesktopNotification(ValueChanged<DesktopNotification>? value) =>
+      terminal.onDesktopNotification = value;
+
+  @override
   String get preeditText => _preeditText;
 
   @override

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -654,6 +654,8 @@ class TerminalControllerImpl extends TerminalController
   }
 
   void _applyTerminalOptions() {
+    terminal.scrollbackMaxBytes = _config.scrollbackMaxBytes;
+    terminal.scrollbackMaxLines = _config.scrollbackMaxLines;
     terminal.kittyImageStorageLimit = _config.kittyImageStorageLimit;
     terminal.setApcBufferLimit(_config.apcBufferLimit);
     terminal.setGlyphProtocol(enabled: _config.glyphProtocol);

--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -157,6 +157,10 @@ class TerminalControllerImpl extends TerminalController
       terminal.onDesktopNotification = value;
 
   @override
+  set onProgressReport(ValueChanged<TerminalProgress>? value) =>
+      terminal.onProgressReport = value;
+
+  @override
   String get preeditText => _preeditText;
 
   @override

--- a/packages/flterm/test/foundation/terminal_config_test.dart
+++ b/packages/flterm/test/foundation/terminal_config_test.dart
@@ -10,7 +10,8 @@ void main() {
 
         expect(config.cols, 80);
         expect(config.rows, 24);
-        expect(config.scrollbackLimit, 10000000);
+        expect(config.scrollbackMaxBytes, 10000);
+        expect(config.scrollbackMaxLines, isNull);
         expect(config.cursorStyle, CursorShape.block);
         expect(config.cursorBlink, isNull);
         expect(config.glyphProtocol, isFalse);
@@ -53,23 +54,27 @@ void main() {
         const original = TerminalConfig(
           cols: 120,
           rows: 40,
-          scrollbackLimit: 50000,
+          scrollbackMaxBytes: 50000,
+          scrollbackMaxLines: 500,
         );
         final copy = original.copyWith(cols: 80);
 
         expect(copy.cols, 80);
         expect(copy.rows, 40);
-        expect(copy.scrollbackLimit, 50000);
+        expect(copy.scrollbackMaxBytes, 50000);
+        expect(copy.scrollbackMaxLines, 500);
 
         const config = TerminalConfig();
         final updated = config.copyWith(
-          scrollbackLimit: 99999,
+          scrollbackMaxBytes: 99999,
+          scrollbackMaxLines: 999,
           apcBufferLimit: 1024,
           glyphProtocol: true,
           cursorBlink: false,
         );
 
-        expect(updated.scrollbackLimit, 99999);
+        expect(updated.scrollbackMaxBytes, 99999);
+        expect(updated.scrollbackMaxLines, 999);
         expect(updated.apcBufferLimit, 1024);
         expect(updated.glyphProtocol, isTrue);
         expect(updated.cursorBlink, isFalse);
@@ -110,6 +115,11 @@ void main() {
 
         const glyphProtocol = TerminalConfig(glyphProtocol: true);
         expect(a, isNot(equals(glyphProtocol)));
+
+        const byteLimited = TerminalConfig(scrollbackMaxBytes: 1024);
+        const lineLimited = TerminalConfig(scrollbackMaxLines: 1024);
+        expect(a, isNot(equals(byteLimited)));
+        expect(a, isNot(equals(lineLimited)));
       });
 
       test('ignores map order', () {

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -198,6 +198,17 @@ void main() {
       });
     });
 
+    group('onDesktopNotification', () {
+      test('forwards OSC 9 notifications', () {
+        DesktopNotification? notification;
+        controller.onDesktopNotification = (value) => notification = value;
+
+        writeControllerUtf8(controller, '\x1b]9;Build finished\x07');
+
+        expect(notification, (title: '', body: 'Build finished'));
+      });
+    });
+
     group('selection', () {
       test('selectRange notifies listeners and installs selection', () {
         var notified = false;

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -774,31 +774,13 @@ void main() {
         expect(controller.config.cols, 120);
       });
 
-      test('initial config applies APC size limits', () {
+      test('initial config applies terminal options', () {
         final custom = TerminalControllerImpl(
           config: const TerminalConfig(
+            scrollbackMaxBytes: 1024,
+            scrollbackMaxLines: 10,
             kittyImageStorageLimit: 1 << 20,
             apcBufferLimit: 1,
-          ),
-        );
-        addTearDown(custom.dispose);
-
-        custom.write(transmitRedPixel(id: 91));
-
-        expect(KittyGraphics.of(custom.terminal)!.image(91), isNull);
-      });
-
-      test('setter applies APC buffer limits', () {
-        controller.config = const TerminalConfig(apcBufferLimit: 1);
-
-        controller.write(transmitRedPixel(id: 92));
-
-        expect(KittyGraphics.of(controller.terminal)!.image(92), isNull);
-      });
-
-      test('initial config applies cursor reset defaults', () {
-        final custom = TerminalControllerImpl(
-          config: const TerminalConfig(
             cursorStyle: CursorShape.underline,
             cursorBlink: true,
           ),
@@ -807,11 +789,36 @@ void main() {
         addTearDown(custom.dispose);
         addTearDown(renderState.dispose);
 
+        expect(custom.terminal.scrollbackMaxBytes, 1024);
+        expect(custom.terminal.scrollbackMaxLines, 10);
+
+        custom.write(transmitRedPixel(id: 91));
+
+        expect(KittyGraphics.of(custom.terminal)!.image(91), isNull);
+
         writeTerminalUtf8(custom.terminal, '\x1b[0 q');
         renderState.update(custom.terminal);
 
         expect(renderState.cursor.shape, CursorShape.underline);
         expect(renderState.cursor.blinking, isTrue);
+      });
+
+      test('setter applies scrollback limits', () {
+        controller.config = const TerminalConfig(
+          scrollbackMaxBytes: 2048,
+          scrollbackMaxLines: 20,
+        );
+
+        expect(controller.terminal.scrollbackMaxBytes, 2048);
+        expect(controller.terminal.scrollbackMaxLines, 20);
+      });
+
+      test('setter applies APC buffer limits', () {
+        controller.config = const TerminalConfig(apcBufferLimit: 1);
+
+        controller.write(transmitRedPixel(id: 92));
+
+        expect(KittyGraphics.of(controller.terminal)!.image(92), isNull);
       });
 
       test('setter applies cursor reset defaults', () {

--- a/packages/flterm/test/widgets/terminal_controller_test.dart
+++ b/packages/flterm/test/widgets/terminal_controller_test.dart
@@ -209,6 +209,17 @@ void main() {
       });
     });
 
+    group('onProgressReport', () {
+      test('forwards determinate OSC 9;4 reports', () {
+        TerminalProgress? report;
+        controller.onProgressReport = (value) => report = value;
+
+        writeControllerUtf8(controller, '\x1b]9;4;1;42\x07');
+
+        expect(report, (state: TerminalProgressState.set, progress: 42));
+      });
+    });
+
     group('selection', () {
       test('selectRange notifies listeners and installs selection', () {
         var notified = false;

--- a/packages/flterm/tool/benchmarks/input_benchmark.dart
+++ b/packages/flterm/tool/benchmarks/input_benchmark.dart
@@ -95,7 +95,7 @@ BenchmarkWorkloadResult _measureWrites({
   required List<Uint8List> chunks,
 }) {
   final controller = TerminalController(
-    config: const TerminalConfig(scrollbackLimit: 0),
+    config: const TerminalConfig(scrollbackMaxBytes: 0),
   );
   try {
     return measureBenchmark(


### PR DESCRIPTION
Forward libghostty's scrollback limits, desktop notifications, and progress reports through flterm. Replace the single scrollback limit with separate byte and line limits, expose the new callback types through the package API, and apply the configured options when terminals are created or reconfigured.