### PR TITLE
feat(flterm): add terminal snapshots

### DIFF
--- a/packages/flterm/CHANGELOG.md
+++ b/packages/flterm/CHANGELOG.md
@@ -18,6 +18,12 @@
 
 ### Added
 
+- **Terminal snapshots**: `TerminalController.snapshot()` captures libghostty
+  state, and `TerminalController.fromSnapshot()` restores it progressively or
+  synchronously. `restoration` exposes lifecycle state, while the
+  `restored` future reports completion and late errors. Continuation tracking
+  supports captures between VT or UTF-8 fragments; view integration preserves
+  snapshot colors and defers resizing while scrollback loads.
 - **Terminal search**: `TerminalController.search` manages incremental searches,
   match navigation, scroll policy, and automatic viewport highlighting.
   `TerminalTheme.search` styles ordinary and selected matches, while

--- a/packages/flterm/README.md
+++ b/packages/flterm/README.md
@@ -152,6 +152,24 @@ TerminalView(
 );
 ```
 
+## Snapshots
+
+Capture terminal state with `controller.snapshot()` and restore it into a new
+controller:
+
+```dart
+final snapshot = controller.snapshot();
+final session = TerminalController.fromSnapshot(snapshot)
+  ..onOutput = backend.write;
+final view = TerminalView(controller: session);
+await session.restored;
+```
+
+The terminal is available immediately while older scrollback loads. Read
+`session.restoration` for lifecycle state, or await `session.restored` for
+completion and late errors. Enable `TerminalConfig.continuationMaxBytes` before
+writing unfinished VT or UTF-8 input that must be captured.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/packages/flterm/lib/flterm.dart
+++ b/packages/flterm/lib/flterm.dart
@@ -40,7 +40,7 @@ export 'package:libghostty/libghostty.dart'
         initializeForWeb;
 
 export 'src/controller/terminal_controller.dart'
-    show OnResize, TerminalController;
+    show OnResize, RestorationState, TerminalController;
 export 'src/controller/terminal_search_controller.dart'
     show TerminalSearchController;
 export 'src/foundation/cell_range.dart' show CellRange;

--- a/packages/flterm/lib/src/controller/terminal_controller.dart
+++ b/packages/flterm/lib/src/controller/terminal_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart' hide Key;
@@ -14,6 +15,24 @@ part 'terminal_controller_impl.dart';
 
 /// Reports the committed terminal grid dimensions to the backend.
 typedef OnResize = void Function(int cols, int rows);
+
+/// Describes the snapshot restoration lifecycle of a [TerminalController].
+enum RestorationState {
+  /// The controller was not created from a snapshot.
+  none,
+
+  /// The terminal is ready while older scrollback is still being restored.
+  restoring,
+
+  /// The complete snapshot was restored and validated.
+  complete,
+
+  /// Progressive restoration stopped before the snapshot was complete.
+  ///
+  /// The terminal remains usable. [TerminalController.restored] completes with
+  /// the restoration error.
+  failed,
+}
 
 /// Manages terminal state and bridges it with [TerminalView].
 ///
@@ -54,6 +73,45 @@ abstract class TerminalController extends ChangeNotifier {
   @internal
   TerminalController.base();
 
+  /// Creates a controller from libghostty snapshot [bytes].
+  ///
+  /// Copies [bytes]. When [progressive] is true, the default, the terminal is
+  /// ready to render before this returns and older scrollback loads
+  /// automatically. When false, the complete snapshot is restored and
+  /// validated before this returns.
+  ///
+  /// [maxContinuationBytes] limits the unfinished terminal input accepted from
+  /// the snapshot. Null uses the libghostty default; zero rejects snapshots
+  /// with unfinished input. [retainContinuation] defaults to false. Set it to
+  /// true to keep tracking unfinished input for subsequent [snapshot] calls.
+  ///
+  /// [deferResize] defaults to true and preserves the snapshot grid size until
+  /// restoration finishes. When false, a view-driven resize may cause
+  /// incompatible scrollback pages to be skipped. [preserveSnapshotColors]
+  /// defaults to true and preserves terminal colors on initial view attachment;
+  /// later theme changes apply normally.
+  ///
+  /// Dimensions, modes, cursor state, and scrollback limits come from the
+  /// snapshot. Replacing [config] afterward applies the new configuration
+  /// normally. Callbacks and backend connections must be wired by the caller.
+  /// Failures before the terminal is renderable throw from this constructor;
+  /// later failures complete [restored] with the restoration error. Dispose the
+  /// controller to cancel progressive restoration and release its resources.
+  ///
+  /// ```dart
+  /// final controller = TerminalController.fromSnapshot(bytes)
+  ///   ..onOutput = backend.write;
+  /// final view = TerminalView(controller: controller);
+  /// ```
+  factory TerminalController.fromSnapshot(
+    Uint8List bytes, {
+    bool progressive,
+    int? maxContinuationBytes,
+    bool retainContinuation,
+    bool deferResize,
+    bool preserveSnapshotColors,
+  }) = TerminalControllerImpl.fromSnapshot;
+
   /// The active [TerminalScreen] buffer, either primary or alternate.
   ///
   /// Full-screen programs such as vim, less, and htop commonly enter the
