### PR TITLE
fix(flterm): stabilize Kitty graphics rendering

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -40,6 +40,9 @@
   selection and terminal mouse reporting.
 - **View updates**: controller swaps transfer terminal focus correctly, and
   changing `TerminalView.fontData` refreshes cell metrics.
+- **Kitty graphics rendering**: unchanged and replacing images remain drawable,
+  decode pressure is bounded, and placement geometry refreshes during initial
+  layout and window resizing.
 
 ## 0.0.5
 

--- a/packages/flterm/lib/src/rendering/kitty_image_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_image_cache.dart
@@ -108,10 +108,10 @@ class KittyImageCache {
     if (image.compression != .none) return null;
     switch (image.format) {
       case KittyImageFormat.rgba:
-        return image.pixelData;
+        return _copyPixelData(image, image.width * image.height * 4);
       case KittyImageFormat.rgb:
-        final src = image.pixelData;
         final pixelCount = image.width * image.height;
+        final src = _copyPixelData(image, pixelCount * 3);
         if (src.length < pixelCount * 3) return null;
         final out = Uint8List(pixelCount * 4);
         for (var i = 0; i < pixelCount; i++) {
@@ -126,6 +126,14 @@ class KittyImageCache {
       case KittyImageFormat.gray:
         return null;
     }
+  }
+
+  Uint8List _copyPixelData(KittyImage image, int byteLength) {
+    final destination = Uint8List(byteLength);
+    final written = image.copyPixelDataInto(destination);
+    return written == destination.length
+        ? destination
+        : Uint8List.sublistView(destination, 0, written);
   }
 }
 

--- a/packages/flterm/lib/src/rendering/kitty_image_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_image_cache.dart
@@ -5,6 +5,9 @@ import 'package:libghostty/libghostty.dart';
 import 'package:meta/meta.dart';
 
 /// Converts raw RGBA image bytes into a Flutter [Image].
+///
+/// The decoder may retain [pixels] until it invokes [callback], but not after.
+/// The cache serializes calls and can reuse the buffer after that boundary.
 typedef KittyImageDecoder =
     void Function(
       Uint8List pixels,
@@ -24,12 +27,22 @@ typedef KittyImageDecoder =
 /// Re-transmissions under the same id are detected by
 /// [KittyImage.generation], so same-sized replacements cannot reuse stale
 /// decoded images.
+///
+/// Decodes are serialized. Requests retain Dart-owned source bytes while
+/// queued, allowing eviction to discard obsolete animation frames before RGB
+/// expansion and Flutter image decoding begin.
 class KittyImageCache {
   final VoidCallback _onImageReady;
   final KittyImageDecoder _decodeImage;
-
+  final Map<int, int> _requestTokens = {};
+  final Map<int, int> _requestedGenerations = {};
   final Map<int, KittyImageCacheEntry> _entries = {};
-  final Map<int, int> _generations = {};
+  final Map<int, _KittyDecodeRequest> _queuedRequests = {};
+  _KittyDecodeRequest? _activeRequest;
+  Uint8List? _rgbSourceBuffer;
+  Uint8List? _rgbDecodeBuffer;
+  var _nextRequestToken = 0;
+  var _disposed = false;
 
   /// [onImageReady] fires when a pending decode completes; typically
   /// wired to a render box's `markNeedsPaint`.
@@ -44,7 +57,13 @@ class KittyImageCache {
       if (entry is KittyImageReady) entry.image.dispose();
     }
     _entries.clear();
-    _generations.clear();
+    _requestedGenerations.clear();
+    _requestTokens.clear();
+    _queuedRequests.clear();
+    _activeRequest = null;
+    _rgbSourceBuffer = null;
+    _rgbDecodeBuffer = null;
+    _disposed = true;
   }
 
   /// Releases any cached entries whose id is not in [live].
@@ -52,23 +71,44 @@ class KittyImageCache {
     _entries.removeWhere((id, entry) {
       if (live.contains(id)) return false;
       if (entry is KittyImageReady) entry.image.dispose();
-      _generations.remove(id);
+      _requestedGenerations.remove(id);
+      _requestTokens.remove(id);
+      _queuedRequests.remove(id);
       return true;
     });
   }
 
   /// Returns the entry for [image], starting a decode on first lookup
   /// or when the image's generation has changed. Never blocks.
+  ///
+  /// A ready entry remains drawable while its replacement decodes. Only the
+  /// latest requested generation may replace it, so rapid updates skip stale
+  /// intermediate results without producing a blank frame.
   KittyImageCacheEntry lookup(KittyImage image) {
+    if (_disposed) throw StateError('KittyImageCache is disposed.');
     final generation = image.generation;
     final existing = _entries[image.id];
-    if (existing != null && _generations[image.id] == generation) {
+    if (existing != null && _requestedGenerations[image.id] == generation) {
       return existing;
     }
-    if (existing is KittyImageReady) existing.image.dispose();
-    _entries[image.id] = KittyImagePending();
-    _generations[image.id] = generation;
-    _beginDecode(image);
+    final previousGeneration = _requestedGenerations[image.id];
+    _requestedGenerations[image.id] = generation;
+    try {
+      _beginDecode(image, existing);
+    } catch (_) {
+      if (previousGeneration == null) {
+        _requestedGenerations.remove(image.id);
+      } else {
+        _requestedGenerations[image.id] = previousGeneration;
+      }
+      _requestTokens.remove(image.id);
+      if (existing == null) {
+        _entries.remove(image.id);
+      } else {
+        _entries[image.id] = existing;
+      }
+      rethrow;
+    }
     return _entries[image.id]!;
   }
 
@@ -82,45 +122,66 @@ class KittyImageCache {
     final existing = _entries[imageId];
     if (existing is KittyImageReady) existing.image.dispose();
     _entries[imageId] = KittyImageReady(image);
-    _generations[imageId] = 0;
+    _requestedGenerations[imageId] = 0;
+    _requestTokens.remove(imageId);
+    _queuedRequests.remove(imageId);
   }
 
-  void _beginDecode(KittyImage image) {
+  void _beginDecode(KittyImage image, KittyImageCacheEntry? existing) {
     final imageId = image.id;
-    final generation = _generations[imageId];
-    final rgba = _ensureRgba(image);
-    if (rgba == null) {
-      _entries[imageId] = KittyImageUnsupported();
+    final generation = _requestedGenerations[imageId];
+    final request = _captureRequest(image, generation!);
+    if (request == null) {
+      if (existing is KittyImageReady) existing.image.dispose();
+      _requestTokens.remove(imageId);
+      _queuedRequests.remove(imageId);
+      _entries[imageId] = const KittyImageUnsupported();
       return;
     }
-    _decodeImage(rgba, image.width, image.height, .rgba8888, (decoded) {
-      if (_generations[imageId] == generation &&
-          _entries[imageId] is KittyImagePending) {
-        _entries[imageId] = KittyImageReady(decoded);
-        _onImageReady();
-      } else {
-        decoded.dispose();
-      }
-    });
+    if (existing is! KittyImageReady) {
+      _entries[imageId] = const KittyImagePending();
+    }
+    final requestToken = ++_nextRequestToken;
+    _requestTokens[imageId] = requestToken;
+    final queued = request.withToken(requestToken);
+    if (_activeRequest == null) {
+      _startDecode(queued);
+    } else {
+      // Keep native-to-Dart copies valid, but defer RGB expansion and Flutter
+      // decoding. Eviction can then discard superseded animation frames before
+      // they consume UI-isolate and raster-thread work.
+      // Refreshing an ID moves it behind other live work so one animated image
+      // cannot starve independent queued placements.
+      _queuedRequests
+        ..remove(imageId)
+        ..[imageId] = queued;
+    }
   }
 
-  Uint8List? _ensureRgba(KittyImage image) {
+  _KittyDecodeRequest? _captureRequest(KittyImage image, int generation) {
     if (image.compression != .none) return null;
-    switch (image.format) {
+    final format = image.format;
+    switch (format) {
       case KittyImageFormat.rgba:
-        return _copyPixelData(image, image.width * image.height * 4);
       case KittyImageFormat.rgb:
         final pixelCount = image.width * image.height;
-        final src = _copyPixelData(image, pixelCount * 3);
-        if (src.length < pixelCount * 3) return null;
-        final out = Uint8List(pixelCount * 4);
-        for (var i = 0; i < pixelCount; i++) {
-          out[i * 4 + 0] = src[i * 3 + 0];
-          out[i * 4 + 1] = src[i * 3 + 1];
-          out[i * 4 + 2] = src[i * 3 + 2];
-          out[i * 4 + 3] = 0xff;
-        }
-        return out;
+        final bytesPerPixel = format == .rgb ? 3 : 4;
+        final byteLength = pixelCount * bytesPerPixel;
+        // A request that starts immediately consumes RGB synchronously during
+        // expansion. Queued requests still allocate independent snapshots so
+        // later terminal mutations cannot alter their pixels.
+        final src = format == .rgb && _activeRequest == null
+            ? _copyRgbPixels(image, byteLength)
+            : _copyPixels(image, byteLength);
+        if (src.length < byteLength) return null;
+        return _KittyDecodeRequest(
+          imageId: image.id,
+          generation: generation,
+          width: image.width,
+          height: image.height,
+          format: format,
+          pixels: src,
+        );
       case KittyImageFormat.png:
       case KittyImageFormat.grayAlpha:
       case KittyImageFormat.gray:
@@ -128,27 +189,170 @@ class KittyImageCache {
     }
   }
 
-  Uint8List _copyPixelData(KittyImage image, int byteLength) {
+  void _completeDecode(_KittyDecodeRequest request, Image decoded) {
+    if (identical(_activeRequest, request)) _activeRequest = null;
+    try {
+      if (_requestedGenerations[request.imageId] == request.generation &&
+          _requestTokens[request.imageId] == request.token) {
+        final previous = _entries[request.imageId];
+        _requestTokens.remove(request.imageId);
+        _entries[request.imageId] = KittyImageReady(decoded);
+        if (previous is KittyImageReady) previous.image.dispose();
+        _onImageReady();
+      } else {
+        decoded.dispose();
+      }
+    } finally {
+      _startNextDecode();
+    }
+  }
+
+  Uint8List _copyRgbPixels(KittyImage image, int byteLength) {
+    final destination = _rgbSourceBuffer?.length == byteLength
+        ? _rgbSourceBuffer!
+        : Uint8List(byteLength);
+    final written = image.copyPixelDataInto(destination);
+    _rgbSourceBuffer = destination;
+    return written == destination.length
+        ? destination
+        : Uint8List.sublistView(destination, 0, written);
+  }
+
+  Uint8List _copyPixels(KittyImage image, int byteLength) {
     final destination = Uint8List(byteLength);
     final written = image.copyPixelDataInto(destination);
     return written == destination.length
         ? destination
         : Uint8List.sublistView(destination, 0, written);
   }
+
+  void _startDecode(_KittyDecodeRequest request) {
+    _activeRequest = request;
+    try {
+      // Only one decode is active, and its callback marks input consumption.
+      // Reusing this staging buffer removes one full-frame allocation without
+      // sharing mutable pixels between overlapping decoders.
+      final pixels = request.takeRgba(_rgbDecodeBuffer);
+      if (request.format == .rgb) _rgbDecodeBuffer = pixels;
+      _decodeImage(
+        pixels,
+        request.width,
+        request.height,
+        .rgba8888,
+        (decoded) => _completeDecode(request, decoded),
+      );
+    } catch (_) {
+      if (identical(_activeRequest, request)) _activeRequest = null;
+      rethrow;
+    }
+  }
+
+  void _startNextDecode() {
+    var decodeFailed = false;
+    while (_activeRequest == null && _queuedRequests.isNotEmpty) {
+      final imageId = _queuedRequests.keys.first;
+      final request = _queuedRequests.remove(imageId)!;
+      if (_requestedGenerations[imageId] != request.generation ||
+          _requestTokens[imageId] != request.token) {
+        continue;
+      }
+      try {
+        _startDecode(request);
+      } on Object {
+        _requestedGenerations.remove(imageId);
+        _requestTokens.remove(imageId);
+        if (_entries[imageId] is KittyImagePending) _entries.remove(imageId);
+        decodeFailed = true;
+      }
+    }
+    if (decodeFailed) _onImageReady();
+  }
 }
 
 /// Result of a cache lookup for a decoded image.
-sealed class KittyImageCacheEntry {}
+sealed class KittyImageCacheEntry {
+  const KittyImageCacheEntry();
+}
 
 /// A decode is in flight. A later repaint will see a [KittyImageReady].
-final class KittyImagePending extends KittyImageCacheEntry {}
+final class KittyImagePending extends KittyImageCacheEntry {
+  const KittyImagePending();
+}
 
 /// The image is decoded and ready to draw.
 final class KittyImageReady extends KittyImageCacheEntry {
   final Image image;
 
-  KittyImageReady(this.image);
+  const KittyImageReady(this.image);
 }
 
 /// The image was rejected due to an unsupported format or compression.
-final class KittyImageUnsupported extends KittyImageCacheEntry {}
+final class KittyImageUnsupported extends KittyImageCacheEntry {
+  const KittyImageUnsupported();
+}
+
+final class _KittyDecodeRequest {
+  final int imageId;
+  final int generation;
+  final int width;
+  final int height;
+  final KittyImageFormat format;
+  Uint8List? pixels;
+  final int token;
+
+  _KittyDecodeRequest({
+    required this.imageId,
+    required this.generation,
+    required this.width,
+    required this.height,
+    required this.format,
+    required this.pixels,
+    this.token = 0,
+  });
+
+  Uint8List takeRgba(Uint8List? reusable) {
+    final source = pixels!;
+    pixels = null;
+    if (format == .rgba) return source;
+    final pixelCount = width * height;
+    final byteLength = pixelCount * 4;
+    final result = reusable?.length == byteLength
+        ? reusable!
+        : Uint8List(byteLength);
+    final rgba = Uint32List.view(result.buffer);
+    // Advance the RGB offset once per pixel. Recomputing `pixel * 3` for each
+    // channel measurably increases this per-frame conversion cost in profile.
+    if (Endian.host == .little) {
+      var sourceOffset = 0;
+      for (var pixel = 0; pixel < pixelCount; pixel++) {
+        rgba[pixel] =
+            source[sourceOffset] |
+            source[sourceOffset + 1] << 8 |
+            source[sourceOffset + 2] << 16 |
+            0xff000000;
+        sourceOffset += 3;
+      }
+    } else {
+      var sourceOffset = 0;
+      for (var pixel = 0; pixel < pixelCount; pixel++) {
+        rgba[pixel] =
+            source[sourceOffset] << 24 |
+            source[sourceOffset + 1] << 16 |
+            source[sourceOffset + 2] << 8 |
+            0xff;
+        sourceOffset += 3;
+      }
+    }
+    return result;
+  }
+
+  _KittyDecodeRequest withToken(int token) => _KittyDecodeRequest(
+    imageId: imageId,
+    generation: generation,
+    width: width,
+    height: height,
+    format: format,
+    pixels: pixels,
+    token: token,
+  );
+}

--- a/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
@@ -14,13 +14,13 @@ import 'paint_state.dart';
 final class KittyPlacementCache {
   final PaintState _state;
   final KittyImageCache _images;
-  final List<KittyPlacementSnapshot> _snapshots = [];
   final Set<int> _liveImageIds = {};
+  final List<KittyPlacementSnapshot> _snapshots = [];
   _SnapshotKey? _key;
 
   KittyPlacementCache({required this._state, required this._images});
 
-  /// Placement snapshots ordered by their signed z-index.
+  /// Placement snapshots ordered by signed z-index, then image ID.
   Iterable<KittyPlacementSnapshot> get snapshots => _snapshots;
 
   /// Refreshes snapshots from [terminal] when protocol or geometry inputs have
@@ -51,9 +51,14 @@ final class KittyPlacementCache {
     );
     if (!geometryDirty && _key == key) return false;
 
-    _clear();
+    final nextSnapshots = <KittyPlacementSnapshot>[];
+    final nextLiveImageIds = <int>{};
+    final drawableImageIds = {
+      for (final snapshot in _snapshots) snapshot.imageId,
+    };
+    var replacementPending = false;
     for (final placement in graphics.placements()) {
-      _liveImageIds.add(placement.imageId);
+      nextLiveImageIds.add(placement.imageId);
 
       final info = placement.renderInfo;
       if (!info.viewportVisible) continue;
@@ -62,8 +67,11 @@ final class KittyPlacementCache {
       final image = graphics.image(placement.imageId);
       if (image == null) continue;
 
-      _images.lookup(image);
-      _snapshots.add(
+      final entry = _images.lookup(image);
+      replacementPending |=
+          entry is KittyImagePending &&
+          !drawableImageIds.contains(placement.imageId);
+      nextSnapshots.add(
         KittyPlacementSnapshot(
           imageId: placement.imageId,
           dst: Rect.fromLTWH(
@@ -85,7 +93,20 @@ final class KittyPlacementCache {
       );
     }
 
-    if (_snapshots.length > 1) _snapshots.sort(_compareZ);
+    if (nextSnapshots.length > 1) nextSnapshots.sort(_compareZ);
+    // Placement and image publication is one visual transaction. This keeps
+    // the last complete frame drawable when clients animate with new IDs.
+    if (replacementPending && _snapshots.isNotEmpty) {
+      _images.evict({..._liveImageIds, ...nextLiveImageIds});
+      return false;
+    }
+
+    _snapshots
+      ..clear()
+      ..addAll(nextSnapshots);
+    _liveImageIds
+      ..clear()
+      ..addAll(nextLiveImageIds);
     _images.evict(_liveImageIds);
     _key = key;
     return true;
@@ -97,7 +118,8 @@ final class KittyPlacementCache {
   }
 
   static int _compareZ(KittyPlacementSnapshot a, KittyPlacementSnapshot b) {
-    return a.z.compareTo(b.z);
+    final z = a.z.compareTo(b.z);
+    return z != 0 ? z : a.imageId.compareTo(b.imageId);
   }
 }
 

--- a/packages/flterm/test/rendering/kitty_graphics_painter_golden_test.dart
+++ b/packages/flterm/test/rendering/kitty_graphics_painter_golden_test.dart
@@ -201,12 +201,14 @@ void main() {
         final image = KittyGraphics.of(terminal)!.image(1)!;
         expect(image.width, 64);
         expect(image.height, 64);
+        final pixels = Uint8List(image.width * image.height * 4);
+        image.copyPixelDataInto(pixels);
 
         final cache = KittyImageCache(onImageReady: () {});
         addTearDown(cache.dispose);
         cache.putReady(
           image.id,
-          await imageFromRgba(image.pixelData, image.width, image.height),
+          await imageFromRgba(pixels, image.width, image.height),
         );
 
         final snapshots = [

--- a/packages/flterm/test/rendering/kitty_image_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_image_cache_test.dart
@@ -43,6 +43,18 @@ void main() {
 
         expect(cache.dispose, returnsNormally);
       });
+
+      test('rejects lookup after disposal', () {
+        final terminal = Terminal(cols: 1, rows: 1);
+        addTearDown(terminal.dispose);
+        terminal.write(
+          Uint8List.fromList('\x1b_Gf=24,s=1,v=1,a=t,i=1;/wAA\x1b\\'.codeUnits),
+        );
+        final image = KittyGraphics.of(terminal)!.image(1)!;
+        final cache = KittyImageCache(onImageReady: () {})..dispose();
+
+        expect(() => cache.lookup(image), throwsStateError);
+      });
     });
 
     group('lookup', () {
@@ -51,6 +63,19 @@ void main() {
         return Uint8List.fromList(
           '\x1b_Gf=24,s=1,v=1,a=t,i=$id;$payload\x1b\\'.codeUnits,
         );
+      }
+
+      void applyImagePressure(
+        KittyImageCache cache,
+        Terminal terminal, {
+        required int firstId,
+        required int lastId,
+      }) {
+        for (var imageId = firstId; imageId <= lastId; imageId++) {
+          terminal.write(transmitPixel(id: imageId, rgb: [imageId, 0, 0]));
+          cache.lookup(KittyGraphics.of(terminal)!.image(imageId)!);
+          cache.evict({1, imageId});
+        }
       }
 
       late Terminal terminal;
@@ -63,18 +88,364 @@ void main() {
         terminal.dispose();
       });
 
-      test('invalidates ready entry when image generation changes', () async {
-        final cache = KittyImageCache(onImageReady: () {});
+      test(
+        'retains prior ready image during valid replacement decode',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final cache = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 7, rgb: [0xff, 0x00, 0x00]));
+          final firstImage = KittyGraphics.of(terminal)!.image(7)!;
+          cache.lookup(firstImage);
+          final firstDecoded = await testImage();
+          callbacks.single(firstDecoded);
+          final previous = cache.lookupById(7);
+
+          terminal.write(transmitPixel(id: 7, rgb: [0x00, 0xff, 0x00]));
+          final replacement = KittyGraphics.of(terminal)!.image(7)!;
+          cache.lookup(replacement);
+
+          final current = cache.lookupById(7);
+
+          expect(current, same(previous));
+        },
+      );
+
+      test(
+        'publishes the newest generation after a stale decode completes',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final cache = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 8, rgb: [0xff, 0x00, 0x00]));
+          final firstImage = KittyGraphics.of(terminal)!.image(8)!;
+          cache.lookup(firstImage);
+          terminal.write(transmitPixel(id: 8, rgb: [0x00, 0xff, 0x00]));
+          final replacement = KittyGraphics.of(terminal)!.image(8)!;
+          cache.lookup(replacement);
+          final firstDecoded = await testImage();
+          final replacementDecoded = await testImage();
+
+          callbacks.single(firstDecoded);
+          callbacks.last(replacementDecoded);
+
+          final entry = cache.lookupById(8)! as KittyImageReady;
+
+          expect(entry.image, same(replacementDecoded));
+        },
+      );
+
+      test('publishes a replacement after its decode completes', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+        );
         addTearDown(cache.dispose);
-        final decoded = await testImage();
-        cache.putReady(7, decoded);
-        terminal.write(transmitPixel(id: 7, rgb: [0xff, 0x00, 0x00]));
-        final image = KittyGraphics.of(terminal)!.image(7)!;
+        terminal.write(transmitPixel(id: 9, rgb: [0xff, 0x00, 0x00]));
+        final firstImage = KittyGraphics.of(terminal)!.image(9)!;
+        cache.lookup(firstImage);
+        callbacks.single(await testImage());
+        terminal.write(transmitPixel(id: 9, rgb: [0x00, 0xff, 0x00]));
+        final replacement = KittyGraphics.of(terminal)!.image(9)!;
+        cache.lookup(replacement);
+        final replacementDecoded = await testImage();
 
-        final entry = cache.lookup(image);
+        callbacks.last(replacementDecoded);
 
-        expect(entry, isA<KittyImagePending>());
+        final entry = cache.lookupById(9)! as KittyImageReady;
+
+        expect(entry.image, same(replacementDecoded));
       });
+
+      test('reuses a ready image for an unchanged generation', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 13, rgb: [0xff, 0x00, 0x00]));
+        final image = KittyGraphics.of(terminal)!.image(13)!;
+        cache.lookup(image);
+        callbacks.single(await testImage());
+        final ready = cache.lookupById(13);
+
+        final reused = cache.lookup(image);
+
+        expect(reused, same(ready));
+      });
+
+      test('expands RGB channels in Flutter pixel order', () {
+        late Uint8List decodedPixels;
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (pixels, _, _, _, _) => decodedPixels = pixels,
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 24, rgb: [0x12, 0x34, 0x56]));
+
+        cache.lookup(KittyGraphics.of(terminal)!.image(24)!);
+
+        expect(decodedPixels, [0x12, 0x34, 0x56, 0xff]);
+      });
+
+      test('expands every RGB pixel without crossing channel boundaries', () {
+        late Uint8List decodedPixels;
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (pixels, _, _, _, _) => decodedPixels = pixels,
+        );
+        addTearDown(cache.dispose);
+        final rgb = [
+          0x12,
+          0x34,
+          0x56,
+          0x78,
+          0x9a,
+          0xbc,
+          0xde,
+          0xf0,
+          0x11,
+          0x22,
+          0x33,
+          0x44,
+          0x55,
+          0x66,
+          0x77,
+        ];
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b_Gf=24,s=5,v=1,a=t,i=25;${base64Encode(rgb)}\x1b\\'.codeUnits,
+          ),
+        );
+
+        cache.lookup(KittyGraphics.of(terminal)!.image(25)!);
+
+        expect(decodedPixels, [
+          0x12,
+          0x34,
+          0x56,
+          0xff,
+          0x78,
+          0x9a,
+          0xbc,
+          0xff,
+          0xde,
+          0xf0,
+          0x11,
+          0xff,
+          0x22,
+          0x33,
+          0x44,
+          0xff,
+          0x55,
+          0x66,
+          0x77,
+          0xff,
+        ]);
+      });
+
+      test('reuses RGB expansion storage after decode completion', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final decodedPixels = <Uint8List>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (pixels, _, _, _, callback) {
+            decodedPixels.add(pixels);
+            callbacks.add(callback);
+          },
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 27, rgb: [0x10, 0x20, 0x30]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(27)!);
+        terminal.write(transmitPixel(id: 28, rgb: [0x40, 0x50, 0x60]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(28)!);
+
+        callbacks.single(await testImage());
+
+        expect(decodedPixels, hasLength(2));
+        expect(decodedPixels.last, same(decodedPixels.first));
+        expect(decodedPixels.last, [0x40, 0x50, 0x60, 0xff]);
+      });
+
+      test('bounds concurrent decodes while newer images arrive', () {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 14, rgb: [0xff, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(14)!);
+        terminal.write(transmitPixel(id: 15, rgb: [0x00, 0xff, 0x00]));
+
+        cache.lookup(KittyGraphics.of(terminal)!.image(15)!);
+
+        expect(callbacks, hasLength(1));
+      });
+
+      test(
+        'continues queued decoding when readiness notification throws',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final cache = KittyImageCache(
+            onImageReady: () => throw StateError('notification failed'),
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 25, rgb: [0x10, 0x00, 0x00]));
+          cache.lookup(KittyGraphics.of(terminal)!.image(25)!);
+          terminal.write(transmitPixel(id: 26, rgb: [0x20, 0x00, 0x00]));
+          cache.lookup(KittyGraphics.of(terminal)!.image(26)!);
+
+          final decoded = await testImage();
+
+          expect(() => callbacks.single(decoded), throwsStateError);
+
+          expect(callbacks, hasLength(2));
+        },
+      );
+
+      test('skips a queued image evicted before decoding', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final decodedRedChannels = <int>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (pixels, _, _, _, callback) {
+            decodedRedChannels.add(pixels.first);
+            callbacks.add(callback);
+          },
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 16, rgb: [0x10, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(16)!);
+        terminal.write(transmitPixel(id: 17, rgb: [0x20, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(17)!);
+        terminal.write(transmitPixel(id: 18, rgb: [0x30, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(18)!);
+        cache.evict({16, 18});
+
+        callbacks.single(await testImage());
+
+        expect(decodedRedChannels, [0x10, 0x30]);
+      });
+
+      test(
+        'coalesces sustained changing-ID pressure to the latest frame',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final decodedRedChannels = <int>[];
+          final cache = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (pixels, _, _, _, callback) {
+              decodedRedChannels.add(pixels.first);
+              callbacks.add(callback);
+            },
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 1, rgb: [1, 0, 0]));
+          cache.lookup(KittyGraphics.of(terminal)!.image(1)!);
+          applyImagePressure(cache, terminal, firstId: 2, lastId: 120);
+
+          callbacks.single(await testImage());
+
+          expect(decodedRedChannels, [1, 120]);
+        },
+      );
+
+      test('does not let a refreshed image starve queued work', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final decodedRedChannels = <int>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (pixels, _, _, _, callback) {
+            decodedRedChannels.add(pixels.first);
+            callbacks.add(callback);
+          },
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 19, rgb: [0x10, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(19)!);
+        terminal.write(transmitPixel(id: 20, rgb: [0x20, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(20)!);
+        terminal.write(transmitPixel(id: 21, rgb: [0x30, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(21)!);
+        terminal.write(transmitPixel(id: 20, rgb: [0x40, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(20)!);
+
+        callbacks.single(await testImage());
+
+        expect(decodedRedChannels, [0x10, 0x30]);
+      });
+
+      test('pre-decoded image removes its queued request', () async {
+        final callbacks = <ui.ImageDecoderCallback>[];
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 22, rgb: [0x10, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(22)!);
+        terminal.write(transmitPixel(id: 23, rgb: [0x20, 0x00, 0x00]));
+        cache.lookup(KittyGraphics.of(terminal)!.image(23)!);
+        final preDecoded = await testImage();
+        cache.putReady(23, preDecoded);
+
+        callbacks.single(await testImage());
+
+        expect(callbacks, hasLength(1));
+      });
+
+      test(
+        'does not republish a decode that completes after disposal',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final cache = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 10, rgb: [0xff, 0x00, 0x00]));
+          final image = KittyGraphics.of(terminal)!.image(10)!;
+          cache.lookup(image);
+          final decoded = await testImage();
+
+          cache.dispose();
+          callbacks.single(decoded);
+
+          expect(cache.lookupById(10), isNull);
+        },
+      );
+
+      test(
+        'ignores an evicted decode after the same generation is requested',
+        () async {
+          final callbacks = <ui.ImageDecoderCallback>[];
+          final cache = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          addTearDown(cache.dispose);
+          terminal.write(transmitPixel(id: 11, rgb: [0xff, 0x00, 0x00]));
+          final image = KittyGraphics.of(terminal)!.image(11)!;
+          cache.lookup(image);
+          cache.evict({});
+          cache.lookup(image);
+          final evicted = await testImage();
+
+          callbacks.first(evicted);
+
+          expect(cache.lookupById(11), isA<KittyImagePending>());
+        },
+      );
 
       test('discards stale pending decode after generation changes', () async {
         final callbacks = <ui.ImageDecoderCallback>[];
@@ -96,6 +467,25 @@ void main() {
         callbacks[0](stale);
 
         expect(cache.lookupById(8), isA<KittyImagePending>());
+      });
+
+      test('retries an image after the decoder throws synchronously', () {
+        var decodeCalls = 0;
+        final cache = KittyImageCache(
+          onImageReady: () {},
+          decodeImage: (_, _, _, _, _) {
+            decodeCalls++;
+            throw StateError('decode failed');
+          },
+        );
+        addTearDown(cache.dispose);
+        terminal.write(transmitPixel(id: 12, rgb: [0xff, 0x00, 0x00]));
+        final image = KittyGraphics.of(terminal)!.image(12)!;
+
+        expect(() => cache.lookup(image), throwsStateError);
+        expect(() => cache.lookup(image), throwsStateError);
+
+        expect(decodeCalls, 2);
       });
     });
   });

