### PR TITLE
feat(flterm): render Kitty Unicode placements

### DIFF
--- a/packages/flterm/lib/src/rendering/cell_content_resolver.dart
+++ b/packages/flterm/lib/src/rendering/cell_content_resolver.dart
@@ -9,6 +9,8 @@ import 'codepoint_classification.dart';
 /// row rendering and block cursor glyph rendering. It does not decide where
 /// or how the entry is painted; row and cursor builders own the output lane.
 final class CellContentResolver {
+  static const _kittyUnicodePlaceholder = 0x10EEEE;
+
   final Atlas _atlas;
   var _lastCodepoint = -1;
   var _lastSpan = 0;
@@ -29,6 +31,7 @@ final class CellContentResolver {
     if (graphemeLength == 0) return null;
 
     final codepoint = cell.codepoint;
+    if (codepoint == _kittyUnicodePlaceholder) return null;
     if (borrowedCell && graphemeLength == 1) {
       return resolveCodepoint(
         codepoint,
@@ -68,6 +71,7 @@ final class CellContentResolver {
     required int span,
   }) {
     if (content.isEmpty) return null;
+    if (codepoint == _kittyUnicodePlaceholder) return null;
 
     if (_usesCodepointEntry(
       codepoint: codepoint,

--- a/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
+++ b/packages/flterm/lib/src/rendering/kitty_placement_cache.dart
@@ -54,8 +54,13 @@ final class KittyPlacementCache {
     final nextSnapshots = <KittyPlacementSnapshot>[];
     final nextLiveImageIds = <int>{};
     var replacementPending = false;
+    var hasVirtualPlacements = false;
     for (final placement in graphics.placements()) {
       nextLiveImageIds.add(placement.imageId);
+      if (placement.isVirtual) {
+        hasVirtualPlacements = true;
+        continue;
+      }
 
       final info = placement.renderInfo;
       if (!info.viewportVisible) continue;
@@ -88,6 +93,50 @@ final class KittyPlacementCache {
             info.sourceHeight.toDouble(),
           ),
           z: placement.z,
+          paintOrder: nextSnapshots.length,
+        ),
+      );
+    }
+
+    final unicodePlacements = hasVirtualPlacements
+        ? graphics.unicodePlacements()
+        : const <KittyUnicodePlacement>[];
+    for (final placement in unicodePlacements) {
+      nextLiveImageIds.add(placement.imageId);
+
+      final info = placement.renderInfo;
+      if (info == null || info.pixelWidth == 0 || info.pixelHeight == 0) {
+        continue;
+      }
+
+      final image = graphics.image(placement.imageId);
+      if (image == null) continue;
+
+      final imageGeneration = image.generation;
+      final entry = _images.lookup(image, generation: imageGeneration);
+      replacementPending |=
+          entry is KittyImagePending ||
+          (entry is KittyImageReady && entry.generation != imageGeneration);
+      nextSnapshots.add(
+        KittyPlacementSnapshot(
+          imageId: placement.imageId,
+          imageGeneration: imageGeneration,
+          dst: Rect.fromLTWH(
+            info.viewportCol * key.cellWidth +
+                info.cellOffsetX / key.devicePixelRatio,
+            info.viewportRow * key.cellHeight +
+                info.cellOffsetY / key.devicePixelRatio,
+            info.pixelWidth / key.devicePixelRatio,
+            info.pixelHeight / key.devicePixelRatio,
+          ),
+          src: Rect.fromLTWH(
+            info.sourceX.toDouble(),
+            info.sourceY.toDouble(),
+            info.sourceWidth.toDouble(),
+            info.sourceHeight.toDouble(),
+          ),
+          z: info.z,
+          paintOrder: nextSnapshots.length,
         ),
       );
     }
@@ -143,7 +192,9 @@ final class KittyPlacementCache {
 
   static int _compareZ(KittyPlacementSnapshot a, KittyPlacementSnapshot b) {
     final z = a.z.compareTo(b.z);
-    return z != 0 ? z : a.imageId.compareTo(b.imageId);
+    if (z != 0) return z;
+    final imageId = a.imageId.compareTo(b.imageId);
+    return imageId != 0 ? imageId : a._paintOrder.compareTo(b._paintOrder);
   }
 }
 
@@ -169,12 +220,15 @@ final class KittyPlacementSnapshot {
   /// Signed z-index from the Kitty graphics protocol.
   final int z;
 
+  final int _paintOrder;
+
   const KittyPlacementSnapshot({
     required this.imageId,
     this.imageGeneration = 0,
     required this.dst,
     required this.src,
     required this.z,
+    this._paintOrder = 0,
   });
 }
 

--- a/packages/flterm/test/rendering/cell_content_resolver_test.dart
+++ b/packages/flterm/test/rendering/cell_content_resolver_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:ui';
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
@@ -39,6 +40,39 @@ void main() {
         style: const Style(),
         span: 1,
       );
+
+      expect(entry, isNull);
+    });
+
+    test('returns null for Kitty Unicode placeholders', () {
+      final entry = resolver.resolve(
+        content: '\u{10EEEE}\u0305\u0305',
+        codepoint: 0x10EEEE,
+        graphemeLength: 3,
+        style: const Style(),
+        span: 1,
+      );
+
+      expect(entry, isNull);
+    });
+
+    test('returns null for a terminal cell containing a Kitty placeholder', () {
+      final terminal = Terminal(cols: 1, rows: 1);
+      addTearDown(terminal.dispose);
+      terminal.write(utf8.encode('\u{10EEEE}\u0305\u0305'));
+      final renderState = RenderState();
+      addTearDown(renderState.dispose);
+      final rows = RowIterator();
+      addTearDown(rows.dispose);
+      final cells = CellIterator();
+      addTearDown(cells.dispose);
+      renderState.update(terminal);
+      rows.reset(renderState);
+      rows.next();
+      cells.reset(rows);
+      cells.next();
+
+      final entry = resolver.resolveCell(cells, style: cells.style, span: 1);
 
       expect(entry, isNull);
     });

--- a/packages/flterm/test/rendering/kitty_placement_cache_test.dart
+++ b/packages/flterm/test/rendering/kitty_placement_cache_test.dart
@@ -4,7 +4,8 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
-import 'dart:ui' show Image, ImageDecoderCallback, Size, decodeImageFromPixels;
+import 'dart:ui'
+    show Image, ImageDecoderCallback, Rect, Size, decodeImageFromPixels;
 
 import 'package:flterm/src/foundation/cell_metrics.dart';
 import 'package:flterm/src/foundation/terminal_theme.dart';
@@ -34,6 +35,24 @@ void main() {
           '\x1b_Gf=24,s=$width,v=1,a=T,i=$id$placement,c=$columns,r=1;'
                   '$payload\x1b\\'
               .codeUnits,
+        ),
+      );
+    }
+
+    void writeUnicodePlacements(Terminal terminal) {
+      final pixels = base64Encode([0xff, 0x00, 0x00]);
+      terminal.write(
+        Uint8List.fromList(
+          utf8.encode(
+            '\x1b_Ga=T,t=d,f=24,i=23,s=1,v=1,C=1,U=1;'
+            '$pixels\x1b\\'
+            '\x1b[2;4H'
+            '\x1b[38;2;0;0;23m'
+            '\u{10EEEE}\u0305\u0305'
+            'x'
+            '\u{10EEEE}\u0305\u0305'
+            '\x1b[39m',
+          ),
         ),
       );
     }
@@ -103,6 +122,43 @@ void main() {
     });
 
     group('sync', () {
+      test(
+        'renders discontinuous Unicode placements away from their definition',
+        () {
+          final unicodeTerminal = Terminal(cols: 8, rows: 3)
+            ..kittyImageStorageLimit = 1 << 20;
+          final unicodeState = PaintState(TerminalTheme.dark(), metrics)
+            ..cols = 8
+            ..rows = 3;
+          final unicodeImages = KittyImageCache(onImageReady: () {});
+          final unicodePlacements = KittyPlacementCache(
+            state: unicodeState,
+            images: unicodeImages,
+          );
+          addTearDown(unicodeImages.dispose);
+          addTearDown(unicodeTerminal.dispose);
+          unicodeTerminal.resize(
+            cols: 8,
+            rows: 3,
+            cellWidthPx: 8,
+            cellHeightPx: 16,
+          );
+          writeUnicodePlacements(unicodeTerminal);
+
+          unicodePlacements.sync(unicodeTerminal, geometryDirty: true);
+
+          expect(unicodePlacements.snapshots, hasLength(2));
+          expect(unicodePlacements.snapshots.map((snapshot) => snapshot.dst), [
+            const Rect.fromLTWH(24, 20, 8, 8),
+            const Rect.fromLTWH(40, 20, 8, 8),
+          ]);
+          expect(unicodePlacements.snapshots.map((snapshot) => snapshot.src), [
+            const Rect.fromLTWH(0, 0, 1, 1),
+            const Rect.fromLTWH(0, 0, 1, 1),
+          ]);
+        },
+      );
+
       test('returns false when generation and geometry are unchanged', () {
         final rebuilt = placements.sync(terminal, geometryDirty: false);
 

--- a/packages/libghostty/lib/libghostty.dart
+++ b/packages/libghostty/lib/libghostty.dart
@@ -123,6 +123,8 @@ export 'src/types/types.dart'
         IoException,
         KittyPlacement,
         KittyPlacementRenderInfo,
+        KittyUnicodePlacement,
+        KittyUnicodePlacementRenderInfo,
         LibGhosttyException,
         LimitExceededException,
         MouseEncoderSize,

--- a/packages/libghostty/lib/src/api/terminal/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/api/terminal/kitty_graphics.dart
@@ -107,6 +107,66 @@ final class KittyGraphics {
     }
   }
 
+  /// Snapshots decoded Kitty Unicode placeholder occurrences in the active
+  /// viewport.
+  ///
+  /// Occurrences are returned as row-major, single-row runs, including runs
+  /// whose image or virtual definition is unavailable. The returned values are
+  /// copied and remain stable after terminal mutations.
+  /// [KittyUnicodePlacement.renderInfo] is null for an unresolved or otherwise
+  /// non-drawable run. Image ids can be resolved through [image] while the
+  /// corresponding image remains stored.
+  ///
+  /// ```dart
+  /// for (final placement in kitty.unicodePlacements()) {
+  ///   final geometry = placement.renderInfo;
+  ///   if (geometry == null) continue;
+  ///   // Draw `placement.imageId` using `geometry`.
+  /// }
+  /// ```
+  List<KittyUnicodePlacement> unicodePlacements() {
+    final iterator = bindings.kittyGraphics
+        .kittyGraphicsUnicodePlacementIteratorNew();
+    try {
+      bindings.kittyGraphics.terminalGetKittyGraphicsUnicodePlacementIterator(
+        _terminal._terminalHandle,
+        iterator,
+      );
+      final out = <KittyUnicodePlacement>[];
+      while (bindings.kittyGraphics.kittyGraphicsUnicodePlacementNext(
+        iterator,
+      )) {
+        final raw = bindings.kittyGraphics.kittyGraphicsUnicodePlacementGet(
+          iterator,
+          _terminal._terminalHandle,
+        );
+        final topLeft = bindings.render.terminalPointFromGridRef(
+          _terminal._terminalHandle,
+          raw.topLeft,
+          .viewport,
+        );
+        if (topLeft == null) throw const InvalidValueException();
+        out.add(
+          KittyUnicodePlacement(
+            topLeft: topLeft,
+            imageId: raw.imageId,
+            placementId: raw.placementId,
+            column: raw.column,
+            row: raw.row,
+            columns: raw.columns,
+            rows: raw.rows,
+            renderInfo: raw.renderInfo,
+          ),
+        );
+      }
+      return out;
+    } finally {
+      bindings.kittyGraphics.kittyGraphicsUnicodePlacementIteratorFree(
+        iterator,
+      );
+    }
+  }
+
   /// Returns the Kitty graphics image storage for [terminal]'s active
   /// screen, or null when Kitty graphics are disabled in the native
   /// library build.

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/ffi.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/ffi.dart
@@ -14,6 +14,7 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
   final _keys = calloc<UnsignedInt>(12);
   final _values = calloc<Pointer<Void>>(12);
   final _multi = calloc<Uint64>(12);
+  final _multiGridRef = calloc<GridRef>();
   final _written = calloc<Size>();
 
   FfiKittyGraphicsBindings();
@@ -241,6 +242,103 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
     );
   }
 
+  @override
+  void terminalGetKittyGraphicsUnicodePlacementIterator(
+    LibGhosttyHandle terminal,
+    LibGhosttyHandle iterator,
+  ) {
+    if (terminal.value == 0 || iterator.value == 0) {
+      checkResultCode(Result.invalidValue.value);
+    }
+    return using((arena) {
+      final out = arena<KittyGraphicsUnicodePlacementIterator>()
+        ..value = Pointer.fromAddress(iterator.value);
+      final result = ghostty_terminal_get(
+        Pointer.fromAddress(terminal.value),
+        .kittyGraphicsUnicodePlacementIterator,
+        out.cast(),
+      );
+      checkResultCode(result.value, operation: 'ghostty_terminal_get');
+    });
+  }
+
+  @override
+  RawKittyUnicodePlacement kittyGraphicsUnicodePlacementGet(
+    LibGhosttyHandle iterator,
+    LibGhosttyHandle terminal,
+  ) {
+    if (iterator.value == 0 || terminal.value == 0) {
+      checkResultCode(Result.invalidValue.value);
+    }
+    _setUnicodePlacementMulti([
+      .topLeft,
+      .imageId,
+      .placementId,
+      .column,
+      .row,
+      .columns,
+      .rows,
+    ]);
+    final result = ghostty_kitty_graphics_unicode_placement_get_multi(
+      Pointer.fromAddress(iterator.value),
+      7,
+      _keys,
+      _values,
+      _written,
+    );
+    checkResultCode(
+      result.value,
+      operation: 'ghostty_kitty_graphics_unicode_placement_get_multi',
+    );
+    final renderInfo = kittyGraphicsUnicodePlacementRenderInfo(
+      iterator,
+      terminal,
+    );
+    int u32(int index) => (_multi + index).cast<Uint32>().value;
+    return (
+      topLeft: _readGridRef(_multiGridRef.ref),
+      imageId: u32(1),
+      placementId: u32(2),
+      column: u32(3),
+      row: u32(4),
+      columns: u32(5),
+      rows: u32(6),
+      renderInfo: renderInfo,
+    );
+  }
+
+  @override
+  void kittyGraphicsUnicodePlacementIteratorFree(LibGhosttyHandle iterator) {
+    if (iterator.value == 0) return;
+    ghostty_kitty_graphics_unicode_placement_iterator_free(
+      Pointer.fromAddress(iterator.value),
+    );
+  }
+
+  @override
+  LibGhosttyHandle kittyGraphicsUnicodePlacementIteratorNew() {
+    return using((arena) {
+      final out = arena<Pointer<KittyGraphicsUnicodePlacementIteratorImpl>>();
+      final code = ghostty_kitty_graphics_unicode_placement_iterator_new(
+        nullptr,
+        out,
+      );
+      checkRequiredCode(
+        code.value,
+        operation: 'ghostty_kitty_graphics_unicode_placement_iterator_new',
+      );
+      return .fromAddress(out.value.address);
+    });
+  }
+
+  @override
+  bool kittyGraphicsUnicodePlacementNext(LibGhosttyHandle iterator) {
+    if (iterator.value == 0) return false;
+    return ghostty_kitty_graphics_unicode_placement_next(
+      Pointer.fromAddress(iterator.value),
+    );
+  }
+
   KittyPlacementRenderInfo? kittyGraphicsPlacementRenderInfo(
     LibGhosttyHandle iterator,
     LibGhosttyHandle image,
@@ -284,6 +382,55 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
         viewportCol: out.ref.viewport_col,
         viewportRow: out.ref.viewport_row,
         viewportVisible: out.ref.viewport_visible,
+        sourceX: out.ref.source_x,
+        sourceY: out.ref.source_y,
+        sourceWidth: out.ref.source_width,
+        sourceHeight: out.ref.source_height,
+      );
+    });
+  }
+
+  KittyUnicodePlacementRenderInfo? kittyGraphicsUnicodePlacementRenderInfo(
+    LibGhosttyHandle iterator,
+    LibGhosttyHandle terminal,
+  ) {
+    if (iterator.value == 0 || terminal.value == 0) {
+      checkResultCode(Result.invalidValue.value);
+    }
+    return using((arena) {
+      final out = KittyGraphicsUnicodePlacementRenderInfo.$allocate(
+        arena,
+        size: sizeOf<KittyGraphicsUnicodePlacementRenderInfo>(),
+        viewport_col: 0,
+        viewport_row: 0,
+        z: -1,
+        cell_offset_x: 0,
+        cell_offset_y: 0,
+        pixel_width: 0,
+        pixel_height: 0,
+        source_x: 0,
+        source_y: 0,
+        source_width: 0,
+        source_height: 0,
+      );
+      final result = ghostty_kitty_graphics_unicode_placement_render_info(
+        Pointer.fromAddress(iterator.value),
+        Pointer.fromAddress(terminal.value),
+        out,
+      );
+      if (result == .noValue) return null;
+      checkResultCode(
+        result.value,
+        operation: 'ghostty_kitty_graphics_unicode_placement_render_info',
+      );
+      return KittyUnicodePlacementRenderInfo(
+        viewportCol: out.ref.viewport_col,
+        viewportRow: out.ref.viewport_row,
+        z: out.ref.z,
+        cellOffsetX: out.ref.cell_offset_x,
+        cellOffsetY: out.ref.cell_offset_y,
+        pixelWidth: out.ref.pixel_width,
+        pixelHeight: out.ref.pixel_height,
         sourceX: out.ref.source_x,
         sourceY: out.ref.source_y,
         sourceWidth: out.ref.source_width,
@@ -359,4 +506,17 @@ final class FfiKittyGraphicsBindings implements KittyGraphicsBindings {
       _values[i] = (_multi + i).cast();
     }
   }
+
+  void _setUnicodePlacementMulti(List<KittyGraphicsUnicodePlacementData> keys) {
+    _multiGridRef.ref.size = sizeOf<GridRef>();
+    for (var i = 0; i < keys.length; i++) {
+      _keys[i] = keys[i].value;
+      _values[i] = keys[i] == .topLeft
+          ? _multiGridRef.cast()
+          : (_multi + i).cast();
+    }
+  }
+
+  static RawGridRef _readGridRef(GridRef ref) =>
+      (node: ref.node.address, x: ref.x, y: ref.y);
 }

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/kitty_graphics.dart
@@ -39,4 +39,16 @@ abstract interface class KittyGraphicsBindings {
     KittyPlacementLayer layer,
   );
   bool kittyGraphicsPlacementNext(LibGhosttyHandle iterator);
+
+  void terminalGetKittyGraphicsUnicodePlacementIterator(
+    LibGhosttyHandle terminal,
+    LibGhosttyHandle iterator,
+  );
+  RawKittyUnicodePlacement kittyGraphicsUnicodePlacementGet(
+    LibGhosttyHandle iterator,
+    LibGhosttyHandle terminal,
+  );
+  void kittyGraphicsUnicodePlacementIteratorFree(LibGhosttyHandle iterator);
+  LibGhosttyHandle kittyGraphicsUnicodePlacementIteratorNew();
+  bool kittyGraphicsUnicodePlacementNext(LibGhosttyHandle iterator);
 }

--- a/packages/libghostty/lib/src/bindings/kitty_graphics/wasm.dart
+++ b/packages/libghostty/lib/src/bindings/kitty_graphics/wasm.dart
@@ -20,6 +20,7 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
   late final int _keys;
   late final int _values;
   late final int _multi;
+  late final int _multiGridRef;
   late final int _written;
 
   WasmKittyGraphicsBindings(this._exports, this._layout)
@@ -31,6 +32,10 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
     _keys = _allocate(12 * 4, alignment: 4);
     _values = _allocate(12 * 4, alignment: 4);
     _multi = _allocate(12 * _wasmOutputSlotSize, alignment: 8);
+    _multiGridRef = _allocate(
+      _layout.gridRefSize,
+      alignment: wasm32PointerSize,
+    );
     _written = _allocate(4, alignment: 4);
   }
 
