### PR TITLE
fix(libghostty): compile ghostty for the CPU baseline, not native

### DIFF
--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -108,7 +108,15 @@ final class CompileFromSource extends LibraryProvider {
       Directory.fromUri(installDir).path,
       '--release=fast',
       if (zigCacheDir != null) ...['--global-cache-dir', zigCacheDir],
-      if (os != .current || arch != .current) '-Dtarget=$zig',
+      // Always pass an explicit target, even for a native build. Without
+      // `-Dtarget`, Zig defaults the CPU model to `native` and tunes the
+      // binary for the build machine (e.g. AVX2/AVX-512 on a CI runner),
+      // which then crashes with an illegal instruction (0xC000001D) on
+      // consumer CPUs lacking those extensions. An explicit target resolves
+      // to the arch's baseline CPU instead. This mirrors the upstream release
+      // workflow (.github/workflows/build.yml), which passes `-Dtarget` for
+      // every artifact, including native ones.
+      '-Dtarget=$zig',
       if (ios == .iPhoneSimulator && arch == .arm64) '-Dcpu=apple_a17',
     ];
 

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -108,14 +108,8 @@ final class CompileFromSource extends LibraryProvider {
       Directory.fromUri(installDir).path,
       '--release=fast',
       if (zigCacheDir != null) ...['--global-cache-dir', zigCacheDir],
-      // Always pass an explicit target, even for a native build. Without
-      // `-Dtarget`, Zig defaults the CPU model to `native` and tunes the
-      // binary for the build machine (e.g. AVX2/AVX-512 on a CI runner),
-      // which then crashes with an illegal instruction (0xC000001D) on
-      // consumer CPUs lacking those extensions. An explicit target resolves
-      // to the arch's baseline CPU instead. This mirrors the upstream release
-      // workflow (.github/workflows/build.yml), which passes `-Dtarget` for
-      // every artifact, including native ones.
+      // Pass -Dtarget so source-compiled libraries use the target CPU baseline
+      // instead of the build machine's CPU.
       '-Dtarget=$zig',
       if (ios == .iPhoneSimulator && arch == .arm64) '-Dcpu=apple_a17',
     ];


### PR DESCRIPTION
## Summary

`source: compile` produces a library tuned for the **build machine's CPU**, so
a binary compiled on a modern CI runner crashes with an illegal instruction
(`0xC000001D`) on consumer CPUs lacking AVX2/AVX-512. On Windows this shows up
as the app "flashing and closing" with no log on some machines.

## Root cause

`CompileFromSource._compile` passes `-Dtarget` to `zig build` **only when
cross-compiling**:

```dart
if (os != .current || arch != .current) '-Dtarget=$zig',
```

For a native build the flag is omitted, so Zig defaults the CPU model to
`native` and tunes `ghostty-vt` for the build host (AVX2/AVX-512 on a typical
CI runner). Local dev builds escape it because `native` == the developer's CPU.

Notably, the **release workflow already does the right thing**:
`.github/workflows/build.yml` (job `build-native`) runs

```
zig build -Demit-lib-vt=true --release=fast -Dtarget=${{ matrix.target }} ${{ matrix.extra_args }}
```

passing `-Dtarget` for **every** artifact, including the native ones. That is
why the prebuilt releases run on older CPUs while the compile hook's native
path does not.

## Fix

Pass `-Dtarget=$zig` unconditionally. An explicit target resolves to the arch's
baseline CPU instead of `native`, matching the release workflow.

## Verification

A native `zig build -Dtarget=aarch64-macos -Demit-lib-vt=true --release=fast`
still builds the dylib successfully (`exit 0`). `flutter analyze` is clean.