@@ -66,6 +124,11 @@ abstract class TerminalController extends ChangeNotifier {
   /// The value contains the defaults applied by the controller. A program can
   /// change live terminal modes with [modeSet], so mode state may differ from
   /// [config].
+  ///
+  /// Restored controllers inherit snapshot dimensions and scrollback and
+  /// continuation limits. Their mode override map starts empty. Cursor defaults
+  /// describe host preferences and may differ from the restored terminal until
+  /// [config] is replaced.
   TerminalConfig get config;
 
   /// Replaces the configuration.
@@ -195,6 +258,22 @@ abstract class TerminalController extends ChangeNotifier {
   /// Empty when no directory has been reported or the shell cleared it. The
   /// value is not parsed or normalized: it may be a `file://` URI or a path.
   String get pwd;
+
+  /// The current snapshot restoration state.
+  ///
+  /// Ordinary controllers report [RestorationState.none]. Synchronous
+  /// restoration reports [RestorationState.complete] before construction
+  /// returns. Changes during progressive restoration notify this controller's
+  /// listeners.
+  RestorationState get restoration;
+
+  /// A future that completes when initial snapshot restoration finishes.
+  ///
+  /// The future is already complete for ordinary controllers and synchronous
+  /// restoration. Progressive restoration errors complete it with the original
+  /// error. Disposing the controller during restoration completes it with a
+  /// [StateError]. Read [restoration] for the current lifecycle state.
+  Future<void> get restored;
 
   /// The number of scrollback rows in the active screen.
   int get scrollbackRows;
@@ -369,6 +448,23 @@ abstract class TerminalController extends ChangeNotifier {
   /// terminal keyboard modes, and [paste] for clipboard content. Empty text is
   /// ignored; otherwise virtual modifiers are cleared after output is sent.
   void sendText(String text);
+
+  /// Encodes the current terminal state as libghostty snapshot bytes.
+  ///
+  /// Returns a newly allocated list that remains valid independently of this
+  /// controller. During progressive restoration, the snapshot includes only
+  /// scrollback that has already loaded. Unfinished VT or UTF-8 input requires
+  /// continuation tracking to have been enabled through
+  /// [TerminalConfig.continuationMaxBytes] before that input arrived. Throws
+  /// when unfinished input cannot be reconstructed. Call serially with [write]
+  /// and outside terminal callbacks.
+  ///
+  /// ```dart
+  /// final controller = TerminalController();
+  /// final bytes = controller.snapshot();
+  /// await sessionStore.save(bytes);
+  /// ```
+  Uint8List snapshot();
 
   /// Toggles a virtual modifier on or off.
   void toggleMod(Mods mod);

--- a/packages/flterm/lib/src/controller/terminal_controller_impl.dart
+++ b/packages/flterm/lib/src/controller/terminal_controller_impl.dart
@@ -24,8 +24,11 @@ final class TerminalControllerImpl extends TerminalController {
   static final _cursorDown = Uint8List.fromList([0x1b, 0x5b, 0x42]);
   static final _cursorUp = Uint8List.fromList([0x1b, 0x5b, 0x41]);
   static final _formFeedBytes = Uint8List.fromList([_formFeed]);
+  static final _alreadyRestored = Future<void>.value();
 
   final Terminal _terminal;
+  final bool _deferResize;
+  final bool _preserveSnapshotColors;
   final _viewportChanges = ChangeNotifier();
   late final InputEncoder _inputEncoder;
   late final SelectionSession _selection;
@@ -33,6 +36,7 @@ final class TerminalControllerImpl extends TerminalController {
 
   ColorScheme _colorScheme = .dark;
   SurfaceGeometry? _committedGeometry;
+  SurfaceGeometry? _deferredGeometry;
   TerminalConfig _config;
   var _disposed = false;
   late _Observation _observation;
@@ -43,20 +47,91 @@ final class TerminalControllerImpl extends TerminalController {
   OnResize? _onResize;
   var _pwd = '';
   var _pwdChanged = false;
+  Completer<void>? _restorationCompletion;
+  var _restorationState = RestorationState.none;
+  Timer? _restorationWork;
+  SnapshotDecoder? _snapshotDecoder;
   Object? _viewToken;
   Mods _virtualMods = const .none();
 
   TerminalControllerImpl({TerminalConfig config = const TerminalConfig()})
-    : _config = config,
+    : _deferResize = false,
+      _preserveSnapshotColors = false,
+      _config = config,
       _terminal = Terminal(cols: config.cols, rows: config.rows),
       super.base() {
+    _initialize(applyConfig: true);
+  }
+
+  factory TerminalControllerImpl.fromSnapshot(
+    Uint8List bytes, {
+    bool progressive = true,
+    int? maxContinuationBytes,
+    bool retainContinuation = false,
+    bool deferResize = true,
+    bool preserveSnapshotColors = true,
+  }) {
+    final decoder = SnapshotDecoder(
+      bytes,
+      maxContinuationBytes: maxContinuationBytes,
+      retainContinuation: retainContinuation,
+    );
+    try {
+      final terminal = progressive ? decoder.ready() : decoder.decode();
+      try {
+        final controller = TerminalControllerImpl._restored(
+          terminal,
+          deferResize: deferResize,
+          preserveSnapshotColors: preserveSnapshotColors,
+        ).._snapshotDecoder = decoder;
+        controller._restorationCompletion = Completer<void>();
+        controller._restorationCompletion!.future.ignore();
+        if (progressive) {
+          controller._restorationState = .restoring;
+          controller._scheduleRestoration();
+        } else {
+          controller._restorationState = .complete;
+          controller._releaseSnapshotDecoder();
+          controller._restorationCompletion!.complete();
+        }
+        return controller;
+      } catch (_) {
+        terminal.dispose();
+        rethrow;
+      }
+    } catch (_) {
+      decoder.dispose();
+      rethrow;
+    }
+  }
+
+  TerminalControllerImpl._restored(
+    this._terminal, {
+    required this._deferResize,
+    required this._preserveSnapshotColors,
+  }) : _config = TerminalConfig(
+         cols: _terminal.geometry.cols,
+         rows: _terminal.geometry.rows,
+         scrollbackMaxBytes: _terminal.scrollbackMaxBytes,
+         scrollbackMaxLines: _terminal.scrollbackMaxLines,
+         continuationMaxBytes: _terminal.continuationMaxBytes,
+         modes: const {},
+       ),
+       super.base() {
+    _initialize(applyConfig: false);
+  }
+
+  void _initialize({required bool applyConfig}) {
     _inputEncoder = InputEncoder(_terminal);
     _search = TerminalSearchControllerImpl(_terminal, _viewportChanges);
     _selection = SelectionSession(_terminal, notifyListeners);
     installDefaultKittyPngDecoder();
     _wireTerminalCallbacks();
-    _applyModes();
-    _applyTerminalOptions();
+    if (applyConfig) {
+      _applyModes();
+      _applyTerminalOptions();
+    }
+    _pwd = _terminal.pwd;
     _observation = _readObservation();
     _terminal.addListener(_onTerminalChanged);
   }
@@ -97,6 +172,22 @@ final class TerminalControllerImpl extends TerminalController {
   }
 
   bool get isDisposed => _disposed;
+
+  bool get isResizeDeferred => _deferResize && _restorationState == .restoring;
+
+  bool get preservesSnapshotColors => _preserveSnapshotColors;
+
+  @override
+  RestorationState get restoration {
+    _checkNotDisposed();
+    return _restorationState;
+  }
+
+  @override
+  Future<void> get restored {
+    _checkNotDisposed();
+    return _restorationCompletion?.future ?? _alreadyRestored;
+  }
 
   @override
   MouseTracking get mouseTracking {
@@ -155,7 +246,7 @@ final class TerminalControllerImpl extends TerminalController {
   set onResize(OnResize? value) {
     _checkNotDisposed();
     _onResize = value;
-    if (value == null) return;
+    if (value == null || isResizeDeferred) return;
 
     final geometry = _committedGeometry;
     if (geometry != null) value(geometry.cols, geometry.rows);
@@ -283,6 +374,18 @@ final class TerminalControllerImpl extends TerminalController {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    if (_restorationState == .restoring) {
+      _restorationState = .failed;
+    }
+    _releaseSnapshotDecoder();
+    final completion = _restorationCompletion;
+    if (completion != null && !completion.isCompleted) {
+      completion.completeError(
+        StateError(
+          'TerminalController was disposed during snapshot restoration.',
+        ),
+      );
+    }
     _viewToken = null;
     _terminal.removeListener(_onTerminalChanged);
     _search.dispose();
@@ -316,10 +419,35 @@ final class TerminalControllerImpl extends TerminalController {
   void handleResize(SurfaceMeasurement measurement) {
     _checkNotDisposed();
     final geometry = SurfaceGeometry.tryFrom(measurement);
-    if (geometry == null || geometry == _committedGeometry) return;
+    if (geometry == null) return;
+    if (isResizeDeferred) {
+      _deferredGeometry = geometry;
+      final saved = _terminal.geometry;
+      final inputGeometry = SurfaceGeometry.tryFrom(
+        SurfaceMeasurement(
+          cols: saved.cols,
+          rows: saved.rows,
+          cellWidth: measurement.cellWidth,
+          cellHeight: measurement.cellHeight,
+          paddingLeft: measurement.paddingLeft,
+          paddingRight: measurement.paddingRight,
+          paddingTop: measurement.paddingTop,
+          paddingBottom: measurement.paddingBottom,
+          devicePixelRatio: measurement.devicePixelRatio,
+        ),
+      );
+      if (inputGeometry != null) {
+        _inputEncoder.updateGeometry(inputGeometry);
+        _selection.updateGeometry(inputGeometry);
+        _committedGeometry = inputGeometry;
+      }
+      return;
+    }
+    if (geometry == _committedGeometry) return;
 
     final previous = _committedGeometry;
     _commitGeometry(geometry);
+    if (_disposed) return;
     if (previous == null ||
         previous.cols != geometry.cols ||
         previous.rows != geometry.rows) {
@@ -554,6 +682,12 @@ final class TerminalControllerImpl extends TerminalController {
     clearVirtualMods();
   }
 
+  @override
+  Uint8List snapshot() {
+    _checkNotDisposed();
+    return _terminal.encodeSnapshot();
+  }
+
   void setColorScheme(ColorScheme value) {
     _checkNotDisposed();
     if (_colorScheme == value) return;
@@ -601,6 +735,7 @@ final class TerminalControllerImpl extends TerminalController {
   }
 
   void _applyTerminalOptions() {
+    _terminal.continuationMaxBytes = _config.continuationMaxBytes;
     _terminal.scrollbackMaxBytes = _config.scrollbackMaxBytes;
     _terminal.scrollbackMaxLines = _config.scrollbackMaxLines;
     _terminal.kittyImageStorageLimit = _config.kittyImageStorageLimit;
@@ -613,6 +748,59 @@ final class TerminalControllerImpl extends TerminalController {
 
   void _checkNotDisposed() {
     if (_disposed) throw StateError('TerminalController is disposed.');
+  }
+
+  void _releaseSnapshotDecoder() {
+    _restorationWork?.cancel();
+    _restorationWork = null;
+    _snapshotDecoder?.dispose();
+    _snapshotDecoder = null;
+  }
+
+  void _scheduleRestoration() {
+    _restorationWork = Timer(const Duration(milliseconds: 1), _restoreHistory);
+  }
+
+  void _restoreHistory() {
+    _restorationWork = null;
+    final decoder = _snapshotDecoder!;
+    SnapshotProgress? progress;
+    try {
+      progress = decoder.next();
+    } on Object catch (error, stackTrace) {
+      _finishRestoration(error: error, stackTrace: stackTrace);
+      return;
+    }
+    if (progress == null) {
+      _finishRestoration();
+      return;
+    }
+    _scheduleRestoration();
+    if (progress.rows > 0) _search.refresh();
+    if (!_disposed) _viewportChanges.notifyListeners();
+    if (!_disposed) notifyListeners();
+  }
+
+  void _finishRestoration({Object? error, StackTrace? stackTrace}) {
+    _restorationState = error == null ? .complete : .failed;
+    _releaseSnapshotDecoder();
+    final completion = _restorationCompletion!;
+    if (error != null) {
+      completion.completeError(error, stackTrace);
+    } else {
+      completion.complete();
+    }
+    final geometry = _deferredGeometry;
+    _deferredGeometry = null;
+    try {
+      if (geometry != null) {
+        _commitGeometry(geometry);
+        if (!_disposed) _onResize?.call(geometry.cols, geometry.rows);
+      }
+    } finally {
+      if (!_disposed) _viewportChanges.notifyListeners();
+      if (!_disposed) notifyListeners();
+    }
   }
 
   void _commitGeometry(SurfaceGeometry geometry) {
@@ -629,6 +817,7 @@ final class TerminalControllerImpl extends TerminalController {
         cellWidthPx: geometry.cellWidthPx,
         cellHeightPx: geometry.cellHeightPx,
       );
+      if (_disposed) return;
     }
 
     _inputEncoder.updateGeometry(geometry);

--- a/packages/flterm/lib/src/controller/terminal_search_controller.dart
+++ b/packages/flterm/lib/src/controller/terminal_search_controller.dart
@@ -242,6 +242,8 @@ final class TerminalSearchControllerImpl extends ChangeNotifier
     notifyListeners();
   }
 
+  void refresh() => _handleTerminalChanged();
+
   @override
   void search(String query) {
     _checkNotDisposed();

--- a/packages/flterm/lib/src/foundation/terminal_config.dart
+++ b/packages/flterm/lib/src/foundation/terminal_config.dart
@@ -87,6 +87,14 @@ class TerminalConfig {
   /// existing terminal; [TerminalView] supplies its measured live dimensions.
   final int rows;
 
+  /// Maximum number of unfinished VT or UTF-8 bytes retained for snapshots.
+  ///
+  /// Defaults to zero, which disables continuation tracking. Valid values range
+  /// from zero through `0xffffffff` for consistent native and WebAssembly
+  /// behavior. Set a positive limit before writing input that may be unfinished
+  /// when [TerminalController.snapshot] is called.
+  final int continuationMaxBytes;
+
   /// Maximum scrollback buffer size in bytes.
   ///
   /// Defaults to 10,000 bytes. Set to null for no limit, or 0 to disable
@@ -173,6 +181,7 @@ class TerminalConfig {
   const TerminalConfig({
     this.cols = 80,
     this.rows = 24,
+    this.continuationMaxBytes = 0,
     this.cursorBlink,
     this.glyphProtocol = false,
     this.apcBufferLimit = defaultApcBufferLimit,
@@ -188,6 +197,14 @@ class TerminalConfig {
     this.deviceAttributes = const DeviceAttributesResponse(),
   }) : assert(cols > 0, 'cols must be positive'),
        assert(rows > 0, 'rows must be positive'),
+       assert(
+         continuationMaxBytes >= 0,
+         'continuationMaxBytes must be non-negative',
+       ),
+       assert(
+         continuationMaxBytes <= 0xffffffff,
+         'continuationMaxBytes must fit an unsigned 32-bit integer',
+       ),
        assert(
          scrollbackMaxBytes == null || scrollbackMaxBytes >= 0,
          'scrollbackMaxBytes must be non-negative',
@@ -210,6 +227,7 @@ class TerminalConfig {
   int get hashCode => Object.hash(
     cols,
     rows,
+    continuationMaxBytes,
     scrollbackMaxBytes,
     scrollbackMaxLines,
     kittyImageStorageLimit,
@@ -231,6 +249,7 @@ class TerminalConfig {
       other is TerminalConfig &&
           cols == other.cols &&
           rows == other.rows &&
+          continuationMaxBytes == other.continuationMaxBytes &&
           scrollbackMaxBytes == other.scrollbackMaxBytes &&
           scrollbackMaxLines == other.scrollbackMaxLines &&
           kittyImageStorageLimit == other.kittyImageStorageLimit &&
@@ -249,6 +268,7 @@ class TerminalConfig {
   TerminalConfig copyWith({
     int? cols,
     int? rows,
+    int? continuationMaxBytes,
     int? scrollbackMaxBytes,
     int? scrollbackMaxLines,
     int? kittyImageStorageLimit,
@@ -266,6 +286,7 @@ class TerminalConfig {
     return TerminalConfig(
       cols: cols ?? this.cols,
       rows: rows ?? this.rows,
+      continuationMaxBytes: continuationMaxBytes ?? this.continuationMaxBytes,
       scrollbackMaxBytes: scrollbackMaxBytes ?? this.scrollbackMaxBytes,
       scrollbackMaxLines: scrollbackMaxLines ?? this.scrollbackMaxLines,
       kittyImageStorageLimit:
@@ -289,6 +310,7 @@ class TerminalConfig {
   String toString() =>
       'TerminalConfig('
       'cols: $cols, rows: $rows, '
+      'continuationMaxBytes: $continuationMaxBytes, '
       'scrollbackMaxBytes: $scrollbackMaxBytes, '
       'scrollbackMaxLines: $scrollbackMaxLines, '
       'modes: ${modes.length} entries)';

--- a/packages/flterm/lib/src/rendering/terminal_renderer.dart
+++ b/packages/flterm/lib/src/rendering/terminal_renderer.dart
@@ -82,6 +82,9 @@ final class TerminalRenderer extends LeafRenderObjectWidget {
   /// Toggled by a timer in [TerminalView].
   final bool blinkVisible;
 
+  /// Whether layout preserves the terminal grid while reporting view geometry.
+  final bool resizeDeferred;
+
   /// IME preedit text to draw at the cursor before it is committed.
   final String preeditText;
 
@@ -116,6 +119,7 @@ final class TerminalRenderer extends LeafRenderObjectWidget {
     required this.atlasPool,
     this.devicePixelRatio = 1,
     this.blinkVisible = true,
+    this.resizeDeferred = false,
     this.preeditText = '',
     this.linkSnapshot = .empty,
     required this.onGeometryChanged,
@@ -137,6 +141,7 @@ final class TerminalRenderer extends LeafRenderObjectWidget {
       onGeometryChanged: onGeometryChanged,
       onViewportRowChanged: onViewportRowChanged,
       blinkVisible: blinkVisible,
+      resizeDeferred: resizeDeferred,
       preeditText: preeditText,
       linkSnapshot: linkSnapshot,
       focused: focused,
@@ -180,6 +185,7 @@ final class TerminalRenderer extends LeafRenderObjectWidget {
       ..onViewportRowChanged = onViewportRowChanged
       ..focused = focused
       ..blinkVisible = blinkVisible
+      ..resizeDeferred = resizeDeferred
       ..preeditText = preeditText
       ..linkSnapshot = linkSnapshot;
   }
@@ -218,6 +224,8 @@ final class TerminalRenderBox extends RenderBox {
   var _lastCellHeight = 0.0;
   var _lastCellWidth = 0.0;
   var _lastDevicePixelRatio = 0.0;
+  var _lastMeasuredCols = 0;
+  var _lastMeasuredRows = 0;
   var _lastScrollbackRows = 0;
   var _lastSurfacePadding = EdgeInsets.zero;
   LinkSnapshot _linkSnapshot;
@@ -226,9 +234,11 @@ final class TerminalRenderBox extends RenderBox {
   ViewportOffset _offset;
   ValueChanged<SurfaceMeasurement> _onGeometryChanged;
   ValueChanged<int> _onViewportRowChanged;
+  double? _pendingPixelCorrection;
   int? _pendingViewportRow;
   var _performingLayout = false;
   var _preeditText = '';
+  bool _resizeDeferred;
   bool? _primaryStickToBottom;
   AtlasPool _atlasPool;
   var _stickToBottom = true;
@@ -246,6 +256,7 @@ final class TerminalRenderBox extends RenderBox {
     required this._atlasPool,
     required this._devicePixelRatio,
     bool blinkVisible = true,
+    this._resizeDeferred = false,
     this._linkSnapshot = .empty,
     this._preeditText = '',
     required this._onGeometryChanged,
@@ -272,6 +283,10 @@ final class TerminalRenderBox extends RenderBox {
 
   Terminal get _terminal => _frameSource.terminal;
 
+  @visibleForTesting
+  ({int cols, int rows}) get debugGridSize =>
+      (cols: _paintState.cols, rows: _paintState.rows);
+
   set surfacePadding(EdgeInsets value) {
     if (_surfacePadding == value) return;
     _surfacePadding = value;
@@ -292,6 +307,12 @@ final class TerminalRenderBox extends RenderBox {
     if (_preeditText == value) return;
     _preeditText = value;
     markNeedsPaint();
+  }
+
+  set resizeDeferred(bool value) {
+    if (_resizeDeferred == value) return;
+    _resizeDeferred = value;
+    markNeedsLayout();
   }
 
   set linkSnapshot(LinkSnapshot value) {
@@ -407,6 +428,7 @@ final class TerminalRenderBox extends RenderBox {
       _primaryStickToBottom = null;
       _cellWidthPx = 0;
       _cellHeightPx = 0;
+      _pendingPixelCorrection = null;
       _pendingViewportRow = null;
     }
     _needsFrameSync = true;
@@ -516,12 +538,25 @@ final class TerminalRenderBox extends RenderBox {
     try {
       final maxW = constraints.hasBoundedWidth ? constraints.maxWidth : 0.0;
       final maxH = constraints.hasBoundedHeight ? constraints.maxHeight : 0.0;
-      final (newCols, newRows) = _paintState.metrics.gridSize(maxW, maxH);
+      final (measuredCols, measuredRows) = _paintState.metrics.gridSize(
+        maxW,
+        maxH,
+      );
+      late final int renderCols;
+      late final int renderRows;
+      if (_resizeDeferred) {
+        final terminalGeometry = _terminal.geometry;
+        renderCols = terminalGeometry.cols;
+        renderRows = terminalGeometry.rows;
+      } else {
+        renderCols = measuredCols;
+        renderRows = measuredRows;
+      }
 
       size = constraints.constrain(
         Size(
-          newCols * _paintState.metrics.cellWidth,
-          newRows * _paintState.metrics.cellHeight,
+          measuredCols * _paintState.metrics.cellWidth,
+          measuredRows * _paintState.metrics.cellHeight,
         ),
       );
 
@@ -529,7 +564,10 @@ final class TerminalRenderBox extends RenderBox {
       final atlasReconfigured = _acquireAtlasForCurrentConfig(dpr: dpr);
 
       final gridChanged =
-          newCols != _paintState.cols || newRows != _paintState.rows;
+          renderCols != _paintState.cols || renderRows != _paintState.rows;
+      final measuredGridChanged =
+          measuredCols != _lastMeasuredCols ||
+          measuredRows != _lastMeasuredRows;
       final cellWidthPx = (_paintState.metrics.cellWidth * dpr).round();
       final cellHeightPx = (_paintState.metrics.cellHeight * dpr).round();
       final logicalMetricsChanged =
@@ -537,7 +575,7 @@ final class TerminalRenderBox extends RenderBox {
           _paintState.metrics.cellHeight != _lastCellHeight;
       final devicePixelRatioChanged = dpr != _lastDevicePixelRatio;
       final geometryChanged =
-          gridChanged ||
+          measuredGridChanged ||
           cellWidthPx != _cellWidthPx ||
           cellHeightPx != _cellHeightPx ||
           logicalMetricsChanged ||
@@ -546,15 +584,19 @@ final class TerminalRenderBox extends RenderBox {
       if (_paintState.devicePixelRatio != dpr) {
         _paintState.devicePixelRatio = dpr;
       }
+      if (gridChanged) {
+        _paintState.cols = renderCols;
+        _paintState.rows = renderRows;
+        if (renderCols > 0 && renderRows > 0) {
+          _pipeline.configureGrid(renderRows, renderCols);
+        }
+      }
       if (geometryChanged) {
-        _paintState.cols = newCols;
-        _paintState.rows = newRows;
-        if (newCols > 0 && newRows > 0) {
-          if (gridChanged) _pipeline.configureGrid(newRows, newCols);
+        if (measuredCols > 0 && measuredRows > 0) {
           _onGeometryChanged(
             SurfaceMeasurement(
-              cols: newCols,
-              rows: newRows,
+              cols: measuredCols,
+              rows: measuredRows,
               cellWidth: _paintState.metrics.cellWidth,
               cellHeight: _paintState.metrics.cellHeight,
               paddingLeft: _surfacePadding.left,
@@ -570,6 +612,8 @@ final class TerminalRenderBox extends RenderBox {
         _lastCellWidth = _paintState.metrics.cellWidth;
         _lastCellHeight = _paintState.metrics.cellHeight;
         _lastDevicePixelRatio = dpr;
+        _lastMeasuredCols = measuredCols;
+        _lastMeasuredRows = measuredRows;
       }
       _lastSurfacePadding = _surfacePadding;
 
@@ -579,7 +623,9 @@ final class TerminalRenderBox extends RenderBox {
       // rebinding invalidates atlas references inside the pipeline.
       if (gridChanged) _pipeline.markAllRowsDirty();
 
-      if (geometryChanged || atlasReconfigured) _markFrameDirty();
+      if (geometryChanged || gridChanged || atlasReconfigured) {
+        _markFrameDirty();
+      }
     } finally {
       _performingLayout = false;
     }
@@ -654,9 +700,14 @@ final class TerminalRenderBox extends RenderBox {
 
     final scrollbar = _terminal.scrollbar;
     final scrollbackLen = scrollbar.total - scrollbar.visible;
-    final flutterRow = (_offset.pixels / _paintState.metrics.cellHeight)
-        .floor();
-    if (flutterRow != scrollbar.offset) {
+    final cellHeight = _paintState.metrics.cellHeight;
+    final flutterRow = (_offset.pixels / cellHeight).floor();
+    final addedRows = scrollbackLen - _lastScrollbackRows;
+    if (addedRows > 0 && scrollbar.offset == flutterRow + addedRows) {
+      _pendingPixelCorrection = addedRows * cellHeight;
+      _pendingViewportRow = null;
+      _stickToBottom = scrollbackLen <= 0 || scrollbar.offset >= scrollbackLen;
+    } else if (flutterRow != scrollbar.offset) {
       _pendingViewportRow = scrollbar.offset;
       _stickToBottom = scrollbackLen <= 0 || scrollbar.offset >= scrollbackLen;
     }
@@ -683,6 +734,7 @@ final class TerminalRenderBox extends RenderBox {
 
     if (_terminal.activeScreen == .alternate) {
       _primaryStickToBottom ??= _stickToBottom;
+      _pendingPixelCorrection = null;
       _pendingViewportRow = null;
       _offset.applyContentDimensions(0, 0);
       _lastScrollbackRows = 0;
@@ -700,6 +752,12 @@ final class TerminalRenderBox extends RenderBox {
     final scrollbackLen = scrollbar.total - scrollbar.visible;
     final cellHeight = _paintState.metrics.cellHeight;
     final maxExtent = scrollbackLen * cellHeight;
+
+    final pendingPixelCorrection = _pendingPixelCorrection;
+    _pendingPixelCorrection = null;
+    if (pendingPixelCorrection != null) {
+      _offset.correctBy(pendingPixelCorrection);
+    }
 
     final pendingViewportRow = _pendingViewportRow;
     _pendingViewportRow = null;

--- a/packages/flterm/lib/src/view/terminal_view.dart
+++ b/packages/flterm/lib/src/view/terminal_view.dart
@@ -177,6 +177,7 @@ final class _TerminalViewState extends State<TerminalView>
   late CellMetrics _metrics;
   var _ownsFocusNode = false;
   var _ownsScrollController = false;
+  late bool _resizeDeferred;
   Uint8List? _resolvedFontData;
   late TerminalScrollController _scrollController;
   late TerminalTheme _theme;
@@ -265,6 +266,7 @@ final class _TerminalViewState extends State<TerminalView>
     if (controllerChanged) {
       _attachment = ViewAttachment(_controller);
       _attachment.addListener(_onControllerChanged);
+      _resizeDeferred = _attachment.resizeDeferred;
       _links.invalidateContent();
     }
 
@@ -278,7 +280,11 @@ final class _TerminalViewState extends State<TerminalView>
     if (themeChanged) {
       _theme = widget.theme ?? TerminalTheme.dark();
     }
-    if (controllerChanged || themeChanged) _attachment.applyTheme(_theme);
+    if (controllerChanged) {
+      _attachment.applyTheme(_theme, initial: true);
+    } else if (themeChanged) {
+      _attachment.applyTheme(_theme);
+    }
 
     final fontDataChanged = widget.fontData != oldWidget.fontData;
     final fontFamilyChanged = _theme.fontFamily != oldTheme.fontFamily;
@@ -332,13 +338,14 @@ final class _TerminalViewState extends State<TerminalView>
     _ownsFocusNode = widget.focusNode == null;
 
     _theme = widget.theme ?? TerminalTheme.dark();
-    _attachment.applyTheme(_theme);
+    _attachment.applyTheme(_theme, initial: true);
     _metrics = _measureMetrics();
 
     if (widget.fontData == null) unawaited(_resolveFontData(_theme.fontFamily));
 
     _scrollController = widget.scrollController ?? TerminalScrollController();
     _ownsScrollController = widget.scrollController == null;
+    _resizeDeferred = _attachment.resizeDeferred;
     _scrollController.activeScreen = _controller.activeScreen;
     _scrollController.addListener(_onScrollChanged);
     _attachment.addListener(_onControllerChanged);
@@ -442,6 +449,7 @@ final class _TerminalViewState extends State<TerminalView>
                   devicePixelRatio: _devicePixelRatio,
                   preeditText: _attachment.input.preeditText,
                   blinkVisible: _cursorBlink.value,
+                  resizeDeferred: _resizeDeferred,
                   linkSnapshot: _links.snapshot(),
                   onGeometryChanged: _handleResize,
                   onViewportRowChanged: _attachment.handleViewportRowChanged,
@@ -552,6 +560,10 @@ final class _TerminalViewState extends State<TerminalView>
   void _onControllerChanged() {
     _links.invalidateContent();
     _syncLinkInteraction();
+    final resizeDeferred = _attachment.resizeDeferred;
+    if (_resizeDeferred != resizeDeferred) {
+      setState(() => _resizeDeferred = resizeDeferred);
+    }
     final activeScreen = _controller.activeScreen;
     if (_scrollController.activeScreen != activeScreen) {
       _scrollController.activeScreen = activeScreen;

--- a/packages/flterm/lib/src/view/view_attachment.dart
+++ b/packages/flterm/lib/src/view/view_attachment.dart
@@ -103,6 +103,8 @@ final class ViewAttachment extends ChangeNotifier {
 
   MouseTracking get mouseTracking => _controller.mouseTracking;
 
+  bool get resizeDeferred => _controller.isResizeDeferred;
+
   Terminal get terminal => _controller.terminal;
 
   Listenable get viewportChanges => _controller.viewportChanges;
@@ -119,13 +121,17 @@ final class ViewAttachment extends ChangeNotifier {
     return mods;
   }
 
-  void applyTheme(TerminalTheme theme) {
-    final background = _rgb(theme.background);
+  void applyTheme(TerminalTheme theme, {bool initial = false}) {
+    final preserveColors = initial && _controller.preservesSnapshotColors;
+    final background = preserveColors
+        ? terminal.background ?? _rgb(theme.background)
+        : _rgb(theme.background);
     final Brightness brightness = colorPerceivedLuminance(background) > 0.5
         ? .light
         : .dark;
     input.keyboardAppearance = brightness;
     _controller.setColorScheme(brightness == .light ? .light : .dark);
+    if (preserveColors) return;
     terminal
       ..foreground = _rgb(theme.foreground)
       ..background = background

--- a/packages/flterm/test/controller/terminal_controller_test.dart
+++ b/packages/flterm/test/controller/terminal_controller_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:convert';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flterm/src/controller/terminal_controller.dart';
 import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/input/input_message.dart';
@@ -57,7 +58,513 @@ void main() {
       );
     }
 
+    group('fromSnapshot', () {
+      Terminal terminalWithHistory({int lineCount = 10000}) {
+        final terminal = Terminal(cols: 16, rows: 2)
+          ..scrollbackMaxBytes = null
+          ..scrollbackMaxLines = null;
+        addTearDown(terminal.dispose);
+        terminal.write(
+          utf8.encode(
+            List.generate(lineCount, (index) => 'line$index').join('\r\n'),
+          ),
+        );
+        return terminal;
+      }
+
+      TerminalControllerImpl restore(
+        Terminal source, {
+        bool progressive = true,
+        bool deferResize = true,
+      }) {
+        final restored =
+            TerminalController.fromSnapshot(
+                  source.encodeSnapshot(),
+                  progressive: progressive,
+                  deferResize: deferResize,
+                )
+                as TerminalControllerImpl;
+        addTearDown(restored.dispose);
+        return restored;
+      }
+
+      SurfaceMeasurement measurement(int cols, int rows) {
+        return SurfaceMeasurement(
+          cols: cols,
+          rows: rows,
+          cellWidth: 8,
+          cellHeight: 16,
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
+          paddingBottom: 0,
+          devicePixelRatio: 1,
+        );
+      }
+
+      group('validation', () {
+        test('rejects a malformed snapshot prefix', () {
+          final bytes = Uint8List.fromList([1, 2, 3]);
+
+          expect(
+            () => TerminalController.fromSnapshot(bytes),
+            throwsA(isA<InvalidValueException>()),
+          );
+        });
+
+        test('rejects a continuation limit below zero', () {
+          expect(
+            () => TerminalController.fromSnapshot(
+              Uint8List(0),
+              maxContinuationBytes: -1,
+            ),
+            throwsRangeError,
+          );
+        });
+
+        test('rejects a continuation limit above the uint32 maximum', () {
+          expect(
+            () => TerminalController.fromSnapshot(
+              Uint8List(0),
+              maxContinuationBytes: 0x100000000,
+            ),
+            throwsRangeError,
+          );
+        });
+      });
+
+      group('synchronous restoration', () {
+        test('reports complete restoration state before returning', () {
+          final source = Terminal(cols: 16, rows: 2);
+          addTearDown(source.dispose);
+
+          final restored = restore(source, progressive: false);
+
+          expect(restored.restoration, RestorationState.complete);
+        });
+
+        test('restores terminal content before returning', () {
+          final source = Terminal(cols: 16, rows: 2);
+          addTearDown(source.dispose);
+          source.write(utf8.encode('restored'));
+
+          final restored = restore(source, progressive: false);
+          final formatter = restored.createFormatter(format: .plain);
+          addTearDown(formatter.dispose);
+
+          expect(formatter.format(), startsWith('restored'));
+        });
+
+        test('completes restored before returning', () async {
+          final source = Terminal(cols: 16, rows: 2);
+          addTearDown(source.dispose);
+
+          final restored = restore(source, progressive: false);
+
+          await expectLater(restored.restored, completes);
+        });
+      });
+
+      group('progressive restoration', () {
+        test('reports restoring while older scrollback is pending', () {
+          final source = terminalWithHistory();
+
+          final restored = restore(source);
+
+          expect(restored.restoration, RestorationState.restoring);
+        });
+
+        test('returns with older scrollback still pending', () {
+          final source = terminalWithHistory();
+
+          final restored = restore(source);
+
+          expect(restored.scrollbackRows, lessThan(source.scrollbackRows));
+        });
+
+        test('loads remaining scrollback automatically', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.scrollbackRows, source.scrollbackRows);
+          });
+        });
+
+        test('reports complete after loading history', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.restoration, RestorationState.complete);
+          });
+        });
+
+        test('notifies listeners when restoration completes', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+            final states = <RestorationState>[];
+            restored.addListener(() => states.add(restored.restoration));
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(states, contains(RestorationState.complete));
+          });
+        });
+
+        test('completes restored after loading history', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+            var completed = false;
+            restored.restored.then<void>((_) => completed = true).ignore();
+
+            async.elapse(const Duration(seconds: 1));
+            async.flushMicrotasks();
+
+            expect(completed, isTrue);
+          });
+        });
+
+        test('copies the source bytes', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final bytes = source.encodeSnapshot();
+            final restored = TerminalController.fromSnapshot(bytes);
+            addTearDown(restored.dispose);
+            bytes.fillRange(0, bytes.length, 0);
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.scrollbackRows, source.scrollbackRows);
+          });
+        });
+
+        test('refreshes an active search as history arrives', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+            restored.search.search('line');
+            async.elapse(Duration.zero);
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.search.totalMatches, 10000);
+          });
+        });
+
+        test('preserves live output while history arrives', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+            final output = utf8.encode('\r\nlive output');
+            source.write(output);
+
+            restored.write(output);
+            async.elapse(const Duration(seconds: 1));
+
+            final expected = Formatter(terminal: source, format: .plain);
+            addTearDown(expected.dispose);
+            final actual = restored.createFormatter(format: .plain);
+            addTearDown(actual.dispose);
+            expect(actual.format(), expected.format());
+          });
+        });
+      });
+
+      group('failure', () {
+        TerminalControllerImpl restoreDamaged() {
+          final source = terminalWithHistory();
+          final bytes = source.encodeSnapshot()..last ^= 0xff;
+          final restored =
+              TerminalController.fromSnapshot(bytes) as TerminalControllerImpl;
+          addTearDown(restored.dispose);
+          return restored;
+        }
+
+        test('reports failed after a late decoding error', () {
+          fakeAsync((async) {
+            final restored = restoreDamaged();
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.restoration, RestorationState.failed);
+          });
+        });
+
+        test('notifies listeners when restoration fails', () {
+          fakeAsync((async) {
+            final restored = restoreDamaged();
+            final states = <RestorationState>[];
+            restored.addListener(() => states.add(restored.restoration));
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(states, contains(RestorationState.failed));
+          });
+        });
+
+        test('reports a late decoding error through restored', () {
+          fakeAsync((async) {
+            final restored = restoreDamaged();
+            Object? failure;
+            restored.restored
+                .then<void>(
+                  (_) {},
+                  onError: (Object error, StackTrace _) => failure = error,
+                )
+                .ignore();
+
+            async.elapse(const Duration(seconds: 1));
+            async.flushMicrotasks();
+
+            expect(failure, isA<InvalidValueException>());
+          });
+        });
+
+        test('keeps the terminal usable after a late decoding error', () {
+          fakeAsync((async) {
+            final restored = restoreDamaged();
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(
+              () => restored.write(utf8.encode('still usable')),
+              returnsNormally,
+            );
+          });
+        });
+
+        test('reports disposal during restoration through restored', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source);
+            Object? failure;
+            restored.restored
+                .then<void>(
+                  (_) {},
+                  onError: (Object error, StackTrace _) => failure = error,
+                )
+                .ignore();
+
+            restored.dispose();
+            async.flushMicrotasks();
+
+            expect(failure, isA<StateError>());
+          });
+        });
+      });
+
+      group('terminal state', () {
+        test('preserves restored modes after leaving the alternate screen', () {
+          final source = Terminal(cols: 16, rows: 2);
+          addTearDown(source.dispose);
+          source.write(utf8.encode('\x1b[?7lprimary\x1b[?1049halternate'));
+          final restored = restore(source, progressive: false);
+
+          restored.write(utf8.encode('\x1b[?1049l'));
+
+          expect(restored.modeGet(const .autoWrap()), isFalse);
+        });
+
+        test('exposes the restored working directory immediately', () {
+          final source = Terminal(cols: 16, rows: 2)
+            ..pwd = 'file:///tmp/session';
+          addTearDown(source.dispose);
+
+          final restored = restore(source, progressive: false);
+
+          expect(restored.pwd, 'file:///tmp/session');
+        });
+      });
+
+      group('continuation', () {
+        test('resumes a split UTF-8 character', () {
+          final source = TerminalController(
+            config: const TerminalConfig(continuationMaxBytes: 1024),
+          );
+          addTearDown(source.dispose);
+          source.write(Uint8List.fromList([0xe7, 0x95]));
+          final restored = TerminalController.fromSnapshot(
+            source.snapshot(),
+            progressive: false,
+          );
+          addTearDown(restored.dispose);
+
+          restored.write(Uint8List.fromList([0x8c]));
+
+          final formatter = restored.createFormatter(format: .plain);
+          addTearDown(formatter.dispose);
+          expect(formatter.format(), startsWith('界'));
+        });
+
+        test('retains unfinished input when requested', () {
+          final source = TerminalController(
+            config: const TerminalConfig(continuationMaxBytes: 1024),
+          );
+          addTearDown(source.dispose);
+          source.write(utf8.encode('\x1b['));
+          final restored = TerminalController.fromSnapshot(
+            source.snapshot(),
+            progressive: false,
+            retainContinuation: true,
+            maxContinuationBytes: 1024,
+          );
+          addTearDown(restored.dispose);
+
+          final decoder = SnapshotDecoder(
+            restored.snapshot(),
+            retainContinuation: true,
+          );
+          addTearDown(decoder.dispose);
+          final terminal = decoder.decode();
+          addTearDown(terminal.dispose);
+
+          expect(terminal.continuation, utf8.encode('\x1b['));
+        });
+
+        test('stops continuation tracking by default', () {
+          final source = TerminalController(
+            config: const TerminalConfig(continuationMaxBytes: 1024),
+          );
+          addTearDown(source.dispose);
+          source.write(utf8.encode('\x1b['));
+          final restored = TerminalController.fromSnapshot(
+            source.snapshot(),
+            progressive: false,
+          );
+          addTearDown(restored.dispose);
+
+          expect(restored.snapshot, throwsA(isA<InvalidValueException>()));
+        });
+
+        test('rejects unfinished input above the decoder limit', () {
+          final source = TerminalController(
+            config: const TerminalConfig(continuationMaxBytes: 1024),
+          );
+          addTearDown(source.dispose);
+          source.write(utf8.encode('\x1b['));
+          final bytes = source.snapshot();
+
+          expect(
+            () =>
+                TerminalController.fromSnapshot(bytes, maxContinuationBytes: 0),
+            throwsA(isA<LimitExceededException>()),
+          );
+        });
+      });
+
+      group('deferred resize', () {
+        test('defers backend resize reports while history loads', () {
+          final restored = restore(terminalWithHistory());
+          final sizes = <(int, int)>[];
+          restored.onResize = (cols, rows) => sizes.add((cols, rows));
+
+          restored.handleResize(measurement(80, 24));
+
+          expect(sizes, isEmpty);
+        });
+
+        test('commits only the latest measurement after restoration', () {
+          fakeAsync((async) {
+            final restored = restore(terminalWithHistory());
+            final sizes = <(int, int)>[];
+            restored.onResize = (cols, rows) => sizes.add((cols, rows));
+            restored.handleResize(measurement(80, 24));
+            restored.handleResize(measurement(100, 30));
+
+            async.elapse(const Duration(seconds: 1));
+
+            expect(sizes, [(100, 30)]);
+          });
+        });
+
+        test('allows resize to skip incompatible history when requested', () {
+          fakeAsync((async) {
+            final source = terminalWithHistory();
+            final restored = restore(source, deferResize: false);
+
+            restored.handleResize(measurement(80, 24));
+            async.elapse(const Duration(seconds: 1));
+
+            expect(restored.scrollbackRows, lessThan(source.scrollbackRows));
+          });
+        });
+
+        test('keeps completion when the resize callback disposes', () {
+          fakeAsync((async) {
+            final restored = restore(terminalWithHistory());
+            var completed = false;
+            restored.onResize = (cols, rows) => restored.dispose();
+            restored.handleResize(measurement(80, 24));
+            restored.restored.then<void>((_) => completed = true).ignore();
+
+            async.elapse(const Duration(seconds: 1));
+            async.flushMicrotasks();
+
+            expect(completed, isTrue);
+          });
+        });
+      });
+    });
+
+    group('snapshot', () {
+      test('rejects unfinished input without prior tracking', () {
+        controller.write(utf8.encode('\x1b['));
+
+        expect(controller.snapshot, throwsA(isA<InvalidValueException>()));
+      });
+
+      test('captures only scrollback that is currently loaded', () {
+        final source = Terminal(cols: 16, rows: 2)..scrollbackMaxBytes = null;
+        addTearDown(source.dispose);
+        source.write(
+          utf8.encode(
+            List.generate(10000, (index) => 'line$index').join('\r\n'),
+          ),
+        );
+        final restored = TerminalController.fromSnapshot(
+          source.encodeSnapshot(),
+        );
+        addTearDown(restored.dispose);
+        final loadedRows = restored.scrollbackRows;
+
+        final decoder = SnapshotDecoder(restored.snapshot());
+        addTearDown(decoder.dispose);
+        final decoded = decoder.decode();
+        addTearDown(decoded.dispose);
+
+        expect(decoded.scrollbackRows, loadedRows);
+      });
+
+      test('produces a libghostty-compatible snapshot', () {
+        controller.write(utf8.encode('saved terminal'));
+
+        final decoder = SnapshotDecoder(controller.snapshot());
+        addTearDown(decoder.dispose);
+        final terminal = decoder.decode();
+        addTearDown(terminal.dispose);
+        final formatter = Formatter(terminal: terminal, format: .plain);
+        addTearDown(formatter.dispose);
+
+        expect(formatter.format(), startsWith('saved terminal'));
+      });
+    });
+
     group('constructor', () {
+      test('has no restoration state for an ordinary controller', () {
+        expect(controller.restoration, RestorationState.none);
+      });
+
+      test('is already restored for an ordinary controller', () async {
+        await expectLater(controller.restored, completes);
+      });
+
       test('exposes terminal state without a view attachment', () {
         expect(controller.terminal, isA<Terminal>());
       });

--- a/packages/flterm/test/foundation/terminal_config_test.dart
+++ b/packages/flterm/test/foundation/terminal_config_test.dart
@@ -12,6 +12,7 @@ void main() {
         expect(config.rows, 24);
         expect(config.scrollbackMaxBytes, 10000);
         expect(config.scrollbackMaxLines, isNull);
+        expect(config.continuationMaxBytes, 0);
         expect(config.cursorStyle, CursorShape.block);
         expect(config.cursorBlink, isNull);
         expect(config.glyphProtocol, isFalse);
@@ -30,6 +31,26 @@ void main() {
 
         expect(config.modes[const TerminalMode.autoWrap()], isFalse);
         expect(config.modes[const TerminalMode.cursorBlinking()], isTrue);
+      });
+
+      test('accepts the maximum portable continuation limit', () {
+        const config = TerminalConfig(continuationMaxBytes: 0xffffffff);
+
+        expect(config.continuationMaxBytes, 0xffffffff);
+      });
+
+      test('rejects a negative continuation limit', () {
+        expect(
+          () => TerminalConfig(continuationMaxBytes: -1),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('rejects a continuation limit above the portable maximum', () {
+        expect(
+          () => TerminalConfig(continuationMaxBytes: 0x100000000),
+          throwsA(isA<AssertionError>()),
+        );
       });
     });
 
@@ -56,6 +77,7 @@ void main() {
           rows: 40,
           scrollbackMaxBytes: 50000,
           scrollbackMaxLines: 500,
+          continuationMaxBytes: 600,
         );
         final copy = original.copyWith(cols: 80);
 
@@ -63,6 +85,7 @@ void main() {
         expect(copy.rows, 40);
         expect(copy.scrollbackMaxBytes, 50000);
         expect(copy.scrollbackMaxLines, 500);
+        expect(copy.continuationMaxBytes, 600);
 
         const config = TerminalConfig();
         final updated = config.copyWith(
@@ -71,6 +94,7 @@ void main() {
           apcBufferLimit: 1024,
           glyphProtocol: true,
           cursorBlink: false,
+          continuationMaxBytes: 2048,
         );
 
         expect(updated.scrollbackMaxBytes, 99999);
@@ -78,6 +102,7 @@ void main() {
         expect(updated.apcBufferLimit, 1024);
         expect(updated.glyphProtocol, isTrue);
         expect(updated.cursorBlink, isFalse);
+        expect(updated.continuationMaxBytes, 2048);
         expect(updated.cols, config.cols);
       });
     });
@@ -120,6 +145,12 @@ void main() {
         const lineLimited = TerminalConfig(scrollbackMaxLines: 1024);
         expect(a, isNot(equals(byteLimited)));
         expect(a, isNot(equals(lineLimited)));
+
+        const continuationA = TerminalConfig(continuationMaxBytes: 1024);
+        const continuationB = TerminalConfig(continuationMaxBytes: 2048);
+        const continuationC = TerminalConfig(continuationMaxBytes: 1024);
+        expect(continuationA, equals(continuationC));
+        expect(continuationA, isNot(equals(continuationB)));
       });
 
       test('ignores map order', () {

--- a/packages/flterm/test/rendering/terminal_renderer_test.dart
+++ b/packages/flterm/test/rendering/terminal_renderer_test.dart
@@ -49,6 +49,7 @@ void main() {
     ValueChanged<int>? onViewportRowChanged,
     AtlasPool? atlasPool,
     ViewportOffset? offset,
+    bool resizeDeferred = false,
   }) {
     selection?.applyTo(terminal);
     atlasPool ??= createAtlasPool();
@@ -72,6 +73,7 @@ void main() {
             devicePixelRatio: devicePixelRatio,
             focused: focused,
             blinkVisible: blinkVisible,
+            resizeDeferred: resizeDeferred,
             onGeometryChanged: (geometry) {
               terminal.resize(
                 cols: geometry.cols,
@@ -123,6 +125,43 @@ void main() {
         find.byType(TerminalRenderer),
       );
       expect(box.size.height, 80.0);
+    });
+
+    testWidgets('uses the terminal grid while resize is deferred', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          terminal,
+          maxWidth: 10 * defaultMetrics.cellWidth,
+          maxHeight: 3 * defaultMetrics.cellHeight,
+          resizeDeferred: true,
+        ),
+      );
+
+      final box = tester.renderObject<TerminalRenderBox>(
+        find.byType(TerminalRenderer),
+      );
+
+      expect(box.debugGridSize, (cols: defaultCols, rows: defaultRows));
+    });
+
+    testWidgets('reports measured grid while resize is deferred', (
+      tester,
+    ) async {
+      SurfaceMeasurement? reportedGeometry;
+
+      await tester.pumpWidget(
+        wrap(
+          terminal,
+          maxWidth: 10 * defaultMetrics.cellWidth,
+          maxHeight: 3 * defaultMetrics.cellHeight,
+          resizeDeferred: true,
+          onGeometryChanged: (geometry) => reportedGeometry = geometry,
+        ),
+      );
+
+      expect((reportedGeometry!.cols, reportedGeometry!.rows), (10, 3));
     });
 
     testWidgets('metrics change triggers layout', (tester) async {

--- a/packages/flterm/test/view/terminal_view_test.dart
+++ b/packages/flterm/test/view/terminal_view_test.dart
@@ -233,6 +233,87 @@ void main() {
 
     tearDown(() => controller.dispose());
 
+    group('snapshot restoration', () {
+      void replaceWithHistorySnapshot({int lineCount = 10000}) {
+        final source = Terminal(cols: 12, rows: 3)
+          ..scrollbackMaxBytes = null
+          ..scrollbackMaxLines = null;
+        addTearDown(source.dispose);
+        source.write(
+          utf8.encode(
+            List.generate(lineCount, (index) => 'line$index').join('\r\n'),
+          ),
+        );
+        controller.dispose();
+        controller = TerminalController.fromSnapshot(source.encodeSnapshot());
+      }
+
+      testWidgets('renders the saved grid while history loads', (tester) async {
+        replaceWithHistorySnapshot();
+
+        await tester.pumpWidget(wrapInApp(controller: controller));
+
+        final renderBox = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        expect(renderBox.debugGridSize, (cols: 12, rows: 3));
+
+        controller.dispose();
+        await tester.pumpWidget(const SizedBox());
+      });
+
+      testWidgets('commits the measured grid after restoration', (
+        tester,
+      ) async {
+        replaceWithHistorySnapshot();
+        await tester.pumpWidget(wrapInApp(controller: controller));
+
+        await tester.pumpAndSettle();
+
+        final renderBox = tester.renderObject<TerminalRenderBox>(
+          find.byType(TerminalRenderer),
+        );
+        expect(renderBox.debugGridSize, isNot((cols: 12, rows: 3)));
+      });
+
+      testWidgets(
+        'keeps the visible scrollback row anchored as history arrives',
+        (tester) async {
+          replaceWithHistorySnapshot();
+          final scrollController = TerminalScrollController();
+          addTearDown(scrollController.dispose);
+          await tester.pumpWidget(
+            wrapInApp(
+              controller: controller,
+              scrollController: scrollController,
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 1));
+          final cellHeight = tester
+              .widget<TerminalRenderer>(find.byType(TerminalRenderer))
+              .metrics
+              .cellHeight;
+          scrollController.jumpTo(
+            scrollController.position.maxScrollExtent / 2,
+          );
+          await tester.pump();
+          final pixelsBefore = scrollController.position.pixels;
+          final rowsBefore = controller.scrollbackRows;
+
+          await tester.pump(const Duration(milliseconds: 1));
+
+          final addedRows = controller.scrollbackRows - rowsBefore;
+          expect(
+            scrollController.position.pixels,
+            closeTo(pixelsBefore + addedRows * cellHeight, 0.01),
+          );
+
+          controller.dispose();
+          await tester.pumpWidget(const SizedBox());
+        },
+      );
+    });
+
     void writeNumberedLines(int count) {
       for (var i = 0; i < count; i++) {
         writeUtf8(controller, 'line $i\r\n');

--- a/packages/flterm/test/view/view_attachment_test.dart
+++ b/packages/flterm/test/view/view_attachment_test.dart
@@ -9,7 +9,8 @@ import 'package:flterm/src/foundation.dart';
 import 'package:flterm/src/view/view_attachment.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:libghostty/libghostty.dart' show Mods, RgbColor, TerminalScreen;
+import 'package:libghostty/libghostty.dart'
+    show Mods, RgbColor, Terminal, TerminalScreen;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -117,6 +118,23 @@ void main() {
     });
 
     group('applyTheme', () {
+      void replaceWithRestored({bool preserveSnapshotColors = true}) {
+        final source = Terminal(cols: 12, rows: 3)
+          ..foreground = const RgbColor(12, 34, 56)
+          ..background = const RgbColor(65, 43, 21);
+        addTearDown(source.dispose);
+        attachment.dispose();
+        controller.dispose();
+        controller =
+            TerminalController.fromSnapshot(
+                  source.encodeSnapshot(),
+                  progressive: false,
+                  preserveSnapshotColors: preserveSnapshotColors,
+                )
+                as TerminalControllerImpl;
+        attachment = ViewAttachment(controller);
+      }
+
       test('applies view colors to the terminal session', () {
         final theme = TerminalTheme.dark();
 
@@ -125,6 +143,42 @@ void main() {
         expect(attachment.terminal.foreground, rgb(theme.foreground));
         expect(attachment.terminal.background, rgb(theme.background));
         expect(attachment.terminal.palette[1], rgb(theme.palette[1]));
+      });
+
+      test('preserves snapshot colors on initial attachment', () {
+        replaceWithRestored();
+
+        attachment.applyTheme(TerminalTheme.dark(), initial: true);
+
+        expect(
+          (attachment.terminal.foreground, attachment.terminal.background),
+          (const RgbColor(12, 34, 56), const RgbColor(65, 43, 21)),
+        );
+      });
+
+      test('applies a later theme after preserving snapshot colors', () {
+        replaceWithRestored();
+        final theme = TerminalTheme.light();
+        attachment.applyTheme(TerminalTheme.dark(), initial: true);
+
+        attachment.applyTheme(theme);
+
+        expect(
+          (attachment.terminal.foreground, attachment.terminal.background),
+          (rgb(theme.foreground), rgb(theme.background)),
+        );
+      });
+
+      test('applies initial colors when preservation is disabled', () {
+        replaceWithRestored(preserveSnapshotColors: false);
+        final theme = TerminalTheme.dark();
+
+        attachment.applyTheme(theme, initial: true);
+
+        expect(
+          (attachment.terminal.foreground, attachment.terminal.background),
+          (rgb(theme.foreground), rgb(theme.background)),
+        );
       });
     });
 


### PR DESCRIPTION
Expose terminal snapshot capture and restoration through TerminalController.snapshot() and
TerminalController.fromSnapshot(), including synchronous and progressive restoration, lifecycle state
and completion reporting, continuation handling, deferred view resizing, restored color preservation,
and stable scrollback positioning as older rows load. Keep libghostty decoder details internal to
flterm and add focused controller, configuration, rendering, and view coverage.