@@ -282,6 +287,121 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
     return _exports.ghostty_kitty_graphics_placement_next(iterator.value) != 0;
   }
 
+  @override
+  void terminalGetKittyGraphicsUnicodePlacementIterator(
+    LibGhosttyHandle terminal,
+    LibGhosttyHandle iterator,
+  ) {
+    if (terminal.value == 0 || iterator.value == 0) {
+      throw const InvalidValueException();
+    }
+    final frame = _scratch.acquire(const []);
+    try {
+      final out = frame.variableAddress(
+        0,
+        wasm32PointerSize,
+        alignment: wasm32PointerSize,
+      );
+      _memory.writeU32(out, iterator.value);
+      final result = Result.fromValue(
+        _exports.ghostty_terminal_get(
+          terminal.value,
+          TerminalData.kittyGraphicsUnicodePlacementIterator.value,
+          out,
+        ),
+      );
+      checkCode(result, operation: 'ghostty_terminal_get');
+    } finally {
+      frame.release();
+    }
+  }
+
+  @override
+  RawKittyUnicodePlacement kittyGraphicsUnicodePlacementGet(
+    LibGhosttyHandle iterator,
+    LibGhosttyHandle terminal,
+  ) {
+    if (iterator.value == 0 || terminal.value == 0) {
+      throw const InvalidValueException();
+    }
+    _setUnicodePlacementMulti([
+      .topLeft,
+      .imageId,
+      .placementId,
+      .column,
+      .row,
+      .columns,
+      .rows,
+    ]);
+    final result = Result.fromValue(
+      _exports.ghostty_kitty_graphics_unicode_placement_get_multi(
+        iterator.value,
+        7,
+        _keys,
+        _values,
+        _written,
+      ),
+    );
+    checkCode(
+      result,
+      operation: 'ghostty_kitty_graphics_unicode_placement_get_multi',
+    );
+    final renderInfo = kittyGraphicsUnicodePlacementRenderInfo(
+      iterator,
+      terminal,
+    );
+    int u32(int index) => _memory.readU32(_multi + index * _wasmOutputSlotSize);
+    return (
+      topLeft: _readGridRef(_multiGridRef),
+      imageId: u32(1),
+      placementId: u32(2),
+      column: u32(3),
+      row: u32(4),
+      columns: u32(5),
+      rows: u32(6),
+      renderInfo: renderInfo,
+    );
+  }
+
+  @override
+  void kittyGraphicsUnicodePlacementIteratorFree(LibGhosttyHandle iterator) {
+    if (iterator.value == 0) return;
+    _exports.ghostty_kitty_graphics_unicode_placement_iterator_free(
+      iterator.value,
+    );
+  }
+
+  @override
+  LibGhosttyHandle kittyGraphicsUnicodePlacementIteratorNew() {
+    final frame = _scratch.acquire(const []);
+    try {
+      final out = frame.variableAddress(
+        0,
+        wasm32PointerSize,
+        alignment: wasm32PointerSize,
+      );
+      final result = Result.fromValue(
+        _exports.ghostty_kitty_graphics_unicode_placement_iterator_new(0, out),
+      );
+      checkCode(
+        result,
+        operation: 'ghostty_kitty_graphics_unicode_placement_iterator_new',
+      );
+      return .fromAddress(_exports.ghostty_wasm_take_opaque(out));
+    } finally {
+      frame.release();
+    }
+  }
+
+  @override
+  bool kittyGraphicsUnicodePlacementNext(LibGhosttyHandle iterator) {
+    if (iterator.value == 0) return false;
+    return _exports.ghostty_kitty_graphics_unicode_placement_next(
+          iterator.value,
+        ) !=
+        0;
+  }
+
   KittyPlacementRenderInfo? kittyGraphicsPlacementRenderInfo(
     LibGhosttyHandle iterator,
     LibGhosttyHandle image,
@@ -322,6 +442,64 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
         sourceWidth: _memory.readU32(out + _layout.kittyRenderInfoSourceWidth),
         sourceHeight: _memory.readU32(
           out + _layout.kittyRenderInfoSourceHeight,
+        ),
+      );
+    } finally {
+      frame.release();
+    }
+  }
+
+  KittyUnicodePlacementRenderInfo? kittyGraphicsUnicodePlacementRenderInfo(
+    LibGhosttyHandle iterator,
+    LibGhosttyHandle terminal,
+  ) {
+    if (iterator.value == 0 || terminal.value == 0) {
+      throw const InvalidValueException();
+    }
+    final size = _layout.kittyUnicodeRenderInfoSize;
+    final frame = _scratch.acquire(const []);
+    try {
+      final out = frame.variableAddress(0, size, alignment: wasm32PointerSize);
+      _memory.writeU32(out, size);
+      final result = Result.fromValue(
+        _exports.ghostty_kitty_graphics_unicode_placement_render_info(
+          iterator.value,
+          terminal.value,
+          out,
+        ),
+      );
+      if (result == .noValue) return null;
+      checkCode(
+        result,
+        operation: 'ghostty_kitty_graphics_unicode_placement_render_info',
+      );
+      return KittyUnicodePlacementRenderInfo(
+        viewportCol: _memory.readI32(
+          out + _layout.kittyUnicodeRenderInfoViewportCol,
+        ),
+        viewportRow: _memory.readI32(
+          out + _layout.kittyUnicodeRenderInfoViewportRow,
+        ),
+        z: _memory.readI32(out + _layout.kittyUnicodeRenderInfoZ),
+        cellOffsetX: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoCellOffsetX,
+        ),
+        cellOffsetY: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoCellOffsetY,
+        ),
+        pixelWidth: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoPixelWidth,
+        ),
+        pixelHeight: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoPixelHeight,
+        ),
+        sourceX: _memory.readU32(out + _layout.kittyUnicodeRenderInfoSourceX),
+        sourceY: _memory.readU32(out + _layout.kittyUnicodeRenderInfoSourceY),
+        sourceWidth: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoSourceWidth,
+        ),
+        sourceHeight: _memory.readU32(
+          out + _layout.kittyUnicodeRenderInfoSourceHeight,
         ),
       );
     } finally {
@@ -409,4 +587,21 @@ final class WasmKittyGraphicsBindings implements KittyGraphicsBindings {
       _memory.writeU32(_values + i * 4, _multi + i * _wasmOutputSlotSize);
     }
   }