--- a/packages/flterm/test/rendering/kitty_placement_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_placement_cache_test.dart
@@ -1,8 +1,10 @@
 @Tags(['ffi'])
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:ui' show Image, ImageDecoderCallback, Size, decodeImageFromPixels;
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
 import 'package:flterm/src/foundation/terminal_theme.dart';
@@ -16,12 +18,55 @@ void main() {
   group('KittyPlacementCache', () {
     const metrics = CellMetrics(cellWidth: 8, cellHeight: 16, baseline: 12);
 
-    void writePlacedImage(Terminal terminal) {
+    void writePlacedImage(Terminal terminal, {int id = 11}) {
       final payload = base64Encode([0xff, 0x00, 0x00]);
       terminal.write(
         Uint8List.fromList(
-          '\x1b_Gf=24,s=1,v=1,a=T,i=11,c=1,r=1;$payload\x1b\\'.codeUnits,
+          '\x1b_Gf=24,s=1,v=1,a=T,i=$id,c=1,r=1;$payload\x1b\\'.codeUnits,
         ),
+      );
+    }
+
+    Future<Image> testImage() {
+      final completer = Completer<Image>();
+      decodeImageFromPixels(
+        Uint8List.fromList([0xff, 0xff, 0xff, 0xff]),
+        1,
+        1,
+        .rgba8888,
+        completer.complete,
+      );
+      return completer.future;
+    }
+
+    ({
+      List<ImageDecoderCallback> decodeCallbacks,
+      KittyImageCache images,
+      KittyPlacementCache placements,
+      PaintState state,
+      Terminal terminal,
+    })
+    geometryFixture() {
+      final decodeCallbacks = <ImageDecoderCallback>[];
+      final terminal = Terminal(cols: 8, rows: 2)
+        ..kittyImageStorageLimit = 1 << 20;
+      final state = PaintState(TerminalTheme.dark(), metrics)
+        ..cols = 8
+        ..rows = 2;
+      final images = KittyImageCache(
+        onImageReady: () {},
+        decodeImage: (_, _, _, _, callback) => decodeCallbacks.add(callback),
+      );
+      final placements = KittyPlacementCache(state: state, images: images);
+      writePlacedImage(terminal);
+      terminal.resize(cols: 8, rows: 2, cellWidthPx: 8, cellHeightPx: 16);
+      placements.sync(terminal, geometryDirty: true);
+      return (
+        decodeCallbacks: decodeCallbacks,
+        images: images,
+        placements: placements,
+        state: state,
+        terminal: terminal,
       );
     }
 
@@ -61,12 +106,143 @@ void main() {
         expect(rebuilt, isTrue);
       });
 
+      test('refreshes destination geometry after a physical resize', () {
+        final fixture = geometryFixture();
+        addTearDown(fixture.images.dispose);
+        addTearDown(fixture.terminal.dispose);
+        fixture.state.metrics = const CellMetrics(
+          cellWidth: 16,
+          cellHeight: 32,
+          baseline: 24,
+        );
+        fixture.terminal.resize(
+          cols: 8,
+          rows: 2,
+          cellWidthPx: 16,
+          cellHeightPx: 32,
+        );
+        fixture.placements.sync(fixture.terminal, geometryDirty: true);
+
+        expect(
+          fixture.placements.snapshots.single.dst.size,
+          const Size(16, 32),
+        );
+      });
+
+      test('does not request another decode after a physical resize', () {
+        final fixture = geometryFixture();
+        addTearDown(fixture.images.dispose);
+        addTearDown(fixture.terminal.dispose);
+        fixture.state.metrics = const CellMetrics(
+          cellWidth: 16,
+          cellHeight: 32,
+          baseline: 24,
+        );
+        fixture.terminal.resize(
+          cols: 8,
+          rows: 2,
+          cellWidthPx: 16,
+          cellHeightPx: 32,
+        );
+
+        fixture.placements.sync(fixture.terminal, geometryDirty: true);
+
+        expect(fixture.decodeCallbacks, hasLength(1));
+      });
+
       test('removes snapshots hidden by terminal scrolling', () {
         terminal.write(Uint8List.fromList('\x1b[2;1H\n'.codeUnits));
 
         placements.sync(terminal, geometryDirty: true);
 
         expect(placements.snapshots, isEmpty);
+      });
+
+      test(
+        'retains the ready placement while a different image decodes',
+        () async {
+          final callbacks = <ImageDecoderCallback>[];
+          final controlledImages = KittyImageCache(
+            onImageReady: () {},
+            decodeImage: (_, _, _, _, callback) => callbacks.add(callback),
+          );
+          final controlledPlacements = KittyPlacementCache(
+            state: state,
+            images: controlledImages,
+          );
+          addTearDown(controlledImages.dispose);
+          terminal.resize(cols: 8, rows: 2, cellWidthPx: 8, cellHeightPx: 16);
+          controlledPlacements.sync(terminal, geometryDirty: true);
+          callbacks.single(await testImage());
+
+          terminal.write(
+            Uint8List.fromList('\x1b_Ga=d,d=I,i=11\x1b\\'.codeUnits),
+          );
+          writePlacedImage(terminal, id: 12);
+          controlledPlacements.sync(terminal, geometryDirty: true);
+          final whilePending = controlledPlacements.snapshots.single.imageId;
+          final oldReadyWhilePending =
+              controlledImages.lookupById(11) is KittyImageReady;
+          callbacks.last(await testImage());
+
+          controlledPlacements.sync(terminal, geometryDirty: false);
+
+          expect(
+            (
+              whilePending,
+              oldReadyWhilePending,
+              controlledPlacements.snapshots.single.imageId,
+              controlledImages.lookupById(11),
+            ),
+            (11, true, 12, null),
+          );
+        },
+      );
+
+      test('orders equal-z placements by ascending image id', () {
+        final equalZTerminal = Terminal(cols: 8, rows: 4)
+          ..kittyImageStorageLimit = 1 << 20;
+        final equalZState = PaintState(TerminalTheme.dark(), metrics)
+          ..cols = 8
+          ..rows = 4;
+        final equalZImages = KittyImageCache(onImageReady: () {});
+        final equalZPlacements = KittyPlacementCache(
+          state: equalZState,
+          images: equalZImages,
+        );
+        addTearDown(equalZImages.dispose);
+        addTearDown(equalZTerminal.dispose);
+        final payload = base64Encode([0xff, 0x00, 0x00]);
+
+        equalZTerminal.write(
+          Uint8List.fromList(
+            '\x1b_Gf=24,s=1,v=1,a=T,i=2,p=1,c=1,r=1;$payload\x1b\\'.codeUnits,
+          ),
+        );
+        equalZTerminal.write(
+          Uint8List.fromList(
+            '\x1b_Gf=24,s=1,v=1,a=T,i=11,p=1,c=1,r=1;$payload\x1b\\'.codeUnits,
+          ),
+        );
+        equalZTerminal.write(
+          Uint8List.fromList(
+            '\x1b_Gf=24,s=1,v=1,a=T,i=13,p=1,c=1,r=1;$payload\x1b\\'.codeUnits,
+          ),
+        );
+        equalZTerminal.resize(
+          cols: 8,
+          rows: 4,
+          cellWidthPx: 8,
+          cellHeightPx: 16,
+        );
+
+        equalZPlacements.sync(equalZTerminal, geometryDirty: true);
+
+        expect(equalZPlacements.snapshots.map((snapshot) => snapshot.imageId), [
+          2,
+          11,
+          13,
+        ]);
       });
     });
   });

