### PR TITLE
fix(flterm): avoid selection notifications during build

### DIFF
--- a/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/widgets/terminal_controller_impl.dart
@@ -235,11 +235,7 @@ class TerminalControllerImpl extends TerminalController
   }
 
   @override
-  void clearSelection() {
-    if (terminal.selection == null) return;
-    _selectionGesture.reset();
-    _setSelection(null, clearIfNull: true);
-  }
+  void clearSelection() => _clearSelection(notify: true);
 
   @override
   void clearVirtualMods() {
@@ -490,6 +486,9 @@ class TerminalControllerImpl extends TerminalController
   void hideKeyboard() => _updateKeyboardState(.hidden);
 
   @override
+  void invalidateSelection() => _clearSelection(notify: false);
+
+  @override
   bool modeGet(TerminalMode mode) => terminal.modeGet(mode);
 
   @override
@@ -683,6 +682,13 @@ class TerminalControllerImpl extends TerminalController
       row: _clampInt(position.row, 0, _lastRows - 1),
       col: _clampInt(position.col, 0, _lastCols - 1),
     );
+  }
+
+  void _clearSelection({required bool notify}) {
+    if (terminal.selection == null) return;
+    _selectionGesture.reset();
+    _mutateSelection(() => terminal.selection = null);
+    if (notify) super.notifyListeners();
   }
 
   bool _consumeCommittedCompositionEditKey(

--- a/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
+++ b/packages/flterm/lib/src/widgets/terminal_gesture_detector.dart
@@ -82,7 +82,7 @@ class _TerminalGestureDetectorState extends State<TerminalGestureDetector> {
     super.didUpdateWidget(oldWidget);
     if (widget.metrics != oldWidget.metrics ||
         widget.binding != oldWidget.binding) {
-      _binding.clearSelection();
+      _binding.invalidateSelection();
       _stopAutoScroll();
       _drag = null;
       _pressCell = null;

--- a/packages/flterm/lib/src/widgets/terminal_view_binding.dart
+++ b/packages/flterm/lib/src/widgets/terminal_view_binding.dart
@@ -86,6 +86,9 @@ abstract interface class TerminalViewBinding {
   /// listeners and may change [Terminal.compressionActivity].
   void handleViewportChanged();
 
+  /// Invalidates the current selection without publishing a controller change.
+  void invalidateSelection();
+
   /// Requests keyboard focus for the attached view.
   void requestFocus();
 


### PR DESCRIPTION
Invalidate selection during widget updates without notifying listeners, preventing `setState` calls during build while keeping explicit selection clearing observable through the controller API.

Resolves #136