+
+  void _setUnicodePlacementMulti(List<KittyGraphicsUnicodePlacementData> keys) {
+    _memory.writeU32(_multiGridRef, _layout.gridRefSize);
+    for (var i = 0; i < keys.length; i++) {
+      _memory.writeU32(_keys + i * 4, keys[i].value);
+      _memory.writeU32(
+        _values + i * 4,
+        keys[i] == .topLeft ? _multiGridRef : _multi + i * _wasmOutputSlotSize,
+      );
+    }
+  }
+
+  RawGridRef _readGridRef(int pointer) => (
+    node: _memory.readPtr(pointer + _layout.gridRefNode),
+    x: _memory.readU16(pointer + _layout.gridRefX),
+    y: _memory.readU16(pointer + _layout.gridRefY),
+  );
 }

--- a/packages/libghostty/lib/src/bindings/types.dart
+++ b/packages/libghostty/lib/src/bindings/types.dart
@@ -1,5 +1,6 @@
 import '../generated/libghostty_enums.g.dart';
 import '../types/color.dart';
+import '../types/kitty_graphics.dart';
 import 'result_helpers.dart';
 
 const defaultRawColor = (tag: StyleColorTag.none, palette: 0, r: 0, g: 0, b: 0);
@@ -82,6 +83,18 @@ typedef RawColor = ({StyleColorTag tag, int palette, int r, int g, int b});
 
 /// An untracked native grid reference.
 typedef RawGridRef = ({int node, int x, int y});