--- a/packages/flterm/test/view/terminal_view_test.dart
+++ b/packages/flterm/test/view/terminal_view_test.dart
@@ -324,6 +324,49 @@ void main() {
       expect(rows.last, greaterThan(0));
     });
 
+    testWidgets('sizes a pinned Kitty placement during first layout', (
+      tester,
+    ) async {
+      final kittyController = TerminalController(
+        config: const TerminalConfig(cursorBlink: false),
+      );
+      addTearDown(kittyController.dispose);
+      final fontData = File(
+        'test/fixtures/fonts/JetBrainsMono-Regular.ttf',
+      ).readAsBytesSync();
+      const payload = '/wAA';
+      kittyController.write(
+        Uint8List.fromList(
+          '\x1b_Gf=24,s=1,v=1,a=T,i=1,c=1,r=1;$payload\x1b\\'.codeUnits,
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 480,
+              child: TerminalView(
+                controller: kittyController,
+                padding: EdgeInsets.zero,
+                fontData: fontData,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final nativeTerminal = terminal(kittyController);
+      final placement = KittyGraphics.of(nativeTerminal)!.placements().single;
+      final geometry = nativeTerminal.geometry;
+      expect(
+        (placement.renderInfo.pixelWidth, placement.renderInfo.pixelHeight),
+        (geometry.widthPx ~/ geometry.cols, geometry.heightPx ~/ geometry.rows),
+      );
+    });
+
     testWidgets('geometry uses the Flutter view device pixel ratio', (
       tester,
     ) async {

--- a/packages/libghostty/CHANGELOG.md
+++ b/packages/libghostty/CHANGELOG.md
@@ -19,6 +19,9 @@
   position.
 - **Exception constructors**: messages and operation context use the named
   `message` and `operation` arguments.
+- **Kitty pixel data**: `KittyImage.pixelData` is replaced by
+  `copyPixelDataInto()`, which copies into caller-owned storage and returns the
+  written byte count.
 
 ### Added
 

--- a/packages/libghostty/lib/src/api/terminal/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/api/terminal/kitty_graphics.dart
@@ -21,7 +21,10 @@ part of 'terminal.dart';
 ///   if (!placement.renderInfo.viewportVisible) continue;
 ///   final image = kitty.image(placement.imageId);
 ///   if (image == null) continue;
-///   // draw `image.pixelData` cropped to `placement.renderInfo.source*`
+///   if (image.format != KittyImageFormat.rgba) continue;
+///   final pixels = Uint8List(image.width * image.height * 4);
+///   image.copyPixelDataInto(pixels);
+///   // Draw `pixels` cropped to `placement.renderInfo.source*`
 ///   // at grid cell (renderInfo.viewportCol, renderInfo.viewportRow).
 /// }
 /// ```
@@ -124,8 +127,8 @@ final class KittyGraphics {
 /// immediately. Do not access a [KittyImage] after mutating the terminal;
 /// reacquire it through [KittyGraphics.image] first.
 ///
-/// [pixelData] is the exception: it copies the bytes into a Dart-owned
-/// [Uint8List], so the returned buffer remains valid after mutations.
+/// [copyPixelDataInto] is the exception. It copies the bytes into Dart-owned
+/// storage that remains valid after mutations.
 @immutable
 final class KittyImage {
   // The image handle points into terminal-owned storage. This strong reference
@@ -137,12 +140,12 @@ final class KittyImage {
 
   const KittyImage._(this._handle, this._owner);
 
-  /// Compression of [pixelData].
+  /// Compression of the stored pixel data.
   KittyImageCompression get compression {
     return bindings.kittyGraphics.kittyGraphicsImageGetCompression(_handle);
   }
 
-  /// Pixel format of [pixelData].
+  /// Format of the stored pixel data.
   KittyImageFormat get format {
     return bindings.kittyGraphics.kittyGraphicsImageGetFormat(_handle);
   }
@@ -169,16 +172,21 @@ final class KittyImage {
   /// Image number assigned by the protocol, or zero when unset.
   int get number => bindings.kittyGraphics.kittyGraphicsImageGetNumber(_handle);
 
-  /// Raw pixel bytes, copied into a Dart-owned buffer so the list remains
-  /// valid after subsequent terminal mutations.
-  ///
-  /// Stored images are already decoded and decompressed before they reach this
-  /// API. PNG payloads are decoded through the callback installed via
-  /// [LibGhostty.setPngDecoder] and exposed here as RGBA.
-  Uint8List get pixelData {
-    return bindings.kittyGraphics.kittyGraphicsImageGetPixelData(_handle);
-  }
-
   /// Image width in pixels.
   int get width => bindings.kittyGraphics.kittyGraphicsImageGetWidth(_handle);
+
+  /// Copies the raw pixel bytes into [destination] and returns the byte count.
+  ///
+  /// Stored images are already decoded and decompressed. PNG payloads are
+  /// decoded through the callback installed via [LibGhostty.setPngDecoder]
+  /// and copied as RGBA. The destination must be large enough for the complete
+  /// payload; otherwise a [RangeError] is thrown. The copy completes
+  /// synchronously, so the written bytes remain valid after subsequent
+  /// terminal mutations.
+  int copyPixelDataInto(Uint8List destination) {
+    return bindings.kittyGraphics.kittyGraphicsImageGetPixelData(
+      _handle,
+      destination,
+    );
+  }
 }

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/ffi.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/ffi.dart
@@ -106,24 +106,21 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
       _imageGetU32(image, .number);
 
   @override
-  Uint8List kittyGraphicsImageGetPixelData(LibGhosttyHandle image) {
-    if (image.value == 0) checkResultCode(Result.invalidValue.value);
-    _setImageMulti([.dataPtr, .dataLen]);
-    final result = ghostty_kitty_graphics_image_get_multi(
-      Pointer.fromAddress(image.value),
-      2,
-      _keys,
-      _values,
-      _written,
-    );
-    checkResultCode(
-      result.value,
-      operation: 'ghostty_kitty_graphics_image_get_multi',
-    );
-    final pointer = (_multi + 0).cast<Pointer<Uint8>>().value;
-    final length = (_multi + 1).cast<Size>().value;
-    if (pointer == nullptr || length == 0) return Uint8List(0);
-    return Uint8List.fromList(pointer.asTypedList(length));
+  int kittyGraphicsImageGetPixelData(
+    LibGhosttyHandle image,
+    Uint8List destination,
+  ) {
+    final source = _imagePixelDataView(image);
+    if (destination.length < source.length) {
+      throw RangeError.range(
+        destination.length,
+        source.length,
+        null,
+        'destination.length',
+      );
+    }
+    destination.setRange(0, source.length, source);
+    return source.length;
   }
 
   @override
@@ -327,6 +324,26 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
       );
       return out.value;
     });
+  }
+
+  Uint8List _imagePixelDataView(LibGhosttyHandle image) {
+    if (image.value == 0) checkResultCode(Result.invalidValue.value);
+    _setImageMulti([.dataPtr, .dataLen]);
+    final result = ghostty_kitty_graphics_image_get_multi(
+      Pointer.fromAddress(image.value),
+      2,
+      _keys,
+      _values,
+      _written,
+    );
+    checkResultCode(
+      result.value,
+      operation: 'ghostty_kitty_graphics_image_get_multi',
+    );
+    final pointer = (_multi + 0).cast<Pointer<Uint8>>().value;
+    final length = (_multi + 1).cast<Size>().value;
+    if (pointer == nullptr || length == 0) return Uint8List(0);
+    return pointer.asTypedList(length);
   }
 
   void _setImageMulti(List<KittyGraphicsImageData> keys) {

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/kitty_graphics.dart
@@ -21,7 +21,10 @@ abstract interface class KittyGraphicsBindings {
   int kittyGraphicsImageGetHeight(LibGhosttyHandle image);
   int kittyGraphicsImageGetId(LibGhosttyHandle image);
   int kittyGraphicsImageGetNumber(LibGhosttyHandle image);
-  Uint8List kittyGraphicsImageGetPixelData(LibGhosttyHandle image);
+  int kittyGraphicsImageGetPixelData(
+    LibGhosttyHandle image,
+    Uint8List destination,
+  );
   int kittyGraphicsImageGetWidth(LibGhosttyHandle image);
 
   KittyPlacement kittyGraphicsPlacementGet(

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/wasm.dart
@@ -141,23 +141,21 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
       _imageGetU32(image, .number);
 
   @override
-  Uint8List kittyGraphicsImageGetPixelData(LibGhosttyHandle image) {
-    if (image.value == 0) throw const InvalidValueException();
-    _setImageMulti([.dataPtr, .dataLen]);
-    final result = Result.fromValue(
-      _exports.ghostty_kitty_graphics_image_get_multi(
-        image.value,
-        2,
-        _keys,
-        _values,
-        _written,
-      ),
-    );
-    checkCode(result, operation: 'ghostty_kitty_graphics_image_get_multi');
-    final pointer = _memory.readPtr(_multi);
-    final length = _memory.readU32(_multi + _wasmOutputSlotSize);
-    if (pointer == 0 || length == 0) return Uint8List(0);
-    return Uint8List.fromList(_memory.readBytes(pointer, length));
+  int kittyGraphicsImageGetPixelData(
+    LibGhosttyHandle image,
+    Uint8List destination,
+  ) {
+    final source = _imagePixelDataView(image);
+    if (destination.length < source.length) {
+      throw RangeError.range(
+        destination.length,
+        source.length,
+        null,
+        'destination.length',
+      );
+    }
+    destination.setRange(0, source.length, source);
+    return source.length;
   }
 
   @override
@@ -372,6 +370,25 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
     } finally {
       frame.release();
     }
+  }
+
+  Uint8List _imagePixelDataView(LibGhosttyHandle image) {
+    if (image.value == 0) throw const InvalidValueException();
+    _setImageMulti([.dataPtr, .dataLen]);
+    final result = Result.fromValue(
+      _exports.ghostty_kitty_graphics_image_get_multi(
+        image.value,
+        2,
+        _keys,
+        _values,
+        _written,
+      ),
+    );
+    checkCode(result, operation: 'ghostty_kitty_graphics_image_get_multi');
+    final pointer = _memory.readPtr(_multi);
+    final length = _memory.readU32(_multi + _wasmOutputSlotSize);
+    if (pointer == 0 || length == 0) return Uint8List(0);
+    return _memory.readBytes(pointer, length);
   }
 
   int _require(int pointer) {

--- a/packages/libghostty/test/api/terminal/kitty_graphics_test.dart
+++ b/packages/libghostty/test/api/terminal/kitty_graphics_test.dart
@@ -1,6 +1,7 @@
 @Tags(['ffi'])
 library;
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:libghostty/libghostty.dart';
@@ -44,14 +45,44 @@ void main() {
           expect(image.format, KittyImageFormat.rgb);
         });
 
-        test('returns decoded RGB bytes', () {
+        test('copies decoded RGB bytes', () {
           terminal.write(_transmitRedPixel(id: 7));
+          final destination = Uint8List(3);
 
           final image = KittyGraphics.of(terminal)!.image(7)!;
-          expect(
-            image.pixelData,
-            equals(Uint8List.fromList([0xff, 0x00, 0x00])),
-          );
+          image.copyPixelDataInto(destination);
+
+          expect(destination, [0xff, 0x00, 0x00]);
+        });
+
+        test('returns the copied RGB byte count', () {
+          terminal.write(_transmitRedPixel(id: 8));
+          final destination = Uint8List.fromList([1, 1, 1, 1]);
+
+          final written = KittyGraphics.of(
+            terminal,
+          )!.image(8)!.copyPixelDataInto(destination);
+
+          expect(written, 3);
+        });
+
+        test('keeps copied RGB bytes stable after terminal mutation', () {
+          terminal.write(_transmitRedPixel(id: 8));
+          final destination = Uint8List(3);
+          KittyGraphics.of(terminal)!.image(8)!.copyPixelDataInto(destination);
+
+          terminal.write(_transmitRedPixel(id: 9));
+
+          expect(destination, [0xff, 0x00, 0x00]);
+        });
+
+        test('rejects insufficient pixel destination storage', () {
+          terminal.write(_transmitRedPixel(id: 9));
+          final image = KittyGraphics.of(terminal)!.image(9)!;
+          final destination = Uint8List.fromList([1, 2]);
+
+          expect(() => image.copyPixelDataInto(destination), throwsRangeError);
+          expect(destination, [1, 2]);
         });
       });
 
@@ -139,7 +170,7 @@ void main() {
         expect(image!.width, 2);
         expect(image.height, 1);
         expect(image.format, KittyImageFormat.rgba);
-        expect(image.pixelData, hasLength(8));
+        expect(image.copyPixelDataInto(Uint8List(8)), 8);
       });
 
       test('rejects payload when callback returns null', () {
@@ -150,6 +181,54 @@ void main() {
         );
 
         expect(KittyGraphics.of(terminal)!.image(56), isNull);
+      });
+
+      test('rejects payload when callback throws', () {
+        LibGhostty.setPngDecoder((_) {
+          throw StateError('decoder failed');
+        });
+
+        terminal.write(
+          Uint8List.fromList('\x1b_Gf=100,a=t,i=58;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(KittyGraphics.of(terminal)!.image(58), isNull);
+      });
+
+      test('rejects payload when callback returns short RGBA data', () {
+        LibGhostty.setPngDecoder(
+          (_) => DecodedImage(width: 1, height: 1, rgba: Uint8List(3)),
+        );
+
+        terminal.write(
+          Uint8List.fromList('\x1b_Gf=100,a=t,i=59;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(KittyGraphics.of(terminal)!.image(59), isNull);
+      });
+
+      test('rejects payload when callback returns oversized RGBA data', () {
+        LibGhostty.setPngDecoder(
+          (_) => DecodedImage(width: 1, height: 1, rgba: Uint8List(5)),
+        );
+
+        terminal.write(
+          Uint8List.fromList('\x1b_Gf=100,a=t,i=60;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(KittyGraphics.of(terminal)!.image(60), isNull);
+      });
+
+      test('rejects payload with mismatched dimensions', () {
+        LibGhostty.setPngDecoder(
+          (_) => DecodedImage(width: 2, height: 1, rgba: Uint8List(4)),
+        );
+
+        terminal.write(
+          Uint8List.fromList('\x1b_Gf=100,a=t,i=61;aGVsbG8=\x1b\\'.codeUnits),
+        );
+
+        expect(KittyGraphics.of(terminal)!.image(61), isNull);
       });
 
       test('clearPngDecoder stops routing to callback', () {
@@ -206,6 +285,116 @@ void main() {
         expect(p.renderInfo.sourceWidth, 1);
         expect(p.renderInfo.sourceHeight, 1);
       });
+
+      test('keeps a placement snapshot stable after terminal mutation', () {
+        terminal.resize(cols: 80, rows: 24, cellWidthPx: 10, cellHeightPx: 20);
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b_Gf=24,s=1,v=1,a=T,i=12,c=2,r=1;/wAA\x1b\\'.codeUnits,
+          ),
+        );
+        final placement = KittyGraphics.of(terminal)!.placements().single;
+        final snapshot = (
+          imageId: placement.imageId,
+          placementId: placement.placementId,
+          isVirtual: placement.isVirtual,
+          xOffset: placement.xOffset,
+          yOffset: placement.yOffset,
+          sourceX: placement.sourceX,
+          sourceY: placement.sourceY,
+          sourceWidth: placement.sourceWidth,
+          sourceHeight: placement.sourceHeight,
+          columns: placement.columns,
+          rows: placement.rows,
+          z: placement.z,
+          renderInfo: placement.renderInfo,
+        );
+
+        terminal.resize(cols: 80, rows: 24, cellWidthPx: 20, cellHeightPx: 40);
+
+        expect((
+          imageId: placement.imageId,
+          placementId: placement.placementId,
+          isVirtual: placement.isVirtual,
+          xOffset: placement.xOffset,
+          yOffset: placement.yOffset,
+          sourceX: placement.sourceX,
+          sourceY: placement.sourceY,
+          sourceWidth: placement.sourceWidth,
+          sourceHeight: placement.sourceHeight,
+          columns: placement.columns,
+          rows: placement.rows,
+          z: placement.z,
+          renderInfo: placement.renderInfo,
+        ), snapshot);
+      });
+
+      test(
+        'reports a negative viewport row for a partially scrolled placement',
+        () {
+          final scrolled = Terminal(cols: 80, rows: 5);
+          addTearDown(scrolled.dispose);
+          scrolled.kittyImageStorageLimit = 1 << 20;
+          scrolled.resize(cols: 80, rows: 5, cellWidthPx: 10, cellHeightPx: 20);
+          scrolled.write(
+            Uint8List.fromList(
+              '\x1b_Ga=t,t=d,f=24,i=13,s=1,v=2;////////\x1b\\'
+                      '\x1b_Ga=p,i=13,p=1,c=1,r=4,C=1;\x1b\\'
+                  .codeUnits,
+            ),
+          );
+          scrolled.write(Uint8List.fromList('\n\n\n\n\n\n'.codeUnits));
+
+          final placement = KittyGraphics.of(scrolled)!.placements().single;
+
+          expect(
+            (
+              placement.renderInfo.viewportVisible,
+              placement.renderInfo.viewportRow,
+            ),
+            (true, -2),
+          );
+        },
+      );
+
+      test(
+        'preserves stretched destination for an oversized source request',
+        () {
+          terminal.resize(
+            cols: 80,
+            rows: 24,
+            cellWidthPx: 10,
+            cellHeightPx: 20,
+          );
+          final payload = base64Encode(Uint8List(64));
+          terminal.write(
+            Uint8List.fromList(
+              '\x1b_Ga=t,t=d,f=32,i=14,s=4,v=4;$payload\x1b\\'.codeUnits,
+            ),
+          );
+          terminal.write(
+            Uint8List.fromList(
+              '\x1b_Ga=p,i=14,p=1,x=3,y=3,w=10,h=10;\x1b\\'.codeUnits,
+            ),
+          );
+
+          final renderInfo = KittyGraphics.of(
+            terminal,
+          )!.placements().single.renderInfo;
+
+          expect(
+            (
+              renderInfo.pixelWidth,
+              renderInfo.pixelHeight,
+              renderInfo.sourceX,
+              renderInfo.sourceY,
+              renderInfo.sourceWidth,
+              renderInfo.sourceHeight,
+            ),
+            (10, 10, 3, 3, 1, 1),
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Stabilize flterm’s Kitty graphics rendering by retaining ready images across unchanged frames and replacements, bounding and deduplicating asynchronous decode work, reusing pixel storage, and refreshing placement geometry when terminal dimensions change. This also replaces the allocating Kitty image pixel getter with a destination-required copy API across the native and Wasm libghostty bindings, with focused coverage for image lifetime, decode failure and backpressure, placement snapshots, resizing, and rendering behavior.

Supersedes #107