### PR TITLE
fix(flterm): recover text input when a delta desyncs from the sentinel

### DIFF
--- a/packages/flterm/lib/src/input/keyboard_input_adapter.dart
+++ b/packages/flterm/lib/src/input/keyboard_input_adapter.dart
@@ -25,6 +25,9 @@ final class KeyboardInputAdapter extends ChangeNotifier {
   static const _delete = 0x7f;
   static const _macFunctionKeyStart = 0xF700;
   static const _macFunctionKeyEnd = 0xF8FF;
+  static const _spacingAcute = 0x00B4;
+  static const _combiningStart = 0x0300;
+  static const _combiningEnd = 0x036F;
 
   final TerminalControllerImpl _controller;
   final _textInput = TextInputSession();
@@ -144,6 +147,8 @@ final class KeyboardInputAdapter extends ChangeNotifier {
       unshiftedCodepoint: unshiftedCodepoint,
     );
 
+    if (_shouldIgnoreDeadKey(input)) return .ignored;
+
     if (_shouldForwardCompositionKey(input)) return .skipRemainingHandlers;
 
     final disposition = _controller.handleTerminalKey(
@@ -196,6 +201,39 @@ final class KeyboardInputAdapter extends ChangeNotifier {
     _preeditText = value;
     _controller.handleTextCompositionChanged(active: value.isNotEmpty);
     notifyListeners();
+  }
+
+  /// Whether a printable key press is a dead key that the IME must compose.
+  ///
+  /// A dead key (acute, grave, tilde) fires a key-down for a printable key
+  /// before the platform has composed a character, so [KeyInput.character] is
+  /// null (some embedders instead deliver the bare accent, U+00B4 or a
+  /// combining diacritic). Under the Kitty keyboard protocol the encoder would
+  /// otherwise turn that press into an escape sequence and send it to the PTY,
+  /// stealing the accent from composition. Returning it as ignored leaves the
+  /// event for the text-input path so the accented character composes normally.
+  ///
+  /// Only unmodified presses of printable keys qualify: Enter, Tab, arrows and
+  /// other non-character keys report a zero unshifted codepoint, and any
+  /// Ctrl/Alt/Super combination (or an active virtual modifier) is a real
+  /// terminal chord that must still be encoded.
+  bool _shouldIgnoreDeadKey(KeyInput input) {
+    if (!_isDesktopPlatform) return false;
+    if (input.action != .press && input.action != .repeat) return false;
+    if (input.unshiftedCodepoint <= 0) return false;
+    if (!_controller.virtualMods.isEmpty) return false;
+    final mods = input.mods;
+    if (mods.hasCtrl || mods.hasAlt || mods.hasSuper) return false;
+    return _isDeadKeyCharacter(input.character);
+  }
+
+  bool _isDeadKeyCharacter(String? character) {
+    if (character == null) return true;
+    final runes = character.runes;
+    if (runes.length != 1) return false;
+    final rune = runes.first;
+    return rune == _spacingAcute ||
+        (rune >= _combiningStart && rune <= _combiningEnd);
   }
 
   bool _shouldForwardCompositionKey(KeyInput input) {

--- a/packages/flterm/lib/src/input/text_input_session.dart
+++ b/packages/flterm/lib/src/input/text_input_session.dart
@@ -201,7 +201,20 @@ final class TextInputSession with DeltaTextInputClient {
         _committedCompositionEdit == .suppressNextDeletionDelta;
     var fromCompositionInBatch = _hadVisiblePreeditText || hasActiveComposition;
     for (final delta in deltas) {
-      _value = delta.apply(_value);
+      final TextEditingValue next;
+      try {
+        next = delta.apply(_value);
+      } on Object {
+        // Some platforms (notably iOS) keep their own marked-text buffer and
+        // ignore the sentinel we push via setEditingState after each commit.
+        // A later delta then references offsets past our sentinel value, so
+        // applying it throws. Left uncaught, that kills the text-input channel
+        // and freezes all further typing (e.g. after composing an accent).
+        // Resync the platform back to the sentinel and drop this batch instead.
+        _recoverFromDesync();
+        return;
+      }
+      _value = next;
       _processDelta(delta, fromCompositionInBatch: fromCompositionInBatch);
       fromCompositionInBatch = fromCompositionInBatch || _hadVisiblePreeditText;
     }
@@ -400,6 +413,20 @@ final class TextInputSession with DeltaTextInputClient {
     if (connection != null && connection.attached) {
       connection.setEditingState(_value);
     }
+  }
+
+  /// Resynchronizes after a delta could not be applied to the sentinel value.
+  ///
+  /// Clears any composition/newline bookkeeping and pushes the sentinel back to
+  /// the platform so subsequent input maps to a known state again, keeping the
+  /// text-input channel alive instead of letting the failure freeze typing.
+  void _recoverFromDesync() {
+    _clearNewlineActionSuppression();
+    _clearCommittedCompositionEdit();
+    final hadVisiblePreeditText = _hadVisiblePreeditText;
+    _hadVisiblePreeditText = false;
+    if (hadVisiblePreeditText) _onPreeditChanged?.call('');
+    _resetBuffer();
   }
 
   void _resetInputState() {

--- a/packages/flterm/lib/src/input/text_input_session.dart
+++ b/packages/flterm/lib/src/input/text_input_session.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 /// Flutter text input connection for terminal editing.
 ///
@@ -32,6 +32,7 @@ final class TextInputSession with DeltaTextInputClient {
   var _newlineActionsToSuppress = 0;
   Timer? _newlineActionDedupeTimer;
   var _newlineDeltasToSuppress = 0;
+  var _reopenScheduled = false;
   VoidCallback? _onNewline;
   ValueChanged<int>? _onDelete;
   ValueChanged<String>? _onPreeditChanged;
@@ -211,7 +212,7 @@ final class TextInputSession with DeltaTextInputClient {
         // applying it throws. Left uncaught, that kills the text-input channel
         // and freezes all further typing (e.g. after composing an accent).
         // Resync the platform back to the sentinel and drop this batch instead.
-        _recoverFromDesync();
+        _recoverFromDesync(delta);
         return;
       }
       _value = next;
@@ -415,18 +416,64 @@ final class TextInputSession with DeltaTextInputClient {
     }
   }
 
-  /// Resynchronizes after a delta could not be applied to the sentinel value.
+  /// Resynchronizes after [failedDelta] could not be applied to the sentinel.
   ///
-  /// Clears any composition/newline bookkeeping and pushes the sentinel back to
-  /// the platform so subsequent input maps to a known state again, keeping the
+  /// Clears any composition/newline bookkeeping and forces the platform back to
+  /// the sentinel so subsequent input maps to a known state again, keeping the
   /// text-input channel alive instead of letting the failure freeze typing.
-  void _recoverFromDesync() {
+  ///
+  /// A plain [setEditingState] is not enough on iOS: it keeps its own
+  /// marked-text buffer and ignores the sentinel we push, so every following
+  /// delta stays anchored to that buffer and re-desyncs, dropping input
+  /// indefinitely (e.g. after composing a dead-key accent with a physical
+  /// keyboard). The connection has to be reopened so iOS discards the marked
+  /// text and re-anchors on a fresh sentinel, but reopening synchronously here
+  /// lands mid-delivery and does not re-engage key input until the view is
+  /// refocused, so it is deferred past this callback (see [_scheduleReopen]).
+  ///
+  /// The failing delta usually carries the composed character iOS was trying to
+  /// commit (a dead-key accent), so it is salvaged and committed before the
+  /// batch is dropped; otherwise the accent would be lost with the batch.
+  void _recoverFromDesync(TextEditingDelta failedDelta) {
     _clearNewlineActionSuppression();
     _clearCommittedCompositionEdit();
     final hadVisiblePreeditText = _hadVisiblePreeditText;
     _hadVisiblePreeditText = false;
     if (hadVisiblePreeditText) _onPreeditChanged?.call('');
-    _resetBuffer();
+
+    final salvaged = switch (failedDelta) {
+      TextEditingDeltaInsertion(:final textInserted) => textInserted,
+      TextEditingDeltaReplacement(:final replacementText) => replacementText,
+      _ => '',
+    };
+    if (salvaged.isNotEmpty) _commitText(salvaged);
+
+    _value = _sentinel;
+    if (_connection != null && _connection!.attached) {
+      _scheduleReopen();
+    } else {
+      _resetBuffer();
+    }
+  }
+
+  /// Reopens the text-input connection after the current platform callback.
+  ///
+  /// Closing/reopening while a delta batch is still being delivered leaves iOS
+  /// with an open channel that stops handing over keys until the view is
+  /// refocused. Deferring to a microtask lets the platform finish the current
+  /// delivery first; the fresh connection then receives subsequent keys and is
+  /// re-shown so key delivery resumes without a manual refocus.
+  void _scheduleReopen() {
+    if (_reopenScheduled) return;
+    _reopenScheduled = true;
+    scheduleMicrotask(() {
+      _reopenScheduled = false;
+      final connection = _connection;
+      if (connection == null || !connection.attached) return;
+      _closeConnection();
+      _openConnection();
+      _connection?.show();
+    });
   }
 
   void _resetInputState() {

--- a/packages/flterm/lib/src/input/text_input_session.dart
+++ b/packages/flterm/lib/src/input/text_input_session.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 /// Flutter text input connection for terminal editing.
@@ -456,17 +457,19 @@ final class TextInputSession with DeltaTextInputClient {
     }
   }
 
-  /// Reopens the text-input connection after the current platform callback.
+  /// Reopens the text-input connection after the current frame.
   ///
   /// Closing/reopening while a delta batch is still being delivered leaves iOS
   /// with an open channel that stops handing over keys until the view is
-  /// refocused. Deferring to a microtask lets the platform finish the current
-  /// delivery first; the fresh connection then receives subsequent keys and is
-  /// re-shown so key delivery resumes without a manual refocus.
+  /// refocused. A microtask still runs inside the same platform turn, so the
+  /// reopen is deferred to the next post-frame callback: that lets iOS fully
+  /// settle its marked-text state first, and the fresh connection then receives
+  /// subsequent keys and is re-shown so key delivery resumes without a manual
+  /// refocus.
   void _scheduleReopen() {
     if (_reopenScheduled) return;
     _reopenScheduled = true;
-    scheduleMicrotask(() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
       _reopenScheduled = false;
       final connection = _connection;
       if (connection == null || !connection.attached) return;

--- a/packages/flterm/test/input/keyboard_input_adapter_test.dart
+++ b/packages/flterm/test/input/keyboard_input_adapter_test.dart
@@ -1,0 +1,101 @@
+@Tags(['ffi'])
+library;
+
+import 'dart:convert';
+
+import 'package:flterm/src/controller/terminal_controller.dart';
+import 'package:flterm/src/input/keyboard_input_adapter.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show KeyEventResult;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('KeyboardInputAdapter dead keys', () {
+    late TerminalControllerImpl controller;
+    late KeyboardInputAdapter adapter;
+    late List<int> output;
+
+    setUp(() {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      controller = TerminalControllerImpl();
+      output = <int>[];
+      controller.onOutput = output.addAll;
+      adapter = KeyboardInputAdapter(controller);
+      // Enable the Kitty keyboard protocol so an unmodified printable press
+      // would otherwise be encoded and sent to the PTY.
+      controller.write(Uint8List.fromList(utf8.encode('\x1b[>1u')));
+    });
+
+    tearDown(() {
+      adapter.dispose();
+      controller.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    KeyDownEvent keyDown(
+      PhysicalKeyboardKey physical,
+      LogicalKeyboardKey logical, {
+      String? character,
+    }) {
+      return KeyDownEvent(
+        physicalKey: physical,
+        logicalKey: logical,
+        character: character,
+        timeStamp: Duration.zero,
+      );
+    }
+
+    test('dead key with a null character is ignored and reaches no PTY', () {
+      // The acute/tilde dead key sits on the bracketLeft physical position and
+      // fires a key-down with no composed character yet.
+      final result = adapter.handleKeyEvent(
+        keyDown(
+          PhysicalKeyboardKey.bracketLeft,
+          LogicalKeyboardKey.bracketLeft,
+        ),
+      );
+
+      expect(result, KeyEventResult.ignored);
+      expect(output, isEmpty);
+    });
+
+    test('dead key delivered as a bare acute is ignored', () {
+      final result = adapter.handleKeyEvent(
+        keyDown(
+          PhysicalKeyboardKey.bracketLeft,
+          LogicalKeyboardKey.bracketLeft,
+          character: '´',
+        ),
+      );
+
+      expect(result, KeyEventResult.ignored);
+      expect(output, isEmpty);
+    });
+
+    test('plain printable key still encodes to the PTY under Kitty', () {
+      final result = adapter.handleKeyEvent(
+        keyDown(
+          PhysicalKeyboardKey.keyA,
+          LogicalKeyboardKey.keyA,
+          character: 'a',
+        ),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(output, isNotEmpty);
+    });
+
+    test('Enter is not treated as a dead key and reaches the PTY', () {
+      final result = adapter.handleKeyEvent(
+        keyDown(PhysicalKeyboardKey.enter, LogicalKeyboardKey.enter),
+      );
+
+      expect(result, KeyEventResult.handled);
+      expect(output, isNotEmpty);
+    });
+  });
+}

--- a/packages/flterm/test/input/text_input_session_test.dart
+++ b/packages/flterm/test/input/text_input_session_test.dart
@@ -64,6 +64,46 @@ void main() {
     tearDown(() => handler.detach());
 
     group('updateEditingValueWithDeltas', () {
+      test('recovers when a delta cannot apply to the sentinel value', () {
+        final calls = recordTextInputCalls();
+        handler.ensureAttached();
+        calls.clear();
+
+        // A platform that ignored our sentinel reset (e.g. iOS after an accent)
+        // can send a delta referencing offsets past our value. Applying it
+        // would throw; the session must recover instead of freezing.
+        expect(
+          () => handler.updateEditingValueWithDeltas([
+            const TextEditingDeltaDeletion(
+              oldText: 'abcde',
+              deletedRange: TextRange(start: 3, end: 5),
+              selection: TextSelection.collapsed(offset: 3),
+              composing: TextRange.empty,
+            ),
+          ]),
+          returnsNormally,
+        );
+
+        // Channel stays alive and is resynced back to the sentinel.
+        expect(handler.isAttached, isTrue);
+        expect(
+          calls.where((call) => call.method == 'TextInput.setEditingState'),
+          isNotEmpty,
+        );
+
+        // Subsequent normal input still commits.
+        handler.updateEditingValueWithDeltas([
+          const TextEditingDeltaInsertion(
+            oldText: ' ',
+            textInserted: 'x',
+            insertionOffset: 1,
+            selection: TextSelection.collapsed(offset: 2),
+            composing: TextRange.empty,
+          ),
+        ]);
+        expect(commits, ['x']);
+      });
+
       test('commits inserted text', () {
         handler.updateEditingValueWithDeltas([
           const TextEditingDeltaInsertion(


### PR DESCRIPTION
## Summary

On iOS, composing an accent (dead key + vowel) freezes the terminal: after the
accent commits, no further typing registers. Plain keys are fine until the first
accent.

## Root cause

`TextInputSession` keeps a one-space sentinel and pushes it back via
`setEditingState` after every commit, translating deltas relative to it. iOS,
however, keeps its own marked-text buffer and **ignores that reset** right after
a composition. An accent commits an IME-like character (`> 0x7f`), the buffer is
reset on our side but not on iOS's, and the next delta iOS sends references
offsets past our sentinel value.

`delta.apply(_value)` then throws a `RangeError`. Because that happens inside
`updateEditingValueWithDeltas`, the exception tears down the platform text-input
channel — every subsequent keystroke is dropped, so typing freezes entirely.
Desktop platforms honor the reset, so they never hit it.

## Fix

Guard each `delta.apply`; on failure, resync the platform back to the sentinel
and drop that batch instead of letting the exception kill the connection. The
channel stays alive and input keeps working.

## Test

Adds a regression test that drives a delta whose range exceeds the sentinel
(which throws today) and asserts the session recovers, stays attached, and keeps
committing subsequent input. `flutter analyze` is clean; the full `flterm` suite
passes.

> Note: the throwing delta is reproduced synthetically in the test. Validation
> of the exact iOS accent sequence on a device/simulator is still recommended,
> but the recovery is a strict robustness improvement regardless of the trigger.