+
+/// Copied Kitty Unicode placement fields returned by the bindings.
+typedef RawKittyUnicodePlacement = ({
+  RawGridRef topLeft,
+  int imageId,
+  int placementId,
+  int column,
+  int row,
+  int columns,
+  int rows,
+  KittyUnicodePlacementRenderInfo? renderInfo,
+});
 
 /// Render-state dimensions and dirty state returned by a batched query.
 typedef RawRenderStateSummary = ({int cols, int rows, RenderStateDirty dirty});

--- a/packages/libghostty/lib/src/bindings/wasm/layouts.dart
+++ b/packages/libghostty/lib/src/bindings/wasm/layouts.dart
@@ -323,6 +323,20 @@ final class Layouts {
   late final int kittyRenderInfoSourceWidth;
   late final int kittyRenderInfoSourceHeight;
 
+  // GhosttyKittyGraphicsUnicodePlacementRenderInfo
+  late final int kittyUnicodeRenderInfoSize;
+  late final int kittyUnicodeRenderInfoViewportCol;
+  late final int kittyUnicodeRenderInfoViewportRow;
+  late final int kittyUnicodeRenderInfoZ;
+  late final int kittyUnicodeRenderInfoCellOffsetX;
+  late final int kittyUnicodeRenderInfoCellOffsetY;
+  late final int kittyUnicodeRenderInfoPixelWidth;
+  late final int kittyUnicodeRenderInfoPixelHeight;
+  late final int kittyUnicodeRenderInfoSourceX;
+  late final int kittyUnicodeRenderInfoSourceY;
+  late final int kittyUnicodeRenderInfoSourceWidth;
+  late final int kittyUnicodeRenderInfoSourceHeight;
+
   // GhosttyPointCoordinate
   late final int pointCoordinateSize;
   late final int pointCoordinateX;
@@ -660,6 +674,20 @@ final class Layouts {
     kittyRenderInfoSourceY = struct['source_y'];
     kittyRenderInfoSourceWidth = struct['source_width'];
     kittyRenderInfoSourceHeight = struct['source_height'];
+
+    struct = _Struct(types, 'GhosttyKittyGraphicsUnicodePlacementRenderInfo');
+    kittyUnicodeRenderInfoSize = struct.size;
+    kittyUnicodeRenderInfoViewportCol = struct['viewport_col'];
+    kittyUnicodeRenderInfoViewportRow = struct['viewport_row'];
+    kittyUnicodeRenderInfoZ = struct['z'];
+    kittyUnicodeRenderInfoCellOffsetX = struct['cell_offset_x'];
+    kittyUnicodeRenderInfoCellOffsetY = struct['cell_offset_y'];
+    kittyUnicodeRenderInfoPixelWidth = struct['pixel_width'];
+    kittyUnicodeRenderInfoPixelHeight = struct['pixel_height'];
+    kittyUnicodeRenderInfoSourceX = struct['source_x'];
+    kittyUnicodeRenderInfoSourceY = struct['source_y'];
+    kittyUnicodeRenderInfoSourceWidth = struct['source_width'];
+    kittyUnicodeRenderInfoSourceHeight = struct['source_height'];
 
     struct = _Struct(types, 'GhosttyMouseEncoderSize');
     mouseEncoderSizeSize = struct.size;

--- a/packages/libghostty/lib/src/generated/libghostty.g.dart
+++ b/packages/libghostty/lib/src/generated/libghostty.g.dart
@@ -1877,6 +1877,185 @@ Result ghostty_kitty_graphics_placement_viewport_pos(
   );
 }
 
+/// Read one field from the current decoded occurrence.
+///
+/// For TOP_LEFT, initialize the output with
+/// GHOSTTY_INIT_SIZED(GridRef). Any prefix of at least sizeof(size_t)
+/// is accepted, and only fields within the declared size are written.
+///
+/// @return GHOSTTY_SUCCESS or GHOSTTY_INVALID_VALUE for a NULL or
+/// unpositioned iterator, invalid data kind, invalid output, or
+/// undersized TOP_LEFT output
+///
+/// @ingroup kitty_graphics
+@ffi.Native<
+  ffi.Int Function(
+    KittyGraphicsUnicodePlacementIterator,
+    ffi.UnsignedInt,
+    ffi.Pointer<ffi.Void>,
+  )
+>(symbol: 'ghostty_kitty_graphics_unicode_placement_get', isLeaf: true)
+external int _ghostty_kitty_graphics_unicode_placement_get(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  int data,
+  ffi.Pointer<ffi.Void> out,
+);
+
+Result ghostty_kitty_graphics_unicode_placement_get(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  KittyGraphicsUnicodePlacementData data,
+  ffi.Pointer<ffi.Void> out,
+) {
+  return Result.fromValue(
+    _ghostty_kitty_graphics_unicode_placement_get(iterator, data.value, out),
+  );
+}
+
+/// Read multiple fields from the current decoded occurrence.
+///
+/// Processing stops at the first error. out_written receives the number of
+/// successfully written values and may be NULL.
+///
+/// @ingroup kitty_graphics
+@ffi.Native<
+  ffi.Int Function(
+    KittyGraphicsUnicodePlacementIterator,
+    ffi.Size,
+    ffi.Pointer<ffi.UnsignedInt>,
+    ffi.Pointer<ffi.Pointer<ffi.Void>>,
+    ffi.Pointer<ffi.Size>,
+  )
+>(symbol: 'ghostty_kitty_graphics_unicode_placement_get_multi', isLeaf: true)
+external int _ghostty_kitty_graphics_unicode_placement_get_multi(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  int count,
+  ffi.Pointer<ffi.UnsignedInt> keys,
+  ffi.Pointer<ffi.Pointer<ffi.Void>> values,
+  ffi.Pointer<ffi.Size> out_written,
+);
+
+Result ghostty_kitty_graphics_unicode_placement_get_multi(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  int count,
+  ffi.Pointer<ffi.UnsignedInt> keys,
+  ffi.Pointer<ffi.Pointer<ffi.Void>> values,
+  ffi.Pointer<ffi.Size> out_written,
+) {
+  return Result.fromValue(
+    _ghostty_kitty_graphics_unicode_placement_get_multi(
+      iterator,
+      count,
+      keys,
+      values,
+      out_written,
+    ),
+  );
+}
+
+/// Free a Unicode placement iterator. A NULL iterator is accepted.
+///
+/// @ingroup kitty_graphics
+@ffi.Native<ffi.Void Function(KittyGraphicsUnicodePlacementIterator)>(
+  isLeaf: true,
+)
+external void ghostty_kitty_graphics_unicode_placement_iterator_free(
+  KittyGraphicsUnicodePlacementIterator iterator,
+);
+
+/// Create a caller-owned Unicode placement iterator.
+///
+/// Populate or rewind it with ghostty_terminal_get() and
+/// GHOSTTY_TERMINAL_DATA_KITTY_GRAPHICS_UNICODE_PLACEMENT_ITERATOR before
+/// iteration.
+///
+/// @param allocator Allocator to use, or NULL for the default allocator
+/// @param[out] out_iterator Created iterator
+/// @return GHOSTTY_SUCCESS, GHOSTTY_OUT_OF_MEMORY, or GHOSTTY_NO_VALUE when
+/// Kitty graphics are disabled
+///
+/// @ingroup kitty_graphics
+@ffi.Native<
+  ffi.Int Function(
+    ffi.Pointer<Allocator>,
+    ffi.Pointer<KittyGraphicsUnicodePlacementIterator>,
+  )
+>(symbol: 'ghostty_kitty_graphics_unicode_placement_iterator_new', isLeaf: true)
+external int _ghostty_kitty_graphics_unicode_placement_iterator_new(
+  ffi.Pointer<Allocator> allocator,
+  ffi.Pointer<KittyGraphicsUnicodePlacementIterator> out_iterator,
+);
+
+Result ghostty_kitty_graphics_unicode_placement_iterator_new(
+  ffi.Pointer<Allocator> allocator,
+  ffi.Pointer<KittyGraphicsUnicodePlacementIterator> out_iterator,
+) {
+  return Result.fromValue(
+    _ghostty_kitty_graphics_unicode_placement_iterator_new(
+      allocator,
+      out_iterator,
+    ),
+  );
+}
+
+/// Advance to the next decoded occurrence in the active viewport.
+///
+/// The viewport bounds used during population are inclusive. Traversal is
+/// row-major: top to bottom, then left to right. Occurrences are single-row
+/// runs and may be returned even when their image or virtual placement
+/// definition is unavailable. Returns false for a NULL, unpopulated, or
+/// exhausted iterator.
+///
+/// @ingroup kitty_graphics
+@ffi.Native<ffi.Bool Function(KittyGraphicsUnicodePlacementIterator)>(
+  isLeaf: true,
+)
+external bool ghostty_kitty_graphics_unicode_placement_next(
+  KittyGraphicsUnicodePlacementIterator iterator,
+);
+
+/// Resolve rendering geometry for the current decoded occurrence.
+///
+/// This looks up the image and virtual definition in the active Kitty storage
+/// of the terminal used to populate the iterator. The terminal must not have
+/// been mutated since population. Initialize out_info with
+/// GHOSTTY_INIT_SIZED(KittyGraphicsUnicodePlacementRenderInfo). Any
+/// size of at least sizeof(size_t) is accepted, and only fields that fit are
+/// written.
+///
+/// @return GHOSTTY_SUCCESS for drawable geometry, GHOSTTY_NO_VALUE when the
+/// occurrence cannot be rendered because its image or definition is
+/// unavailable, its placement grid is out of bounds, or its crop or
+/// destination is empty, or GHOSTTY_INVALID_VALUE for invalid handles,
+/// ownership, output size, or physical terminal geometry
+///
+/// @ingroup kitty_graphics
+@ffi.Native<
+  ffi.Int Function(
+    KittyGraphicsUnicodePlacementIterator,
+    Terminal,
+    ffi.Pointer<KittyGraphicsUnicodePlacementRenderInfo>,
+  )
+>(symbol: 'ghostty_kitty_graphics_unicode_placement_render_info', isLeaf: true)
+external int _ghostty_kitty_graphics_unicode_placement_render_info(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  Terminal terminal,
+  ffi.Pointer<KittyGraphicsUnicodePlacementRenderInfo> out_info,
+);
+
+Result ghostty_kitty_graphics_unicode_placement_render_info(
+  KittyGraphicsUnicodePlacementIterator iterator,
+  Terminal terminal,
+  ffi.Pointer<KittyGraphicsUnicodePlacementRenderInfo> out_info,
+) {
+  return Result.fromValue(
+    _ghostty_kitty_graphics_unicode_placement_render_info(
+      iterator,
+      terminal,
+      out_info,
+    ),
+  );
+}
+
 /// Encode a DECRPM (DEC Private Mode Report) response sequence.
 ///
 /// Writes a mode report escape sequence into the provided buffer.
@@ -6579,6 +6758,105 @@ final class KittyGraphicsPlacementRenderInfo extends ffi.Struct {
     ..ref.viewport_col = viewport_col
     ..ref.viewport_row = viewport_row
     ..ref.viewport_visible = viewport_visible
+    ..ref.source_x = source_x
+    ..ref.source_y = source_y
+    ..ref.source_width = source_width
+    ..ref.source_height = source_height;
+}
+
+/// Opaque handle to a Kitty graphics Unicode placement iterator.
+///
+/// The iterator is caller-owned and remains valid until freed. Populated
+/// traversal state and values are borrowed from the terminal and are
+/// invalidated by terminal mutation.
+///
+/// @ingroup kitty_graphics
+typedef KittyGraphicsUnicodePlacementIterator =
+    ffi.Pointer<KittyGraphicsUnicodePlacementIteratorImpl>;
+
+final class KittyGraphicsUnicodePlacementIteratorImpl extends ffi.Opaque {}
+
+/// Resolved rendering geometry for a Kitty Unicode placement occurrence.
+///
+/// Coordinates are viewport-relative terminal cells. Offsets and destination
+/// dimensions are physical pixels. Source values are image pixels. Initialize
+/// with GHOSTTY_INIT_SIZED(KittyGraphicsUnicodePlacementRenderInfo).
+/// Fields appended in future versions are written only when they fit within
+/// the caller-provided size.
+///
+/// @ingroup kitty_graphics
+final class KittyGraphicsUnicodePlacementRenderInfo extends ffi.Struct {
+  /// Size of this struct in bytes.
+  @ffi.Size()
+  external int size;
+
+  /// Viewport-relative destination column.
+  @ffi.Int32()
+  external int viewport_col;
+
+  /// Viewport-relative destination row.
+  @ffi.Int32()
+  external int viewport_row;
+
+  /// Effective z-index used for Unicode placements.
+  @ffi.Int32()
+  external int z;
+
+  /// Destination x offset from the cell origin in physical pixels.
+  @ffi.Uint32()
+  external int cell_offset_x;
+
+  /// Destination y offset from the cell origin in physical pixels.
+  @ffi.Uint32()
+  external int cell_offset_y;
+
+  /// Destination width in physical pixels.
+  @ffi.Uint32()
+  external int pixel_width;
+
+  /// Destination height in physical pixels.
+  @ffi.Uint32()
+  external int pixel_height;
+
+  /// Source rectangle x origin in image pixels.
+  @ffi.Uint32()
+  external int source_x;
+
+  /// Source rectangle y origin in image pixels.
+  @ffi.Uint32()
+  external int source_y;
+
+  /// Source rectangle width in image pixels.
+  @ffi.Uint32()
+  external int source_width;
+
+  /// Source rectangle height in image pixels.
+  @ffi.Uint32()
+  external int source_height;
+
+  static ffi.Pointer<KittyGraphicsUnicodePlacementRenderInfo> $allocate(
+    ffi.Allocator $allocator, {
+    required int size,
+    required int viewport_col,
+    required int viewport_row,
+    required int z,
+    required int cell_offset_x,
+    required int cell_offset_y,
+    required int pixel_width,
+    required int pixel_height,
+    required int source_x,
+    required int source_y,
+    required int source_width,
+    required int source_height,
+  }) => $allocator<KittyGraphicsUnicodePlacementRenderInfo>()
+    ..ref.size = size
+    ..ref.viewport_col = viewport_col
+    ..ref.viewport_row = viewport_row
+    ..ref.z = z
+    ..ref.cell_offset_x = cell_offset_x
+    ..ref.cell_offset_y = cell_offset_y
+    ..ref.pixel_width = pixel_width
+    ..ref.pixel_height = pixel_height
     ..ref.source_x = source_x
     ..ref.source_y = source_y
     ..ref.source_width = source_width

--- a/packages/libghostty/lib/src/generated/libghostty_enums.g.dart
+++ b/packages/libghostty/lib/src/generated/libghostty_enums.g.dart
@@ -1082,6 +1082,57 @@ enum KittyGraphicsPlacementIteratorOption {
       };
 }
 
+/// Queryable data kinds for
+/// ghostty_kitty_graphics_unicode_placement_get().
+///
+/// @ingroup kitty_graphics
+enum KittyGraphicsUnicodePlacementData {
+  /// Invalid / sentinel value.
+  invalid(0),
+
+  /// Caller-owned snapshot containing a borrowed top-left grid position. The
+  /// position is invalidated by terminal mutation.
+  ///
+  /// Output type: GridRef *
+  topLeft(1),
+
+  /// Image ID. Output type: uint32_t *
+  imageId(2),
+
+  /// Placement ID, or zero when absent. Output type: uint32_t *
+  placementId(3),
+
+  /// Zero-based source-grid column. Output type: uint32_t *
+  column(4),
+
+  /// Zero-based source-grid row. Output type: uint32_t *
+  row(5),
+
+  /// Number of columns in this single-row run. Output type: uint32_t *
+  columns(6),
+
+  /// Number of rows in this run, currently always one. Output type: uint32_t *
+  rows(7);
+
+  final int value;
+  const KittyGraphicsUnicodePlacementData(this.value);
+
+  static KittyGraphicsUnicodePlacementData fromValue(int value) =>
+      switch (value) {
+        0 => invalid,
+        1 => topLeft,
+        2 => imageId,
+        3 => placementId,
+        4 => column,
+        5 => row,
+        6 => columns,
+        7 => rows,
+        _ => throw ArgumentError(
+          'Unknown value for KittyGraphicsUnicodePlacementData: $value',
+        ),
+      };
+}
+
 /// Compression of a Kitty graphics image.
 ///
 /// Note that stored images are always decompressed:
@@ -2986,7 +3037,18 @@ enum TerminalData {
   /// is active.
   ///
   /// Output type: bool *
-  cursorAtPrompt(39);
+  cursorAtPrompt(39),
+
+  /// Populate and rewind a caller-owned Unicode placement iterator over the
+  /// active viewport. The iterator returns decoded Kitty Unicode placeholder
+  /// occurrences, including unresolved occurrences.
+  ///
+  /// The populated traversal state and returned grid references remain valid
+  /// only until the next terminal mutation. Repopulate the iterator before
+  /// using it again after mutation.
+  ///
+  /// Output type: KittyGraphicsUnicodePlacementIterator *
+  kittyGraphicsUnicodePlacementIterator(40);
 
   final int value;
   const TerminalData(this.value);
@@ -3032,6 +3094,7 @@ enum TerminalData {
     37 => mode,
     38 => vtGround,
     39 => cursorAtPrompt,
+    40 => kittyGraphicsUnicodePlacementIterator,
     _ => throw ArgumentError('Unknown value for TerminalData: $value'),
   };
 }

--- a/packages/libghostty/lib/src/generated/libghostty_wasm.g.dart
+++ b/packages/libghostty/lib/src/generated/libghostty_wasm.g.dart
@@ -1139,6 +1139,94 @@ extension type GhosttyExports(JSObject _) implements JSObject {
     Pointer out_row,
   );
 
+  /// Read one field from the current decoded occurrence.
+  ///
+  /// For TOP_LEFT, initialize the output with
+  /// GHOSTTY_INIT_SIZED(GhosttyGridRef). Any prefix of at least sizeof(size_t)
+  /// is accepted, and only fields within the declared size are written.
+  ///
+  /// @return GHOSTTY_SUCCESS or GHOSTTY_INVALID_VALUE for a NULL or
+  /// unpositioned iterator, invalid data kind, invalid output, or
+  /// undersized TOP_LEFT output
+  ///
+  /// @ingroup kitty_graphics
+  external int ghostty_kitty_graphics_unicode_placement_get(
+    int iterator,
+    int data,
+    Pointer out,
+  );
+
+  /// Read multiple fields from the current decoded occurrence.
+  ///
+  /// Processing stops at the first error. out_written receives the number of
+  /// successfully written values and may be NULL.
+  ///
+  /// @ingroup kitty_graphics
+  external int ghostty_kitty_graphics_unicode_placement_get_multi(
+    int iterator,
+    int count,
+    Pointer keys,
+    Pointer values,
+    Pointer out_written,
+  );
+
+  /// Free a Unicode placement iterator. A NULL iterator is accepted.
+  ///
+  /// @ingroup kitty_graphics
+  external void ghostty_kitty_graphics_unicode_placement_iterator_free(
+    int iterator,
+  );
+
+  /// Create a caller-owned Unicode placement iterator.
+  ///
+  /// Populate or rewind it with ghostty_terminal_get() and
+  /// GHOSTTY_TERMINAL_DATA_KITTY_GRAPHICS_UNICODE_PLACEMENT_ITERATOR before
+  /// iteration.
+  ///
+  /// @param allocator Allocator to use, or NULL for the default allocator
+  /// @param[out] out_iterator Created iterator
+  /// @return GHOSTTY_SUCCESS, GHOSTTY_OUT_OF_MEMORY, or GHOSTTY_NO_VALUE when
+  /// Kitty graphics are disabled
+  ///
+  /// @ingroup kitty_graphics
+  external int ghostty_kitty_graphics_unicode_placement_iterator_new(
+    Pointer allocator,
+    Pointer out_iterator,
+  );
+
+  /// Advance to the next decoded occurrence in the active viewport.
+  ///
+  /// The viewport bounds used during population are inclusive. Traversal is
+  /// row-major: top to bottom, then left to right. Occurrences are single-row
+  /// runs and may be returned even when their image or virtual placement
+  /// definition is unavailable. Returns false for a NULL, unpopulated, or
+  /// exhausted iterator.
+  ///
+  /// @ingroup kitty_graphics
+  external int ghostty_kitty_graphics_unicode_placement_next(int iterator);
+
+  /// Resolve rendering geometry for the current decoded occurrence.
+  ///
+  /// This looks up the image and virtual definition in the active Kitty storage
+  /// of the terminal used to populate the iterator. The terminal must not have
+  /// been mutated since population. Initialize out_info with
+  /// GHOSTTY_INIT_SIZED(GhosttyKittyGraphicsUnicodePlacementRenderInfo). Any
+  /// size of at least sizeof(size_t) is accepted, and only fields that fit are
+  /// written.
+  ///
+  /// @return GHOSTTY_SUCCESS for drawable geometry, GHOSTTY_NO_VALUE when the
+  /// occurrence cannot be rendered because its image or definition is
+  /// unavailable, its placement grid is out of bounds, or its crop or
+  /// destination is empty, or GHOSTTY_INVALID_VALUE for invalid handles,
+  /// ownership, output size, or physical terminal geometry
+  ///
+  /// @ingroup kitty_graphics
+  external int ghostty_kitty_graphics_unicode_placement_render_info(
+    int iterator,
+    int terminal,
+    Pointer out_info,
+  );
+
   /// Encode a DECRPM (DEC Private Mode Report) response sequence.
   ///
   /// Writes a mode report escape sequence into the provided buffer.

--- a/packages/libghostty/lib/src/types/kitty_graphics.dart
+++ b/packages/libghostty/lib/src/types/kitty_graphics.dart
@@ -1,5 +1,109 @@
 import 'package:meta/meta.dart';
 
+import 'geometry.dart';
+
+/// Snapshot of a single Kitty graphics placement.
+///
+/// The placement fields and [renderInfo] are copied while the native iterator
+/// is positioned, so this value remains valid after iteration finishes. Image
+/// pixel data is separate and must be resolved through the Kitty graphics
+/// storage while its borrowed handle remains valid.
+@immutable
+final class KittyPlacement {
+  /// Image id this placement references.
+  final int imageId;
+
+  /// Placement id assigned by the protocol, or zero when none was supplied.
+  final int placementId;
+
+  /// Whether this is a virtual Unicode placeholder placement.
+  ///
+  /// Virtual placements do not participate in normal placement rendering.
+  final bool isVirtual;
+
+  /// Pixel offset from the left edge of the anchor cell.
+  final int xOffset;
+
+  /// Pixel offset from the top edge of the anchor cell.
+  final int yOffset;
+
+  /// Requested source rectangle x origin in pixels.
+  final int sourceX;
+
+  /// Requested source rectangle y origin in pixels.
+  final int sourceY;
+
+  /// Requested source rectangle width in pixels, or zero for the full image.
+  final int sourceWidth;
+
+  /// Requested source rectangle height in pixels, or zero for the full image.
+  final int sourceHeight;
+
+  /// Requested number of grid columns, or zero to derive it from image size.
+  final int columns;
+
+  /// Requested number of grid rows, or zero to derive it from image size.
+  final int rows;
+
+  /// Z-index controlling compositing order.
+  ///
+  /// Negative values draw below text and non-negative values draw above text.
+  final int z;
+
+  /// Resolved rendering geometry at the time of capture.
+  final KittyPlacementRenderInfo renderInfo;
+
+  const KittyPlacement({
+    required this.imageId,
+    required this.placementId,
+    required this.isVirtual,
+    required this.xOffset,
+    required this.yOffset,
+    required this.sourceX,
+    required this.sourceY,
+    required this.sourceWidth,
+    required this.sourceHeight,
+    required this.columns,
+    required this.rows,
+    required this.z,
+    required this.renderInfo,
+  });
+
+  @override
+  int get hashCode => Object.hash(
+    imageId,
+    placementId,
+    isVirtual,
+    xOffset,
+    yOffset,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    columns,
+    rows,
+    z,
+    renderInfo,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is KittyPlacement &&
+      other.imageId == imageId &&
+      other.placementId == placementId &&
+      other.isVirtual == isVirtual &&
+      other.xOffset == xOffset &&
+      other.yOffset == yOffset &&
+      other.sourceX == sourceX &&
+      other.sourceY == sourceY &&
+      other.sourceWidth == sourceWidth &&
+      other.sourceHeight == sourceHeight &&
+      other.columns == columns &&
+      other.rows == rows &&
+      other.z == z &&
+      other.renderInfo == renderInfo;
+}
+
 /// Resolved rendering geometry for a Kitty graphics placement.
 ///
 /// This combines rendered pixel size, grid extent, viewport-relative
@@ -104,104 +208,146 @@ final class KittyPlacementRenderInfo {
       other.sourceHeight == sourceHeight;
 }
 
-/// Snapshot of a single Kitty graphics placement.
-///
-/// The placement fields and [renderInfo] are copied while the native iterator
-/// is positioned, so this value remains valid after iteration finishes. Image
-/// pixel data is separate and must be resolved through the Kitty graphics
-/// storage while its borrowed handle remains valid.
+/// Snapshot of one decoded Kitty Unicode placement occurrence.
 @immutable
-final class KittyPlacement {
-  /// Image id this placement references.
+final class KittyUnicodePlacement {
+  /// Viewport-relative position of the occurrence's first cell.
+  final Position topLeft;
+
+  /// Image id referenced by the occurrence.
   final int imageId;
 
-  /// Placement id assigned by the protocol, or zero when none was supplied.
+  /// Placement id assigned by the protocol, or zero when absent.
   final int placementId;
 
-  /// Whether this is a virtual Unicode placeholder placement.
-  ///
-  /// Virtual placements do not participate in normal placement rendering.
-  final bool isVirtual;
+  /// Zero-based source-grid column.
+  final int column;
 
-  /// Pixel offset from the left edge of the anchor cell.
-  final int xOffset;
+  /// Zero-based source-grid row.
+  final int row;
 
-  /// Pixel offset from the top edge of the anchor cell.
-  final int yOffset;
-
-  /// Requested source rectangle x origin in pixels.
-  final int sourceX;
-
-  /// Requested source rectangle y origin in pixels.
-  final int sourceY;
-
-  /// Requested source rectangle width in pixels, or zero for the full image.
-  final int sourceWidth;
-
-  /// Requested source rectangle height in pixels, or zero for the full image.
-  final int sourceHeight;
-
-  /// Requested number of grid columns, or zero to derive it from image size.
+  /// Number of columns in this occurrence.
   final int columns;
 
-  /// Requested number of grid rows, or zero to derive it from image size.
+  /// Number of rows in this occurrence.
   final int rows;
 
-  /// Z-index controlling compositing order.
-  ///
-  /// Negative values draw below text and non-negative values draw above text.
-  final int z;
+  /// Resolved rendering geometry, or null when the occurrence is not drawable.
+  final KittyUnicodePlacementRenderInfo? renderInfo;
 
-  /// Resolved rendering geometry at the time of capture.
-  final KittyPlacementRenderInfo renderInfo;
-
-  const KittyPlacement({
+  const KittyUnicodePlacement({
+    required this.topLeft,
     required this.imageId,
     required this.placementId,
-    required this.isVirtual,
-    required this.xOffset,
-    required this.yOffset,
-    required this.sourceX,
-    required this.sourceY,
-    required this.sourceWidth,
-    required this.sourceHeight,
+    required this.column,
+    required this.row,
     required this.columns,
     required this.rows,
-    required this.z,
-    required this.renderInfo,
+    this.renderInfo,
   });
 
   @override
   int get hashCode => Object.hash(
+    topLeft,
     imageId,
     placementId,
-    isVirtual,
-    xOffset,
-    yOffset,
-    sourceX,
-    sourceY,
-    sourceWidth,
-    sourceHeight,
+    column,
+    row,
     columns,
     rows,
-    z,
     renderInfo,
   );
 
   @override
   bool operator ==(Object other) =>
-      other is KittyPlacement &&
+      other is KittyUnicodePlacement &&
+      other.topLeft == topLeft &&
       other.imageId == imageId &&
       other.placementId == placementId &&
-      other.isVirtual == isVirtual &&
-      other.xOffset == xOffset &&
-      other.yOffset == yOffset &&
+      other.column == column &&
+      other.row == row &&
+      other.columns == columns &&
+      other.rows == rows &&
+      other.renderInfo == renderInfo;
+}
+
+/// Resolved rendering geometry for a Kitty Unicode placement occurrence.
+@immutable
+final class KittyUnicodePlacementRenderInfo {
+  /// Viewport-relative destination column.
+  final int viewportCol;
+
+  /// Viewport-relative destination row.
+  final int viewportRow;
+
+  /// Effective z-index used for the placement.
+  final int z;
+
+  /// Destination x offset from the cell origin in physical pixels.
+  final int cellOffsetX;
+
+  /// Destination y offset from the cell origin in physical pixels.
+  final int cellOffsetY;
+
+  /// Destination width in physical pixels.
+  final int pixelWidth;
+
+  /// Destination height in physical pixels.
+  final int pixelHeight;
+
+  /// Source rectangle x origin in image pixels.
+  final int sourceX;
+
+  /// Source rectangle y origin in image pixels.
+  final int sourceY;
+
+  /// Source rectangle width in image pixels.
+  final int sourceWidth;
+
+  /// Source rectangle height in image pixels.
+  final int sourceHeight;
+
+  const KittyUnicodePlacementRenderInfo({
+    required this.viewportCol,
+    required this.viewportRow,
+    required this.z,
+    required this.cellOffsetX,
+    required this.cellOffsetY,
+    required this.pixelWidth,
+    required this.pixelHeight,
+    required this.sourceX,
+    required this.sourceY,
+    required this.sourceWidth,
+    required this.sourceHeight,
+  });
+
+  @override
+  int get hashCode => Object.hash(
+    viewportCol,
+    viewportRow,
+    z,
+    cellOffsetX,
+    cellOffsetY,
+    pixelWidth,
+    pixelHeight,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      other is KittyUnicodePlacementRenderInfo &&
+      other.viewportCol == viewportCol &&
+      other.viewportRow == viewportRow &&
+      other.z == z &&
+      other.cellOffsetX == cellOffsetX &&
+      other.cellOffsetY == cellOffsetY &&
+      other.pixelWidth == pixelWidth &&
+      other.pixelHeight == pixelHeight &&
       other.sourceX == sourceX &&
       other.sourceY == sourceY &&
       other.sourceWidth == sourceWidth &&
-      other.sourceHeight == sourceHeight &&
-      other.columns == columns &&
-      other.rows == rows &&
-      other.z == z &&
-      other.renderInfo == renderInfo;
+      other.sourceHeight == sourceHeight;
 }

--- a/packages/libghostty/test/api/terminal/kitty_graphics_test.dart
+++ b/packages/libghostty/test/api/terminal/kitty_graphics_test.dart
@@ -357,44 +357,112 @@ void main() {
         },
       );
 
-      test(
-        'preserves stretched destination for an oversized source request',
-        () {
-          terminal.resize(
-            cols: 80,
-            rows: 24,
-            cellWidthPx: 10,
-            cellHeightPx: 20,
-          );
-          final payload = base64Encode(Uint8List(64));
-          terminal.write(
-            Uint8List.fromList(
-              '\x1b_Ga=t,t=d,f=32,i=14,s=4,v=4;$payload\x1b\\'.codeUnits,
-            ),
-          );
-          terminal.write(
-            Uint8List.fromList(
-              '\x1b_Ga=p,i=14,p=1,x=3,y=3,w=10,h=10;\x1b\\'.codeUnits,
-            ),
-          );
+      test('clamps destination to an intersected source rectangle', () {
+        terminal.resize(cols: 80, rows: 24, cellWidthPx: 10, cellHeightPx: 20);
+        final payload = base64Encode(Uint8List(64));
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b_Ga=t,t=d,f=32,i=14,s=4,v=4;$payload\x1b\\'.codeUnits,
+          ),
+        );
+        terminal.write(
+          Uint8List.fromList(
+            '\x1b_Ga=p,i=14,p=1,x=3,y=3,w=10,h=10;\x1b\\'.codeUnits,
+          ),
+        );
 
-          final renderInfo = KittyGraphics.of(
-            terminal,
-          )!.placements().single.renderInfo;
+        final renderInfo = KittyGraphics.of(
+          terminal,
+        )!.placements().single.renderInfo;
 
-          expect(
-            (
-              renderInfo.pixelWidth,
-              renderInfo.pixelHeight,
-              renderInfo.sourceX,
-              renderInfo.sourceY,
-              renderInfo.sourceWidth,
-              renderInfo.sourceHeight,
-            ),
-            (10, 10, 3, 3, 1, 1),
-          );
-        },
-      );
+        expect(
+          (
+            renderInfo.pixelWidth,
+            renderInfo.pixelHeight,
+            renderInfo.sourceX,
+            renderInfo.sourceY,
+            renderInfo.sourceWidth,
+            renderInfo.sourceHeight,
+          ),
+          (1, 1, 3, 3, 1, 1),
+        );
+      });
+    });
+
+    group('unicodePlacements', () {
+      late Terminal terminal;
+
+      setUp(() {
+        terminal = Terminal(cols: 8, rows: 2);
+        terminal.kittyImageStorageLimit = 1 << 20;
+        terminal.resize(cols: 8, rows: 2, cellWidthPx: 8, cellHeightPx: 16);
+      });
+
+      tearDown(() {
+        terminal.dispose();
+      });
+
+      test('returns empty list when no Unicode placements exist', () {
+        expect(KittyGraphics.of(terminal)?.unicodePlacements(), isEmpty);
+      });
+
+      test('decodes Unicode placement metadata', () {
+        terminal.write(_unicodePlacement());
+
+        final placement = KittyGraphics.of(terminal)!.unicodePlacements().first;
+
+        expect(
+          (
+            placement.topLeft,
+            placement.imageId,
+            placement.placementId,
+            placement.column,
+            placement.row,
+            placement.columns,
+            placement.rows,
+          ),
+          (const Position(row: 0, col: 0), 3, 0, 0, 0, 1, 1),
+        );
+      });
+
+      test('resolves drawable Unicode placement geometry', () {
+        terminal.write(_unicodePlacement());
+
+        final info = KittyGraphics.of(
+          terminal,
+        )!.unicodePlacements().first.renderInfo!;
+
+        expect(
+          (
+            info.viewportCol,
+            info.viewportRow,
+            info.pixelWidth,
+            info.pixelHeight,
+          ),
+          (0, 0, 8, 8),
+        );
+      });
+
+      test('retains copied values after terminal mutation', () {
+        terminal.write(_unicodePlacement());
+
+        final placement = KittyGraphics.of(terminal)!.unicodePlacements().first;
+
+        terminal.resize(cols: 8, rows: 2, cellWidthPx: 16, cellHeightPx: 32);
+
+        expect(
+          (placement.topLeft, placement.renderInfo!.pixelWidth),
+          (const Position(row: 0, col: 0), 8),
+        );
+      });
+
+      test('returns null render geometry for an unresolved occurrence', () {
+        terminal.write(_unicodePlaceholderOnly());
+
+        final placement = KittyGraphics.of(terminal)!.unicodePlacements().first;
+
+        expect(placement.renderInfo, isNull);
+      });
     });
   });
 }
