### PR TITLE
fix(libghostty): set iOS deployment target to version 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,11 @@ jobs:
             runner: macos-15
             ext: dylib
           - target: aarch64-ios
+            build_target: aarch64-ios.13.0
             runner: macos-15
             ext: dylib
           - target: aarch64-ios-simulator
+            build_target: aarch64-ios.13.0-simulator
             runner: macos-15
             ext: dylib
             extra_args: -Dcpu=apple_a17
@@ -137,7 +139,7 @@ jobs:
           rm ghostty.tar.gz
       - name: compile
         working-directory: ghostty-src
-        run: zig build -Demit-lib-vt=true --release=fast -Dtarget=${{ matrix.target }} ${{ matrix.extra_args }}
+        run: zig build -Demit-lib-vt=true --release=fast -Dtarget=${{ matrix.build_target || matrix.target }} ${{ matrix.extra_args }}
       - name: prepare artifact
         id: artifact
         run: |

--- a/packages/libghostty/lib/src/hook/library_provider.dart
+++ b/packages/libghostty/lib/src/hook/library_provider.dart
@@ -95,10 +95,11 @@ final class CompileFromSource extends LibraryProvider {
   Future<void> _compile(Directory sourceDir, File target) async {
     final os = input.config.code.targetOS;
     final arch = input.config.code.targetArchitecture;
-    final ios = os == OS.iOS ? input.config.code.iOS.targetSdk : null;
+    final ios = os == .iOS ? input.config.code.iOS.targetSdk : null;
+    final iOSVersion = os == .iOS ? input.config.code.iOS.targetVersion : null;
 
     final installDir = target.parent.parent.uri;
-    final zig = zigTarget(os, arch, iOSSdk: ios);
+    final zig = zigTarget(os, arch, iOSSdk: ios, iOSVersion: iOSVersion);
     final zigCacheDir = os == .windows ? _zigCacheDir(sourceDir) : null;
 
     final zigArgs = [

--- a/packages/libghostty/lib/src/hook/zig_target.dart
+++ b/packages/libghostty/lib/src/hook/zig_target.dart
@@ -1,7 +1,12 @@
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 
-String? zigTarget(OS targetOS, Architecture targetArch, {IOSSdk? iOSSdk}) {
+String? zigTarget(
+  OS targetOS,
+  Architecture targetArch, {
+  IOSSdk? iOSSdk,
+  int? iOSVersion,
+}) {
   final archStr = switch (targetArch) {
     Architecture.x64 => 'x86_64',
     Architecture.arm64 => 'aarch64',
@@ -14,7 +19,11 @@ String? zigTarget(OS targetOS, Architecture targetArch, {IOSSdk? iOSSdk}) {
     OS.macOS => 'macos',
     OS.linux => 'linux-gnu',
     OS.windows => 'windows',
-    OS.iOS => iOSSdk == IOSSdk.iPhoneSimulator ? 'ios-simulator' : 'ios',
+    OS.iOS => switch (iOSSdk) {
+      .iPhoneSimulator =>
+        'ios${iOSVersion == null ? '' : '.$iOSVersion.0'}-simulator',
+      _ => 'ios${iOSVersion == null ? '' : '.$iOSVersion.0'}',
+    },
     OS.android => switch (targetArch) {
       Architecture.arm64 => 'linux-android',
       Architecture.x64 => 'linux-android',

--- a/packages/libghostty/test/zig_target_test.dart
+++ b/packages/libghostty/test/zig_target_test.dart
@@ -23,6 +23,28 @@ void main() {
           'x86_64-ios-simulator',
         );
       });
+
+      test('includes the device deployment version', () {
+        final target = zigTarget(
+          OS.iOS,
+          Architecture.arm64,
+          iOSSdk: IOSSdk.iPhoneOS,
+          iOSVersion: 13,
+        );
+
+        expect(target, 'aarch64-ios.13.0');
+      });
+
+      test('includes the simulator deployment version', () {
+        final target = zigTarget(
+          OS.iOS,
+          Architecture.arm64,
+          iOSSdk: IOSSdk.iPhoneSimulator,
+          iOSVersion: 13,
+        );
+
+        expect(target, 'aarch64-ios.13.0-simulator');
+      });
     });
 
     group('Android', () {


### PR DESCRIPTION
Pass the iOS deployment version into Zig targets for source builds and CI artifacts, producing aarch64-ios.13.0 and aarch64-ios.13.0-simulator for the iOS 13 minimum. This keeps the binary load command aligned with the framework's MinimumOSVersion.

Resolves #127