@@ -402,5 +470,23 @@ void main() {
 Uint8List _transmitRedPixel({int id = 42}) {
   return Uint8List.fromList(
     '\x1b_Gf=24,s=1,v=1,a=t,i=$id;/wAA\x1b\\'.codeUnits,
+  );
+}
+
+Uint8List _unicodePlacement() {
+  return Uint8List.fromList(
+    utf8.encode(
+      '\x1b_Ga=T,t=d,f=24,i=3,s=1,v=1,C=1,U=1;'
+      '/wAA\x1b\\'
+      '\x1b[38;2;0;0;3m'
+      '\u{10EEEE}\u0305\u0305'
+      '\x1b[39m',
+    ),
+  );
+}
+
+Uint8List _unicodePlaceholderOnly() {
+  return Uint8List.fromList(
+    utf8.encode('\x1b[38;2;0;0;3m\u{10EEEE}\u0305\u0305\x1b[39m'),
   );
 }

--- a/packages/libghostty/test/types/kitty_graphics_test.dart
+++ b/packages/libghostty/test/types/kitty_graphics_test.dart
@@ -94,4 +94,106 @@ void main() {
       });
     });
   });
+
+  group('KittyUnicodePlacementRenderInfo', () {
+    KittyUnicodePlacementRenderInfo create({int pixelWidth = 16}) =>
+        KittyUnicodePlacementRenderInfo(
+          viewportCol: -1,
+          viewportRow: 3,
+          z: -1,
+          cellOffsetX: 1,
+          cellOffsetY: 2,
+          pixelWidth: pixelWidth,
+          pixelHeight: 32,
+          sourceX: 3,
+          sourceY: 4,
+          sourceWidth: 5,
+          sourceHeight: 6,
+        );
+
+    group('equality', () {
+      test('compares equal values structurally', () {
+        final first = create();
+        final second = create();
+
+        expect(first, second);
+      });
+
+      test('produces equal hashes for equal values', () {
+        final first = create();
+        final second = create();
+
+        expect(first.hashCode, second.hashCode);
+      });
+
+      test('distinguishes changed values', () {
+        final first = create();
+        final second = create(pixelWidth: 17);
+
+        expect(first, isNot(second));
+      });
+    });
+  });
+
+  group('KittyUnicodePlacement', () {
+    KittyUnicodePlacement create({int imageId = 42}) => KittyUnicodePlacement(
+      topLeft: const Position(row: 0, col: 1),
+      imageId: imageId,
+      placementId: 7,
+      column: 1,
+      row: 2,
+      columns: 3,
+      rows: 1,
+      renderInfo: const KittyUnicodePlacementRenderInfo(
+        viewportCol: 4,
+        viewportRow: 5,
+        z: -1,
+        cellOffsetX: 6,
+        cellOffsetY: 7,
+        pixelWidth: 8,
+        pixelHeight: 9,
+        sourceX: 10,
+        sourceY: 11,
+        sourceWidth: 12,
+        sourceHeight: 13,
+      ),
+    );
+
+    group('equality', () {
+      test('compares equal values structurally', () {
+        final first = create();
+        final second = create();
+
+        expect(first, second);
+      });
+
+      test('produces equal hashes for equal values', () {
+        final first = create();
+        final second = create();
+
+        expect(first.hashCode, second.hashCode);
+      });
+
+      test('distinguishes changed values', () {
+        final first = create();
+        final second = create(imageId: 43);
+
+        expect(first, isNot(second));
+      });
+
+      test('allows missing render geometry', () {
+        const placement = KittyUnicodePlacement(
+          topLeft: Position(row: 0, col: 0),
+          imageId: 1,
+          placementId: 2,
+          column: 3,
+          row: 4,
+          columns: 5,
+          rows: 1,
+        );
+
+        expect(placement.renderInfo, isNull);
+      });
+    });
+  });
 }


### PR DESCRIPTION
Resolves #125

Expose Kitty Unicode placement iteration through libghostty bindings and render resolved occurrences in flterm while suppressing protocol placeholder glyphs and preserving image generation matching.

Blocked by ghostty-org/ghostty#13523